### PR TITLE
docs: overhaul README and TRADEMARK guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,180 +1,187 @@
 <p align="center">
-  <img src="assets/images/logo.png" width="120" alt="Poka CE Logo" />
+  <img src="assets/images/logo.png" width="100" alt="Poka CE Logo" />
 </p>
+
+<h1 align="center">Poka CE — Community Edition</h1>
+<p align="center"><i>Simple. Offline. Yours. — Personal finance management, no cloud required.</i></p>
+<p align="center"><a href="https://getpoka.app">getpoka.app</a></p>
 
 <p align="center">
   <a href="https://github.com/getpoka/poka-ce/actions/workflows/ci.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/getpoka/poka-ce/ci.yml?style=for-the-badge&logo=github" alt="CI" />
+    <img src="https://img.shields.io/github/actions/workflow/status/getpoka/poka-ce/ci.yml?style=for-the-badge&logo=github&label=CI" alt="CI" />
   </a>
   <a href="https://github.com/getpoka/poka-ce/releases">
-    <img src="https://img.shields.io/github/v/release/getpoka/poka-ce?style=for-the-badge&color=blue" alt="Latest Release" />
+    <img src="https://img.shields.io/github/v/release/getpoka/poka-ce?style=for-the-badge&color=5560D6" alt="Latest Release" />
   </a>
   <a href="https://github.com/getpoka/poka-ce/releases">
-    <img src="https://img.shields.io/github/downloads/getpoka/poka-ce/total?style=for-the-badge&color=green" alt="Downloads" />
+    <img src="https://img.shields.io/github/downloads/getpoka/poka-ce/total?style=for-the-badge&color=5560D6" alt="Downloads" />
   </a>
   <a href="https://github.com/getpoka/poka-ce/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/getpoka/poka-ce?style=for-the-badge" alt="License" />
+    <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=for-the-badge" alt="License" />
+  </a>
+  <a href="https://flutter.dev">
+    <img src="https://img.shields.io/badge/Flutter-3.47%2B-02569B?style=for-the-badge&logo=flutter" alt="Flutter" />
   </a>
 </p>
 
-# Poka CE (Community Edition)
-
-Poka CE is a personal finance management application built with Flutter. It provides a simple, flat-design interface to
-help you manage your accounts, budgets, goals, debts, categories, and transactions efficiently and offline-first using a
-local SQLite database (via Drift).
-
-> [!WARNING]
-> **Beta Version:** This app is currently in Beta phase. While most core features are complete, it has not been fully
-tested in all edge cases (such as editing or deleting complex records). You might encounter bugs. Please back up your
-data regularly via Settings and avoid relying on it as your sole financial system for now.
-
-
 <p align="center">
-  <img src="assets/screenshots/01_home-portrait.png" width="250" /> &nbsp; &nbsp;
-  <img src="assets/screenshots/02_transactions-portrait.png" width="250" />
+  <img src="assets/screenshots/01_home-portrait.png" width="220" />&nbsp;&nbsp;
+  <img src="assets/screenshots/02_transactions-portrait.png" width="220" />&nbsp;&nbsp;
+  <img src="assets/screenshots/11_transaction_expense-portrait.png" width="220" />
 </p>
 
 <details>
-  <summary><b>🖼️ Tap to view more screenshots</b></summary>
+  <summary><b>More screenshots</b></summary>
   <br/>
 
 |                                       Home                                       |                                Home (Dark)                                |                               Transactions                                |                              Transactions (Dark)                               |
-  |:--------------------------------------------------------------------------------:|:-------------------------------------------------------------------------:|:-------------------------------------------------------------------------:|:------------------------------------------------------------------------------:|
+|:--------------------------------------------------------------------------------:|:-------------------------------------------------------------------------:|:-------------------------------------------------------------------------:|:------------------------------------------------------------------------------:|
 |        <img src="assets/screenshots/01_home-portrait.png" width="200" />         |  <img src="assets/screenshots/14_dark_home-portrait.png" width="200" />   | <img src="assets/screenshots/02_transactions-portrait.png" width="200" /> | <img src="assets/screenshots/15_dark_transactions-portrait.png" width="200" /> |
 |                                 **Expense Form**                                 |                            **Expense (Dark)**                             |                                **Reports**                                |                                  **Budgets**                                   |
 | <img src="assets/screenshots/11_transaction_expense-portrait.png" width="200" /> | <img src="assets/screenshots/16_dark_expense-portrait.png" width="200" /> |   <img src="assets/screenshots/03_reports-portrait.png" width="200" />    |      <img src="assets/screenshots/05_budgets-portrait.png" width="200" />      |
 
 </details>
 
-## ✨ Features
+---
 
-- 📱 **Offline First**: All data is stored locally on your device for complete privacy and speed.
-- 💳 **Accounts**: Manage multiple accounts with different balances.
-- 💸 **Transactions**: Record income, expenses, and transfers between accounts.
-- 📊 **Budgets**: Set up monthly budgets to control your spending.
-- 🎯 **Goals**: Create saving goals and track your progress.
-- 🤝 **Debts**: Keep track of your loans and debts.
-- 🏷️ **Categories**: Organize your transactions with customizable categories and icons.
-- 🎨 **Beautiful UI**: Flat design built with [ForUI](https://github.com/forui-dev/forui), without shadows, keeping the
-  interface clean and modern.
+## About Poka
+
+Poka CE is a personal finance tracker with one core principle: **your financial data belongs to you, and only you.**
+There is no account to create, no server to sync with, and no subscription to manage. Every transaction, balance, and
+record lives exclusively in a local SQLite database on your device.
+
+Unlike most finance apps that treat cloud sync as a default, Poka CE treats local-first storage as a hard architectural
+constraint — not an optional mode. It is open-source, built with Flutter, and designed to be simple enough for daily use
+without being stripped of the features that matter.
+
+> [!WARNING]
+> **Public Beta — Active Refinement.** Core features are ready for use, but we are actively refining edge cases around
+record management. Occasional breaking changes may occur between versions. We strongly recommend backing up your data
+regularly via **Settings → Backup**.
 
 ---
 
-## 🛠 Tech Stack
+## Key Features
+
+- **Multi-Account Management** — Track multiple accounts simultaneously with real-time balance updates.
+- **Income, Expense & Transfer** — Record all transaction types with full history and filtering.
+- **Budgeting** — Set monthly spending limits per category and monitor adherence.
+- **Goals** — Define saving targets and visualize progress over time.
+- **Debt & Loan Tracking** — Log amounts owed or lent, with paired transaction records.
+- **Split Transactions** — Allocate a single transaction across multiple categories or pockets.
+- **Smart Input Parsing** — Type math expressions directly into the amount field (e.g., `150000+50000*2`); the
+  calculator evaluates them in real time.
+- **Offline First** — 100% local SQLite storage via Drift. No internet required, ever.
+- **Flat Design System** — Built with [ForUI](https://github.com/forui-dev/forui); no shadows, no elevation — clean and
+  sharp.
+
+---
+
+## Tech Stack
 
 - **Framework**: [Flutter](https://flutter.dev/) & Dart
-- **State Management**: [Riverpod](https://riverpod.dev/) (`riverpod_generator`)
-- **Database**: [Drift](https://drift.simonbinder.eu/) (SQLite)
-- **UI & Design**: [ForUI](https://github.com/forui-dev/forui) (Flat design constraints)
-- **Routing**: [GoRouter](https://pub.dev/packages/go_router)
+- **Database**: [Drift](https://drift.simonbinder.eu/) (SQLite, local-only)
+- **State Management**: [Riverpod](https://riverpod.dev/) with `riverpod_generator`
+- **UI & Design System**: [ForUI](https://github.com/forui-dev/forui)
+- **Routing**: [GoRouter](https://pub.dev/packages/go_router) with `go_router_builder`
 - **Localization**: [Slang](https://pub.dev/packages/slang)
+- **Code
+  Generation**: [Freezed](https://pub.dev/packages/freezed), [build_runner](https://pub.dev/packages/build_runner)
 
 ---
 
-## 🚀 Download & Install
+## Download & Install
 
-You can download the latest version of Poka CE directly from
-our [GitHub Releases page](https://github.com/getpoka/poka-ce/releases).
+Download the latest release directly from the [GitHub Releases page](https://github.com/getpoka/poka-ce/releases).
 
 **System Requirements:**
 
 - **OS**: Android 5.0 (Lollipop) or newer (API level 21+)
 - **Storage**: ~30 MB free space (if using Split APK)
-- **Internet**: Not required! Poka CE is 100% offline.
+- **Internet**: Not required — Poka CE is 100% offline.
 
 **Which APK should I choose?**
-To save your data quota and storage, we provide optimized, smaller APKs for different devices.
 
-- `app-arm64-v8a-release.apk` 🚀 **(Recommended)**: Choose this for almost all modern Android phones (2016 and newer).
-- `app-armeabi-v7a-release.apk`: Choose this if you are using an older 32-bit Android phone.
-- `app-universal-release.apk`: Choose this if you are unsure or if the others fail to install. It works on all devices
-  but is larger in size.
+- `app-arm64-v8a-release.apk` **(Recommended)**: Almost all modern Android phones (2016 and newer).
+- `app-armeabi-v7a-release.apk`: Older 32-bit Android devices.
+- `app-universal-release.apk`: Works on all devices, but larger in size. Use this if you are unsure or if the others
+  fail to install.
 
 ---
 
-## 💻 Getting Started (For Developers)
+## Quickstart
 
 ### Prerequisites
 
-- Flutter SDK (version 3.47.1 or newer recommended)
-- Dart SDK (version 3.13.1 or newer recommended)
-- Make (optional, but recommended for build scripts)
+- Flutter SDK **3.47.1** or newer
+- Dart SDK **3.13.1** or newer
 
-### Installation
+### Steps
 
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/getpoka/poka_ce.git
-   cd poka_ce
-   ```
+**1. Clone the repository:**
 
-2. **Install dependencies:**
-   ```bash
-   flutter pub get
-   ```
+```bash
+git clone https://github.com/getpoka/poka-ce.git
+cd poka-ce
+```
 
-3. **Set up the environment variables:**
-   Copy the example environment file:
-   ```bash
-   cp .env.example .env
-   ```
-   *Note: `.env` is required. You can control the database seeder by setting `POKA_SEED_ESSENTIALS=true` (for basic
-   categories) and `POKA_SEED_DUMMY_DATA=true` (for testing data) in your `.env` file.*
+**2. Install dependencies:**
 
-4. **Generate code (Freezed, Riverpod, Drift, Slang, GoRouter):**
-   ```bash
-   make generate
-   ```
-   *(Or run `dart run build_runner build -d` if you don't use Make)*
+```bash
+flutter pub get
+```
 
-5. **Run the application:**
-   ```bash
-   flutter run --dart-define-from-file=.env
-   ```
+**3. Set up environment and generate code:**
 
----
+```bash
+cp .env.example .env
+dart run build_runner build --delete-conflicting-outputs
+```
 
-## 🌍 Translations
+> The `.env` file is required. Set `POKA_ENABLE_SEEDER=true` to populate the database with seed data for development.
 
-Poka CE uses [slang](https://pub.dev/packages/slang) for i18n with namespaces. We would love your help to translate Poka
-CE into your local language!
-Simply duplicate the base `lib/i18n/en/` folder, rename the duplicated folder to your language code (e.g., `es/` for
-Spanish), translate the values inside the JSON files, and submit a Pull Request.
+**4. Run the application:**
+
+```bash
+flutter run --dart-define-from-file=.env
+```
+
+> For the full contribution workflow, testing setup, watch mode code generation, and database migration guide —
+> see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 
-## 🛠️ Development Commands
+## Trademark & Brand Policy
 
-- **Build APK:**
-  ```bash
-  flutter build apk --dart-define-from-file=.env
-  ```
-- **Check (Linting & Formatting):**
-  ```bash
-  make check
-  ```
-- **Fix Lints:**
-  ```bash
-  make fix
-  ```
-- **Run Tests:**
-  ```bash
-  flutter test
-  ```
-- **Test Coverage:**
-  ```bash
-  flutter test --coverage
-  ```
+The Apache 2.0 license covers the code — it does **not** grant rights to the **Poka**, **GetPoka**, or **Octopy ID**
+brand identities. You may freely fork, modify, and self-host this project, but you may not publish a derivative under
+our name, logo, or domains, or imply official affiliation.
+
+Read the full policy: [TRADEMARK.md](TRADEMARK.md).
 
 ---
 
-## 🤝 Contributing
+## Security & Privacy
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, architecture constraints, and the
-process for submitting pull requests to us.
+Poka CE uses an **offline-first, local-only architecture**. All financial data is stored in a SQLite database on the
+user's device. No data is transmitted to any server, and no analytics or telemetry is collected.
+
+**Reporting a Vulnerability:** If you discover a security issue, please follow the responsible disclosure process
+described in [SECURITY.md](SECURITY.md). Do not open a public GitHub issue for security vulnerabilities — contact
+**security@getpoka.app** directly.
 
 ---
 
-## 📄 License
+## Contributing
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+Contributions are welcome — bug reports, feature discussions, and pull requests alike. If you are new to the codebase,
+look for issues labeled `good first issue` as a starting point.
+
+Before submitting a pull request, please read [CONTRIBUTING.md](CONTRIBUTING.md). It covers the architecture
+constraints, code style, commit conventions, branch workflow, and the PR review process.
+
+---
+
+## License
+
+Poka CE is licensed under the **Apache License 2.0**. See [LICENSE](LICENSE) for the full license text.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,40 +1,83 @@
 # Trademark and Branding Guidelines
 
-The Poka Community Edition (CE) source code is open-source and freely available for you to use, modify, and distribute under the terms of its license. However, the open-source license does **not** grant you the right to use our trademarks, brand names, or logos.
+Poka CE is open-source software, and you are free to use, modify, and distribute it under the terms of the Apache
+License 2.0. However, the open-source license does **not** grant any rights to the brand identities, names, logos, or
+visual assets associated with this project.
 
-This document outlines the policy regarding the use of our brand identities, specifically **Octopy ID** and the **Poka** product line, including their associated domains, logos, icons, and visual assets.
+This document defines the community policy for using the **Octopy ID** and **Poka** brand identities.
 
-Our goal is to encourage community contributions and forks while protecting users from confusion, phishing, and unofficial apps masquerading as the official software.
-
-## 1. Reserved Names, Brands, and Domains
-The following names and domains are reserved and represent our core brand identities. Even though we operate independently (non-corporate/unincorporated entity), these brands have been our established identity for a decade and remain exclusively ours:
-
-* **Octopy ID** (`octopy.dev`): Our primary umbrella brand and creator identity, established over 10 years ago.
-* **Poka** / **Poka CE** / **GetPoka** (`getpoka.app`): The specific product brand and domain associated with this project.
-
-## 2. Unacceptable Uses (What You Cannot Do)
-If you fork, modify, or distribute this software (or a modified version of it), you **MUST NOT**:
-* **Use Reserved Names in App Stores:** You cannot publish your application to the Apple App Store, Google Play Store, or any other application directory using "Poka", "GetPoka", or "Octopy" in the app's title, subtitle, or developer name.
-* **Use Reserved Names or Domains:** You cannot register or use domains that contain our trademarks or easily confused variations (e.g., `poka-app-unofficial.com`, `getpoka-community.net`, `octopy-dev.org`) for websites related to your fork.
-* **Use Reserved Names in Namespaces:** You must change the application's package name and namespaces (e.g., you cannot use `app.getpoka.poka` or `dev.octopy.poka`). You must use your own unique reverse-domain namespace.
-* **Use Official Logos:** You must replace all official Poka, GetPoka, and Octopy logos, app icons, and branding assets with your own original graphics before distributing your version of the app.
-* **Claim Affiliation:** You cannot suggest, either directly or indirectly, that your project is official, endorsed by, or affiliated with Octopy ID or the official Poka team.
-
-## 3. Acceptable Uses (What You Can Do)
-You are encouraged to build upon the Poka Community Edition! When doing so, you **MAY**:
-* **Choose a New Name:** Give your forked project a completely new, unique name (e.g., "BudgetTracker by [Your Name]").
-* **Provide Accurate Attribution:** You may mention that your project is based on the Poka Community Edition codebase. 
-  * *Correct usage:* "This application is built on top of the open-source Poka CE codebase."
-  * *Incorrect usage:* "Unofficial Poka App" or "Poka Alternative Edition."
-* **Discuss the Project:** You are free to use the names Poka, GetPoka, or Octopy ID in articles, blog posts, or tutorials when accurately referring to our official project or identity.
-
-## 4. Why Do We Have This Policy?
-We want to keep the Poka CE codebase open for developers to learn from and build upon. However, when users download an app called "Poka," they expect it to be secure, maintained, and officially supported by our team. 
-
-By enforcing strict branding boundaries, we protect the 10-year legacy of the Octopy brand, prevent malicious actors from distributing scam/phishing applications under our product names, and ensure that users always know whether they are using the official app or a community-driven fork.
-
-## 5. Contact Us
-If you have a special use case, want to build an official integration, or have any questions about this policy, please reach out to the core maintainers.
+> **Note on legal standing:** Octopy ID is not a registered legal entity or incorporated company. These guidelines
+> constitute a *community brand policy*, not a legally enforceable trademark registration. We ask the community to respect
+> them in good faith — to protect users from confusion and to preserve the integrity of a brand that has been built over
+> 10 years.
 
 ---
-*By interacting with, forking, or redistributing this repository, you agree to comply with these Trademark and Branding Guidelines alongside the project's open-source license.*
+
+## Our Brand Identities
+
+| Brand                                | Domain        | Description                                              |
+|--------------------------------------|---------------|----------------------------------------------------------|
+| **Octopy ID**                        | `octopy.dev`  | Primary creator identity, established for over 10 years. |
+| **Poka** / **Poka CE** / **GetPoka** | `getpoka.app` | The product brand for this application.                  |
+
+---
+
+## What You Can Do
+
+You are encouraged to fork, study, and build upon Poka CE. When doing so, you **may**:
+
+- **Fork and modify freely** — The code is yours to use under Apache 2.0.
+- **Self-host or distribute** a modified version under a different name.
+- **Attribute accurately** — You may state that your project is *"built on top of the open-source Poka CE codebase."*
+- **Write and publish** articles, tutorials, or blog posts that reference Poka, GetPoka, or Octopy ID when accurately
+  describing this project.
+- **Contribute upstream** — Pull requests, bug reports, and discussions are always welcome.
+
+---
+
+## What You Cannot Do
+
+If you fork or distribute a modified version of this software, you **must not**:
+
+- **Publish to app stores using reserved names** — Do not submit your build to the Apple App Store, Google Play Store,
+  or any other app directory under the name "Poka," "GetPoka," "Octopy," or "Octopy ID" in the app title, subtitle, or
+  developer name.
+- **Register confusable domains** — If you are distributing a fork or derivative of this codebase, do not use domains
+  that include our brand names or close variations (e.g., `poka-app.com`, `getpoka.xyz`, `octopy-dev.org`). This applies
+  only to projects derived from this repository, not to independent products that happen to be in the same category.
+- **Use reserved package namespaces** — You must replace the application's package identifier. Do not use
+  `app.getpoka.*` or `dev.octopy.*`; use your own unique reverse-domain namespace.
+- **Use official visual assets** — Replace all Poka, GetPoka, and Octopy logos, icons, and branding graphics with your
+  own originals before any public distribution.
+- **Imply affiliation or endorsement** — Do not suggest, directly or indirectly, that your fork is official, endorsed
+  by, or affiliated with the Poka team or Octopy ID.
+
+**The distinction matters:** Calling your fork *"Unofficial Poka App"* or *"Poka Alternative"* still implies a
+relationship with our brand and is not acceptable. Use a completely different name instead.
+
+---
+
+## Why This Policy Exists
+
+Keeping Poka CE open-source is a deliberate choice — we want developers to learn from it, contribute to it, and build on
+top of it. However, when a user downloads an app called "Poka," they have a reasonable expectation that it is secure,
+maintained, and officially supported.
+
+This policy exists to:
+
+- Protect users from confusion and from unofficial builds that may be insecure or unmaintained.
+- Prevent bad actors from distributing scam or phishing applications under our established name.
+- Preserve the decade-long identity of the Octopy brand.
+
+---
+
+## Contact
+
+If you have a special use case, want to discuss an official integration, or have questions about this policy, please
+reach out to the core maintainers via the repository's issue tracker or at the contact listed
+on [getpoka.app](https://getpoka.app).
+
+---
+
+*By interacting with, forking, or redistributing this repository, you agree to respect these Trademark and Branding
+Guidelines alongside the project's open-source license.*


### PR DESCRIPTION
## Summary

Rewrites and restructures `README.md` and `TRADEMARK.md` for clarity, correctness, and better audience targeting.

### README.md
- Full section hierarchy: hero → about → features → tech stack → download → quickstart → trademark → security → contributing → license
- Added `getpoka.app` website link to hero section
- Fixed `<h2>` → `<h1>` semantic heading
- Rewrote *About* with sharper, differentiated copy (offline-first as a hard constraint, not a mode)
- Expanded *Key Features* to include split transactions and smart input parsing with realistic examples
- Moved *Download & Install* before *Quickstart* (end-user first, developer second)
- Condensed *Trademark* section to a 3-line summary with link to `TRADEMARK.md`
- Expanded *Contributing* with `good first issue` guidance

### TRADEMARK.md
- Added honest non-legal-entity disclaimer upfront
- Brand identity table (Octopy ID / Poka with domains)
- Reordered: *What You Can Do* before *What You Cannot Do*
- Scoped domain restriction explicitly to forks only (independent products in same niche are not covered)
- Clearer attribution examples and affiliation distinction