### PR TITLE
test: raise suite coverage past 85%

### DIFF
--- a/test/feature/features/accounts/presentation/widgets/sections/goal_account_section_test.dart
+++ b/test/feature/features/accounts/presentation/widgets/sections/goal_account_section_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/features/accounts/domain/account_aggregate.dart';
+import 'package:poka_ce/features/accounts/domain/account_model.dart';
+import 'package:poka_ce/features/accounts/presentation/widgets/sections/goal_account_section.dart';
+import 'package:poka_ce/features/goals/domain/goal_model.dart';
+import 'package:poka_ce/features/goals/presentation/controllers/goal_notifier.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+class _FakeGoalNotifier extends GoalNotifier {
+  final List<GoalModel> goals;
+  _FakeGoalNotifier(this.goals);
+  @override
+  Stream<List<GoalModel>> build() => Stream.value(goals);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  });
+
+  AccountModel goalAccount(String id, String name, {int balance = 0}) => AccountModel(
+    id: id,
+    name: name,
+    type: AccountType.goal,
+    balance: balance,
+    isActive: true,
+    createdAt: DateTime.utc(2024, 1, 1),
+    updatedAt: DateTime.utc(2024, 1, 1),
+  );
+
+  GoalModel goal(String id, String accountId, String name) => GoalModel(
+    id: id,
+    accountId: accountId,
+    name: name,
+    targetAmount: 1000,
+    createdAt: DateTime.utc(2024, 1, 1),
+    updatedAt: DateTime.utc(2024, 1, 1),
+  );
+
+  Widget buildApp(List<AccountAggregate> aggregates, {List<GoalModel> goals = const []}) {
+    final container = ProviderContainer(
+      overrides: [goalProvider.overrideWith(() => _FakeGoalNotifier(goals))],
+    );
+    return UncontrolledProviderScope(
+      container: container,
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GoalAccountSection(aggregates: aggregates, totalAssets: 2000),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('collapsed by default shows only section header', (tester) async {
+    final aggregate = AccountAggregate(account: goalAccount('g1', 'Trip Fund', balance: 500));
+    await tester.pumpWidget(buildApp([aggregate]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('GOALS & SAVINGS'), findsOneWidget);
+    expect(find.text('Trip Fund'), findsNothing);
+  });
+
+  testWidgets('expanding reveals goal account mini cards', (tester) async {
+    final aggregate = AccountAggregate(account: goalAccount('g1', 'Trip Fund', balance: 500));
+    await tester.pumpWidget(buildApp([aggregate]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('GOALS & SAVINGS'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Trip Fund'), findsOneWidget);
+    expect(find.text('25% of assets'), findsOneWidget);
+  });
+
+  testWidgets('collapsing again hides the cards', (tester) async {
+    final aggregate = AccountAggregate(account: goalAccount('g1', 'Trip Fund', balance: 500));
+    await tester.pumpWidget(buildApp([aggregate]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('GOALS & SAVINGS'));
+    await tester.pumpAndSettle();
+    expect(find.text('Trip Fund'), findsOneWidget);
+
+    await tester.tap(find.text('GOALS & SAVINGS'));
+    await tester.pumpAndSettle();
+    expect(find.text('Trip Fund'), findsNothing);
+  });
+}

--- a/test/feature/features/categories/presentation/widgets/views/category_list_tab_test.dart
+++ b/test/feature/features/categories/presentation/widgets/views/category_list_tab_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/features/categories/domain/category_model.dart';
+import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
+import 'package:poka_ce/features/categories/presentation/widgets/tiles/category_tile.dart';
+import 'package:poka_ce/features/categories/presentation/widgets/views/category_list_tab.dart';
+import 'package:poka_ce/shared/widgets/poka_empty_view.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+class _FakeCategoryListNotifier extends CategoryListNotifier {
+  @override
+  Future<List<CategoryModel>> build() => Future.value(const []);
+
+  @override
+  Future<void> reorderCategories(int oldIndex, int newIndex, CategoryType type, {String? parentId}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  });
+
+  CategoryModel cat(String id, String name, {String? parentId, CategoryType type = CategoryType.expense}) =>
+      CategoryModel(
+        id: id,
+        name: name,
+        type: type,
+        parentId: parentId,
+        color: '#EF4444',
+        icon: 'tag',
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+
+  Widget buildApp(List<CategoryModel> categories, {List<CategoryModel> all = const []}) {
+    final container = ProviderContainer(
+      overrides: [categoryListProvider.overrideWith(() => _FakeCategoryListNotifier())],
+    );
+    return UncontrolledProviderScope(
+      container: container,
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Scaffold(
+            body: CategoryListTab(
+              categories: categories,
+              allCategories: all.isEmpty ? categories : all,
+              type: CategoryType.expense,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('CategoryListTab', () {
+    testWidgets('empty categories shows empty view with action', (tester) async {
+      await tester.pumpWidget(buildApp(const []));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PokaEmptyViewCentered), findsOneWidget);
+      expect(find.text('No categories found.'), findsOneWidget);
+    });
+
+    testWidgets('renders category tiles for non-empty list', (tester) async {
+      final categories = [cat('c1', 'Food'), cat('c2', 'Transport'), cat('c3', 'Bills')];
+      await tester.pumpWidget(buildApp(categories));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Food'), findsOneWidget);
+      expect(find.text('Transport'), findsOneWidget);
+      expect(find.text('Bills'), findsOneWidget);
+      expect(find.byType(CategoryTile), findsNWidgets(3));
+    });
+
+    testWidgets('child count reflects sub categories', (tester) async {
+      final categories = [cat('parent', 'Food & Drink')];
+      final all = [
+        categories.first,
+        cat('child1', 'Coffee', parentId: 'parent'),
+        cat('child2', 'Snacks', parentId: 'parent'),
+      ];
+      await tester.pumpWidget(buildApp(categories, all: all));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Food & Drink'), findsOneWidget);
+      expect(find.textContaining('2 subcategories'), findsOneWidget);
+    });
+  });
+}

--- a/test/feature/features/debts/presentation/widgets/debt_repayment_sheet_test.dart
+++ b/test/feature/features/debts/presentation/widgets/debt_repayment_sheet_test.dart
@@ -1,0 +1,306 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:poka_ce/app/providers/use_case_providers.dart';
+import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/core/error/failure.dart';
+import 'package:poka_ce/core/error/result.dart';
+import 'package:poka_ce/features/accounts/domain/account_model.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
+import 'package:poka_ce/features/debts/domain/debt_model.dart';
+import 'package:poka_ce/features/debts/presentation/widgets/debt_repayment_sheet.dart';
+import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
+import 'package:poka_ce/features/transactions/domain/use_cases/create_transaction_use_case.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+class MockCreateTransactionUseCase extends Mock implements CreateTransactionUseCase {}
+
+class FakeTransactionModel extends Fake implements TransactionModel {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+    registerFallbackValue(FakeTransactionModel());
+    registerFallbackValue(TransactionType.expense);
+  });
+
+  late MockCreateTransactionUseCase mockCreate;
+
+  setUp(() {
+    mockCreate = MockCreateTransactionUseCase();
+    when(
+      () => mockCreate.execute(
+        type: any(named: 'type'),
+        accountId: any(named: 'accountId'),
+        amount: any(named: 'amount'),
+        debtId: any(named: 'debtId'),
+        note: any(named: 'note'),
+        transactionDate: any(named: 'transactionDate'),
+        categoryId: any(named: 'categoryId'),
+        allocation: any(named: 'allocation'),
+        splitItems: any(named: 'splitItems'),
+      ),
+    ).thenAnswer((_) async {
+      final now = DateTime.utc(2024, 1, 1);
+      return Success(
+        TransactionModel(
+          id: 'tx1',
+          accountId: 'a1',
+          type: TransactionType.expense,
+          amount: 100,
+          transactionDate: now,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    });
+  });
+
+  List<AccountModel> sampleAccounts() => [
+    AccountModel(
+      id: 'a1',
+      name: 'Wallet',
+      type: AccountType.assets,
+      balance: 100000,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    ),
+    AccountModel(
+      id: 'a2',
+      name: 'Bank',
+      type: AccountType.assets,
+      balance: 50000,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    ),
+  ];
+
+  DebtModel sampleDebt({DebtType type = DebtType.debt}) => DebtModel(
+    id: 'd1',
+    personName: 'Alice',
+    type: type,
+    amount: 1000,
+    remainingAmount: 1000,
+    status: DebtStatus.active,
+    createdAt: DateTime.utc(2024, 1, 1),
+    updatedAt: DateTime.utc(2024, 1, 1),
+    note: 'dinner',
+  );
+
+  Widget buildWidget(DebtModel debt) {
+    return ProviderScope(
+      overrides: [
+        createTransactionUseCaseProvider.overrideWithValue(mockCreate),
+        dashboardProvider.overrideWith(
+          () => _FakeDashboardNotifier(
+            DashboardState(accounts: sampleAccounts(), isLoading: false),
+          ),
+        ),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Scaffold(
+            body: SingleChildScrollView(child: DebtRepaymentSheet(debt: debt)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget buildShowWidget(DebtModel debt) {
+    return ProviderScope(
+      overrides: [
+        createTransactionUseCaseProvider.overrideWithValue(mockCreate),
+        dashboardProvider.overrideWith(
+          () => _FakeDashboardNotifier(
+            DashboardState(accounts: sampleAccounts(), isLoading: false),
+          ),
+        ),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                onPressed: () => DebtRepaymentSheet.show(context, debt),
+                child: const Text('OpenRepayment'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('DebtRepaymentSheet', () {
+    testWidgets('renders date nav, account shelf, amount display and numpad', (tester) async {
+      await tester.pumpWidget(buildWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Pay in Full'), findsOneWidget);
+      expect(find.text('Wallet'), findsOneWidget);
+      expect(find.text('Bank'), findsOneWidget);
+      expect(find.byKey(const Key('numpad-7')), findsOneWidget);
+      expect(find.byKey(const Key('numpad-ok')), findsOneWidget);
+    });
+
+    testWidgets('pay in full sets amount to remaining amount', (tester) async {
+      await tester.pumpWidget(buildWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1,000'), findsWidgets);
+    });
+
+    testWidgets('numpad keys update the amount expression', (tester) async {
+      await tester.pumpWidget(buildWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('numpad-2')));
+      await tester.pumpAndSettle();
+      expect(find.text('2'), findsWidgets);
+
+      await tester.tap(find.byKey(const Key('numpad-5')));
+      await tester.pumpAndSettle();
+      expect(find.text('25'), findsWidgets);
+    });
+
+    testWidgets('OK with amount exceeding remaining shows denied dialog and skips save', (tester) async {
+      await tester.pumpWidget(buildWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('numpad-5')));
+      await tester.pumpAndSettle();
+      // amount is now 10005 > 1000
+      await tester.tap(find.byKey(const Key('numpad-ok')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Action Denied'), findsOneWidget);
+      verifyNever(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          debtId: any(named: 'debtId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          categoryId: any(named: 'categoryId'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      );
+    });
+
+    testWidgets('OK with valid amount saves repayment and closes sheet', (tester) async {
+      await tester.pumpWidget(buildShowWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('OpenRepayment'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('numpad-ok')));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => mockCreate.execute(
+          type: captureAny(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: captureAny(named: 'amount'),
+          debtId: captureAny(named: 'debtId'),
+          note: captureAny(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          categoryId: any(named: 'categoryId'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).captured;
+      expect(captured[0], TransactionType.expense);
+      expect(captured[1], 1000);
+      expect(captured[2], 'd1');
+      expect(captured[3], 'Repayment for Alice');
+      // Sheet should be closed after successful save
+      expect(find.text('Pay in Full'), findsNothing);
+    });
+
+    testWidgets('loan repayment saves as income', (tester) async {
+      await tester.pumpWidget(buildShowWidget(sampleDebt(type: DebtType.loan)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('OpenRepayment'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('numpad-ok')));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => mockCreate.execute(
+          type: captureAny(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          debtId: any(named: 'debtId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          categoryId: any(named: 'categoryId'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).captured;
+      expect(captured[0], TransactionType.income);
+    });
+
+    testWidgets('selecting another account uses it as source', (tester) async {
+      await tester.pumpWidget(buildShowWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('OpenRepayment'));
+      await tester.pumpAndSettle();
+
+      // The sheet auto-selects the first account via microtask.
+      await tester.tap(find.text('Bank'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('numpad-ok')));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: captureAny(named: 'accountId'),
+          amount: any(named: 'amount'),
+          debtId: any(named: 'debtId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          categoryId: any(named: 'categoryId'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).captured;
+      expect(captured[0], 'a2');
+    });
+  });
+}
+
+class _FakeDashboardNotifier extends DashboardNotifier {
+  final DashboardState _state;
+  _FakeDashboardNotifier(this._state);
+  @override
+  DashboardState build() => _state;
+  @override
+  Future<void> refresh() async {}
+}

--- a/test/feature/features/settings/presentation/screens/lock_screen_test.dart
+++ b/test/feature/features/settings/presentation/screens/lock_screen_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:poka_ce/features/settings/presentation/controllers/app_lock_controller.dart';
+import 'package:poka_ce/features/settings/presentation/screens/lock_screen.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+class MockAppLockController extends Notifier<AppLockState> with Mock implements AppLockController {
+  final AppLockState initialState;
+  MockAppLockController(this.initialState);
+
+  @override
+  AppLockState build() => initialState;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  });
+
+  GoRouter buildRouter() => GoRouter(
+    initialLocation: '/lock',
+    routes: [
+      GoRoute(path: '/lock', builder: (_, __) => const LockScreen()),
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const Scaffold(body: Text('Home')),
+      ),
+    ],
+  );
+
+  Widget buildWidget(AppLockState state) {
+    return ProviderScope(
+      overrides: [
+        appLockControllerProvider.overrideWith(() => MockAppLockController(state)),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp.router(
+          routerConfig: buildRouter(),
+          builder: (context, child) => FTheme(
+            data: lightTheme,
+            child: FToaster(child: child!),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('LockScreen', () {
+    testWidgets('renders pin entry ui', (tester) async {
+      await tester.pumpWidget(buildWidget(const AppLockState(isEnabled: true, isAuthenticated: false)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Enter PIN'), findsOneWidget);
+      expect(find.text('Enter 6-digit PIN'), findsOneWidget);
+      expect(find.text('1'), findsOneWidget);
+      expect(find.text('0'), findsOneWidget);
+    });
+
+    testWidgets('typing digits fills pin and triggers verification', (tester) async {
+      final controller = MockAppLockController(const AppLockState(isEnabled: true, isAuthenticated: false));
+      when(() => controller.verifyPin(any())).thenAnswer((_) async => PinVerificationResult.wrongPin);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [appLockControllerProvider.overrideWith(() => controller)],
+          child: TranslationProvider(
+            child: MaterialApp.router(
+              routerConfig: buildRouter(),
+              builder: (context, child) => FTheme(
+                data: lightTheme,
+                child: FToaster(child: child!),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      for (final digit in ['1', '2', '3', '4', '5', '6']) {
+        await tester.tap(find.text(digit));
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      await tester.pumpAndSettle();
+
+      verify(() => controller.verifyPin('123456')).called(1);
+      expect(find.text('Incorrect PIN'), findsOneWidget);
+    });
+
+    testWidgets('successful pin navigates home', (tester) async {
+      final controller = MockAppLockController(const AppLockState(isEnabled: true, isAuthenticated: false));
+      when(() => controller.verifyPin(any())).thenAnswer((_) async => PinVerificationResult.success);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [appLockControllerProvider.overrideWith(() => controller)],
+          child: TranslationProvider(
+            child: MaterialApp.router(
+              routerConfig: buildRouter(),
+              builder: (context, child) => FTheme(
+                data: lightTheme,
+                child: FToaster(child: child!),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      for (final digit in ['9', '8', '7', '6', '5', '4']) {
+        await tester.tap(find.text(digit));
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      await tester.pumpAndSettle();
+
+      verify(() => controller.verifyPin('987654')).called(1);
+      expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('backspace removes last digit', (tester) async {
+      final controller = MockAppLockController(const AppLockState(isEnabled: true, isAuthenticated: false));
+      when(() => controller.verifyPin(any())).thenAnswer((_) async => PinVerificationResult.wrongPin);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [appLockControllerProvider.overrideWith(() => controller)],
+          child: TranslationProvider(
+            child: MaterialApp.router(
+              routerConfig: buildRouter(),
+              builder: (context, child) => FTheme(
+                data: lightTheme,
+                child: FToaster(child: child!),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('1'));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('2'));
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final backspaceFinder = find.byIcon(FPhosphorIcons.backspace);
+      expect(backspaceFinder, findsOneWidget);
+      await tester.tap(backspaceFinder);
+      await tester.pumpAndSettle();
+
+      // Remaining pin is '1'; verification never triggered.
+      verifyNever(() => controller.verifyPin(any()));
+    });
+
+    testWidgets('lockout ignores key presses and shows countdown', (tester) async {
+      final controller = MockAppLockController(
+        AppLockState(
+          isEnabled: true,
+          isAuthenticated: false,
+          lockoutUntil: DateTime.now().add(const Duration(minutes: 1)),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [appLockControllerProvider.overrideWith(() => controller)],
+          child: TranslationProvider(
+            child: MaterialApp.router(
+              routerConfig: buildRouter(),
+              builder: (context, child) => FTheme(
+                data: lightTheme,
+                child: FToaster(child: child!),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Try again in'), findsOneWidget);
+
+      // Key presses are ignored during lockout.
+      await tester.tap(find.text('1'));
+      await tester.pumpAndSettle();
+      verifyNever(() => controller.verifyPin(any()));
+    });
+  });
+}

--- a/test/feature/features/settings/presentation/sheets/settings_sheets_test.dart
+++ b/test/feature/features/settings/presentation/sheets/settings_sheets_test.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import 'package:poka_ce/features/settings/domain/currency_model.dart';
 import 'package:poka_ce/features/settings/presentation/sheets/currency_picker_sheet.dart';
 import 'package:poka_ce/features/settings/presentation/sheets/language_picker_sheet.dart';
+import 'package:poka_ce/features/settings/presentation/sheets/number_format_picker_sheet.dart';
 import 'package:poka_ce/features/settings/presentation/sheets/theme_picker_sheet.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/theme/theme.dart';
@@ -26,6 +27,59 @@ void main() {
   }
 
   group('Settings Sheets', () {
+    testWidgets('NumberFormatPickerSheet renders and pops value', (tester) async {
+      String? result;
+      await tester.pumpWidget(
+        buildTestableWidget(
+          Builder(
+            builder: (context) => FButton(
+              onPress: () async {
+                result = await showNumberFormatPickerSheet(context, 'system');
+              },
+              child: const Text('Show'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('App Default'), findsOneWidget);
+      expect(find.text('1.000.000,00'), findsOneWidget);
+      expect(find.text('1,000,000.00'), findsOneWidget);
+      expect(find.text('1 000 000,00'), findsOneWidget);
+
+      await tester.tap(find.text('1.000.000,00'));
+      await tester.pumpAndSettle();
+
+      expect(result, 'id_ID');
+    });
+
+    testWidgets('NumberFormatPickerSheet pops system format', (tester) async {
+      String? result;
+      await tester.pumpWidget(
+        buildTestableWidget(
+          Builder(
+            builder: (context) => FButton(
+              onPress: () async {
+                result = await showNumberFormatPickerSheet(context, 'en_US');
+              },
+              child: const Text('Show'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('App Default'));
+      await tester.pumpAndSettle();
+
+      expect(result, 'system');
+    });
+
     testWidgets('ThemePickerSheet renders and pops value', (tester) async {
       String? result;
       await tester.pumpWidget(

--- a/test/feature/features/settings/presentation/widgets/easter_egg_icon_test.dart
+++ b/test/feature/features/settings/presentation/widgets/easter_egg_icon_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:forui_phosphor/forui_phosphor.dart';
+import 'package:poka_ce/features/settings/presentation/widgets/easter_egg_icon.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  });
+
+  Widget buildApp() {
+    return TranslationProvider(
+      child: MaterialApp(
+        builder: (context, child) => FTheme(
+          data: lightTheme,
+          child: FToaster(child: child!),
+        ),
+        home: const Scaffold(body: Center(child: EasterEggIcon())),
+      ),
+    );
+  }
+
+  Finder eggDialogImage() => find.byWidgetPredicate(
+    (w) => w is Image && w.image is AssetImage && (w.image as AssetImage).assetName.contains('hasbullah'),
+  );
+
+  group('EasterEggIcon', () {
+    testWidgets('renders the logo asset', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is Image && w.image is AssetImage && (w.image as AssetImage).assetName.contains('logo'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows remaining taps toast on intermediate taps', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      // First tap starts the sequence (no toast). Second to fourth taps show toasts.
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('taps away from a surprise'), findsOneWidget);
+    });
+
+    testWidgets('sequence resets after 2 seconds of inactivity', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Wait past the reset window.
+      await tester.pumpAndSettle(const Duration(seconds: 3));
+
+      // Fresh sequence: first tap again starts from zero, so no surprise dialog yet.
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+      expect(eggDialogImage(), findsNothing);
+    });
+
+    testWidgets('seven rapid taps reveal the easter egg dialog', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(EasterEggIcon));
+      await tester.pump(const Duration(milliseconds: 50));
+      for (var i = 0; i < 6; i++) {
+        await tester.tap(find.byType(EasterEggIcon));
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('easter egg'), findsOneWidget);
+      expect(eggDialogImage(), findsOneWidget);
+
+      // The easter egg dialog is presented with the hasbullah asset.
+      expect(eggDialogImage(), findsOneWidget);
+    });
+  });
+}

--- a/test/feature/features/transactions/presentation/widgets/tile/transaction_tile_expanded_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/tile/transaction_tile_expanded_test.dart
@@ -1,0 +1,357 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:forui_phosphor/forui_phosphor.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:poka_ce/app/providers/use_case_providers.dart';
+import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/core/error/result.dart';
+import 'package:poka_ce/features/accounts/domain/account_aggregate.dart';
+import 'package:poka_ce/features/accounts/domain/account_model.dart';
+import 'package:poka_ce/features/accounts/presentation/controllers/account_list_notifier.dart';
+import 'package:poka_ce/features/categories/domain/category_model.dart';
+import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
+import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
+import 'package:poka_ce/features/transactions/domain/use_cases/update_transaction_use_case.dart';
+import 'package:poka_ce/features/transactions/presentation/widgets/tile/transaction_tile.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+class MockUpdateTransactionUseCase extends Mock implements UpdateTransactionUseCase {}
+
+class FakeTransactionModel extends Fake implements TransactionModel {}
+
+class _FakeCategoryListNotifier extends CategoryListNotifier {
+  final List<CategoryModel> _categories;
+  _FakeCategoryListNotifier(this._categories);
+  @override
+  Future<List<CategoryModel>> build() => Future.value(_categories);
+}
+
+class _FakeAccountListNotifier extends AccountListNotifier {
+  final List<AccountModel> _accounts;
+  _FakeAccountListNotifier(this._accounts);
+  @override
+  Stream<AccountListState> build() async* {
+    yield AccountListState(
+      accounts: _accounts,
+      aggregates: _accounts
+          .where((a) => !a.isPocket)
+          .map((a) => AccountAggregate(account: a, pockets: _accounts.where((p) => p.parentId == a.id).toList()))
+          .toList(),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+    registerFallbackValue(FakeTransactionModel());
+    registerFallbackValue(TransactionType.expense);
+  });
+
+  late MockUpdateTransactionUseCase mockUpdate;
+
+  setUp(() {
+    mockUpdate = MockUpdateTransactionUseCase();
+    when(
+      () => mockUpdate.execute(
+        any(),
+        type: any(named: 'type'),
+        accountId: any(named: 'accountId'),
+        destinationAccountId: any(named: 'destinationAccountId'),
+        transactionDate: any(named: 'transactionDate'),
+        note: any(named: 'note'),
+        splitItems: any(named: 'splitItems'),
+      ),
+    ).thenAnswer((inv) async {
+      final existing = inv.positionalArguments[0] as TransactionModel;
+      return Success(existing);
+    });
+  });
+
+  TransactionModel splitTx() {
+    final now = DateTime(2024, 1, 15, 10, 30);
+    return TransactionModel(
+      id: 't1',
+      accountId: 'a1',
+      type: TransactionType.expense,
+      amount: 700,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+      note: 'receipt',
+      items: [
+        TransactionItemModel(
+          id: 'i1',
+          transactionId: 't1',
+          amount: 300,
+          categoryId: 'c1',
+          note: 'lunch',
+          createdAt: now,
+          updatedAt: now,
+        ),
+        TransactionItemModel(
+          id: 'i2',
+          transactionId: 't1',
+          amount: 400,
+          categoryId: 'c2',
+          note: 'taxi',
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ],
+    );
+  }
+
+  List<CategoryModel> categories() => [
+    CategoryModel(
+      id: 'c1',
+      name: 'Food',
+      type: CategoryType.expense,
+      color: '#EF4444',
+      icon: 'utensils',
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    ),
+    CategoryModel(
+      id: 'c2',
+      name: 'Transport',
+      type: CategoryType.expense,
+      color: '#3B82F6',
+      icon: 'car',
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    ),
+  ];
+
+  List<AccountModel> accounts() => [
+    AccountModel(
+      id: 'a1',
+      name: 'Wallet',
+      type: AccountType.assets,
+      balance: 1000,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    ),
+    AccountModel(
+      id: 'a2',
+      name: 'Savings',
+      type: AccountType.assets,
+      balance: 500,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    ),
+  ];
+
+  Widget buildApp(List<Widget> children) {
+    final container = ProviderContainer(
+      overrides: [
+        updateTransactionUseCaseProvider.overrideWithValue(mockUpdate),
+        categoryListProvider.overrideWith(() => _FakeCategoryListNotifier(categories())),
+        accountListProvider.overrideWith(() => _FakeAccountListNotifier(accounts())),
+      ],
+    );
+    return UncontrolledProviderScope(
+      container: container,
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Scaffold(body: Column(children: children)),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('multi-item tile expands to show sub items and collapses', (tester) async {
+    final tx = splitTx();
+    await tester.pumpWidget(buildApp([RecentTransactionTile(transaction: tx, isBalanceVisible: true)]));
+    await tester.pumpAndSettle();
+
+    // Tap the tile body to expand (has multiple items).
+    await tester.tap(find.text('receipt').first, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    // Sub item notes become visible.
+    expect(find.text('lunch'), findsOneWidget);
+    expect(find.text('taxi'), findsOneWidget);
+
+    // Tap again to collapse.
+    await tester.tap(find.text('receipt').first, warnIfMissed: false);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('removing a sub item calls update with remaining items', (tester) async {
+    final tx = splitTx();
+    await tester.pumpWidget(buildApp([RecentTransactionTile(transaction: tx, isBalanceVisible: true)]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('receipt').first, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    // Swipe the first sub item to reveal delete action, then tap trash.
+    final subTiles = find.byType(RecentTransactionTile);
+    expect(subTiles, findsNWidgets(3)); // parent + 2 sub items
+
+    // Trigger delete via the slidable action of the first sub item.
+    final slideCtx = tester.element(find.text('lunch'));
+    Slidable.of(slideCtx)!.openTo(0.22, duration: const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(FPhosphorIcons.trash).first);
+    await tester.pumpAndSettle();
+
+    verify(
+      () => mockUpdate.execute(
+        any(),
+        type: TransactionType.expense,
+        accountId: 'a1',
+        destinationAccountId: null,
+        transactionDate: any(named: 'transactionDate'),
+        note: any(named: 'note'),
+        splitItems: any(named: 'splitItems'),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('transfer tile resolves destination account label', (tester) async {
+    final now = DateTime(2024, 1, 15, 10, 30);
+    final tx = TransactionModel(
+      id: 't2',
+      accountId: 'a1',
+      destinationAccountId: 'a2',
+      type: TransactionType.transfer,
+      amount: 250,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        TransactionItemModel(
+          id: 'i1',
+          transactionId: 't2',
+          amount: 250,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      buildApp([
+        RecentTransactionTile(
+          transaction: tx,
+          isBalanceVisible: true,
+          account: accounts().first,
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    // Destination account name and source account name both appear.
+    expect(find.text('Savings'), findsOneWidget);
+    expect(find.text('Wallet'), findsOneWidget);
+  });
+
+  testWidgets('sub category shows parent prefix label', (tester) async {
+    final now = DateTime(2024, 1, 15, 10, 30);
+    final tx = TransactionModel(
+      id: 't3',
+      accountId: 'a1',
+      type: TransactionType.expense,
+      amount: 100,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        TransactionItemModel(
+          id: 'i1',
+          transactionId: 't3',
+          amount: 100,
+          categoryId: 'child',
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ],
+    );
+    final categoriesWithChild = [
+      CategoryModel(
+        id: 'parent',
+        name: 'Food & Drink',
+        type: CategoryType.expense,
+        color: '#EF4444',
+        icon: 'utensils',
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      ),
+      CategoryModel(
+        id: 'child',
+        name: 'Coffee',
+        type: CategoryType.expense,
+        parentId: 'parent',
+        color: '#8B5CF6',
+        icon: 'coffee',
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      ),
+    ];
+
+    final container = ProviderContainer(
+      overrides: [
+        updateTransactionUseCaseProvider.overrideWithValue(mockUpdate),
+        categoryListProvider.overrideWith(() => _FakeCategoryListNotifier(categoriesWithChild)),
+        accountListProvider.overrideWith(() => _FakeAccountListNotifier(accounts())),
+      ],
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: TranslationProvider(
+          child: MaterialApp(
+            builder: (context, child) => FTheme(data: lightTheme, child: child!),
+            home: Scaffold(
+              body: Column(
+                children: [
+                  RecentTransactionTile(
+                    transaction: tx,
+                    isBalanceVisible: true,
+                    category: categoriesWithChild[1],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Food & Drink • Coffee'), findsOneWidget);
+  });
+
+  testWidgets('single item tile without handlers does not render slidable', (tester) async {
+    final now = DateTime(2024, 1, 15, 10, 30);
+    final tx = TransactionModel(
+      id: 't4',
+      accountId: 'a1',
+      type: TransactionType.income,
+      amount: 100,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        TransactionItemModel(
+          id: 'i1',
+          transactionId: 't4',
+          amount: 100,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ],
+    );
+    await tester.pumpWidget(buildApp([RecentTransactionTile(transaction: tx, isBalanceVisible: true)]));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slidable), findsNothing);
+  });
+}

--- a/test/unit/core/extensions/string_extension_test.dart
+++ b/test/unit/core/extensions/string_extension_test.dart
@@ -35,4 +35,56 @@ void main() {
       expect('FFFFFF'.toColor(), const Color(0xFFFFFFFF));
     });
   });
+
+  group('StringExtension formatAsNumber', () {
+    test('formats integer with thousands separator', () {
+      expect('50000'.formatAsNumber(), '50,000');
+    });
+
+    test('formats number with decimal part', () {
+      expect('50000.5'.formatAsNumber(), '50,000.5');
+    });
+
+    test('empty integer part becomes zero', () {
+      expect('.5'.formatAsNumber(), '0.5');
+    });
+
+    test('returns original on invalid number', () {
+      expect('abc'.formatAsNumber(), 'abc');
+    });
+
+    test('formats with explicit locale', () {
+      expect('50000.5'.formatAsNumber(localeFormat: 'id'), '50.000,5');
+    });
+  });
+
+  group('StringExtension formatMathExpression', () {
+    test('formats addition', () {
+      expect('5000+10'.formatMathExpression(), '5,000 + 10');
+    });
+
+    test('formats subtraction', () {
+      expect('5000-10'.formatMathExpression(), '5,000 - 10');
+    });
+
+    test('formats multiplication with × symbol', () {
+      expect('2*3'.formatMathExpression(), '2 × 3');
+    });
+
+    test('formats division with ÷ symbol', () {
+      expect('10/2'.formatMathExpression(), '10 ÷ 2');
+    });
+
+    test('formats decimal numbers within expression', () {
+      expect('1.5+2.25'.formatMathExpression(), '1.5 + 2.25');
+    });
+
+    test('formats complex expression', () {
+      expect('100*2+50/5'.formatMathExpression(), '100 × 2 + 50 ÷ 5');
+    });
+
+    test('ignores non-matching characters', () {
+      expect('5+5'.formatMathExpression(), '5 + 5');
+    });
+  });
 }

--- a/test/unit/core/services/notification_service_test.dart
+++ b/test/unit/core/services/notification_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poka_ce/core/services/notification_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NotificationService', () {
+    test('is a singleton', () {
+      final a = NotificationService();
+      final b = NotificationService();
+      expect(identical(a, b), isTrue);
+      expect(identical(notificationService, NotificationService()), isTrue);
+    });
+
+    test('init completes without throwing in test environment', () async {
+      final service = NotificationService();
+      await expectLater(service.init(), completes);
+    });
+
+    test('init is idempotent', () async {
+      final service = NotificationService();
+      await service.init();
+      await expectLater(service.init(), completes);
+    });
+
+    test('showNotification completes without throwing', () async {
+      final service = NotificationService();
+      await expectLater(
+        service.showNotification(id: 1, title: 'Budget Alert', body: 'You exceeded 80%', payload: 'budget-1'),
+        completes,
+      );
+    });
+  });
+}

--- a/test/unit/core/services/preferences_service_test.dart
+++ b/test/unit/core/services/preferences_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:poka_ce/core/services/preferences_service.dart';
@@ -51,6 +52,28 @@ void main() {
       when(() => mockPrefs.clear()).thenAnswer((_) async => true);
       await service.clear();
       verify(() => mockPrefs.clear()).called(1);
+    });
+  });
+
+  group('Preferences providers', () {
+    test('sharedPreferencesProvider throws when not overridden', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(
+        () => container.read(sharedPreferencesProvider),
+        throwsA(
+          predicate((e) => e.toString().contains('UnimplementedError')),
+        ),
+      );
+    });
+
+    test('preferencesServiceProvider builds from overridden prefs', () {
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+      );
+      addTearDown(container.dispose);
+      final resolved = container.read(preferencesServiceProvider);
+      expect(resolved, isA<PreferencesService>());
     });
   });
 }

--- a/test/unit/database/daos/accounts_dao_test.dart
+++ b/test/unit/database/daos/accounts_dao_test.dart
@@ -197,6 +197,66 @@ void main() {
       expect(acc!.balance, 0);
     });
 
+    test('deleteAccount removes row', () async {
+      await db.accountsDao.insertAccount(
+        AccountsCompanion.insert(
+          id: const Value('a-del'),
+          name: 'Trash',
+          type: AccountType.assets,
+        ),
+      );
+      expect(await db.accountsDao.getAccount('a-del'), isNotNull);
+      await db.accountsDao.deleteAccount('a-del');
+      expect(await db.accountsDao.getAccount('a-del'), isNull);
+    });
+
+    test('updateAccountsSort persists custom order', () async {
+      await db.accountsDao.insertAccount(
+        AccountsCompanion.insert(id: const Value('s1'), name: 'One', type: AccountType.assets, sort: const Value(0)),
+      );
+      await db.accountsDao.insertAccount(
+        AccountsCompanion.insert(id: const Value('s2'), name: 'Two', type: AccountType.assets, sort: const Value(1)),
+      );
+      await db.accountsDao.insertAccount(
+        AccountsCompanion.insert(id: const Value('s3'), name: 'Three', type: AccountType.assets, sort: const Value(2)),
+      );
+
+      final all = await db.accountsDao.getAllAccounts();
+      final reordered = all.map((a) {
+        if (a.id == 's1') return a.copyWith(sort: 2);
+        if (a.id == 's3') return a.copyWith(sort: 0);
+        return a;
+      }).toList();
+      await db.accountsDao.updateAccountsSort(reordered);
+
+      final s1 = await db.accountsDao.getAccount('s1');
+      final s3 = await db.accountsDao.getAccount('s3');
+      expect(s1!.sort, 2);
+      expect(s3!.sort, 0);
+    });
+
+    test('getAllAccountCategoriesMap groups categories per account', () async {
+      await db
+          .into(db.accounts)
+          .insert(AccountsCompanion.insert(id: const Value('accA'), name: 'A', type: AccountType.assets));
+      await db
+          .into(db.accounts)
+          .insert(AccountsCompanion.insert(id: const Value('accB'), name: 'B', type: AccountType.assets));
+      await db
+          .into(db.categories)
+          .insert(CategoriesCompanion.insert(id: const Value('c1'), name: 'Food', type: CategoryType.expense));
+      await db
+          .into(db.categories)
+          .insert(CategoriesCompanion.insert(id: const Value('c2'), name: 'Bus', type: CategoryType.expense));
+
+      await db.accountsDao.setAccountCategories('accA', ['c1', 'c2']);
+      await db.accountsDao.setAccountCategories('accB', ['c1']);
+
+      final map = await db.accountsDao.getAllAccountCategoriesMap();
+      expect(map['accA'], containsAll(['c1', 'c2']));
+      expect(map['accB'], ['c1']);
+    });
+
     test('parent pocket cascade delete via FK', () async {
       await db.accountsDao.insertAccount(
         AccountsCompanion.insert(

--- a/test/unit/database/daos/recurring_dao_test.dart
+++ b/test/unit/database/daos/recurring_dao_test.dart
@@ -93,6 +93,55 @@ void main() {
       expect(r!.amount, 999);
     });
 
+    test('getDueRecurring returns only active rows due on or before asOf', () async {
+      await seedAccount('acc1');
+      final now = DateTime.now().toUtc();
+      await db.recurringDao.insertRecurring(
+        RecurringTransactionsCompanion.insert(
+          id: const Value('due1'),
+          accountId: 'acc1',
+          type: TransactionType.expense,
+          amount: 100,
+          period: RecurringPeriod.monthly,
+          nextDate: now.subtract(const Duration(days: 2)),
+        ),
+      );
+      await db.recurringDao.insertRecurring(
+        RecurringTransactionsCompanion.insert(
+          id: const Value('dueToday'),
+          accountId: 'acc1',
+          type: TransactionType.expense,
+          amount: 200,
+          period: RecurringPeriod.monthly,
+          nextDate: now,
+        ),
+      );
+      await db.recurringDao.insertRecurring(
+        RecurringTransactionsCompanion.insert(
+          id: const Value('future'),
+          accountId: 'acc1',
+          type: TransactionType.expense,
+          amount: 300,
+          period: RecurringPeriod.monthly,
+          nextDate: now.add(const Duration(days: 2)),
+        ),
+      );
+      await db.recurringDao.insertRecurring(
+        RecurringTransactionsCompanion.insert(
+          id: const Value('inactiveDue'),
+          accountId: 'acc1',
+          type: TransactionType.expense,
+          amount: 400,
+          period: RecurringPeriod.monthly,
+          nextDate: now.subtract(const Duration(days: 1)),
+          isActive: const Value(false),
+        ),
+      );
+
+      final due = await db.recurringDao.getDueRecurring(now);
+      expect(due.map((r) => r.id).toSet(), {'due1', 'dueToday'});
+    });
+
     test('deleteRecurring removes', () async {
       await seedAccount('acc1');
       await db.recurringDao.insertRecurring(

--- a/test/unit/features/accounts/presentation/controllers/account_form_notifier_test.dart
+++ b/test/unit/features/accounts/presentation/controllers/account_form_notifier_test.dart
@@ -219,5 +219,92 @@ void main() {
       final c2 = s.copyWith(nameError: null);
       expect(c2.nameError, isNull);
     });
+
+    test('setIcon, setColor, setIsActive update state', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.setIcon('wallet');
+      notifier.setColor('#FF5733');
+      notifier.setIsActive(isActive: false);
+      final s = container.read(accountFormProvider);
+      expect(s.icon, 'wallet');
+      expect(s.color, '#FF5733');
+      expect(s.isActive, false);
+    });
+
+    test('init(null, parentAccountId) seeds pocket parent', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.init(null, parentAccountId: 'parent-1');
+      expect(container.read(accountFormProvider).parentAccountId, 'parent-1');
+    });
+
+    test('init(with model) preserves restricted categories and parent', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.init(
+        sampleAccount().copyWith(
+          parentId: 'p1',
+          restrictedCategoryIds: const ['c1', 'c2'],
+          icon: 'wallet',
+          color: '#FFFFFF',
+        ),
+      );
+      final s = container.read(accountFormProvider);
+      expect(s.parentAccountId, 'p1');
+      expect(s.restrictedCategoryIds, ['c1', 'c2']);
+      expect(s.icon, 'wallet');
+      expect(s.color, '#FFFFFF');
+    });
+
+    test('toggleRestrictedCategory adds and removes', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.toggleRestrictedCategory('c1');
+      expect(container.read(accountFormProvider).restrictedCategoryIds, ['c1']);
+      notifier.toggleRestrictedCategory('c1');
+      expect(container.read(accountFormProvider).restrictedCategoryIds, isEmpty);
+    });
+
+    test('toggleParentCategory selects parent with all children', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.toggleParentCategory('parent', ['c1', 'c2']);
+      expect(container.read(accountFormProvider).restrictedCategoryIds.toSet(), {'parent', 'c1', 'c2'});
+
+      notifier.toggleParentCategory('parent', ['c1', 'c2']);
+      expect(container.read(accountFormProvider).restrictedCategoryIds, isEmpty);
+    });
+
+    test('toggleParentCategory avoids duplicates when child preselected', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.toggleRestrictedCategory('c1');
+      notifier.toggleParentCategory('parent', ['c1', 'c2']);
+      final ids = container.read(accountFormProvider).restrictedCategoryIds;
+      expect(ids.toSet(), {'parent', 'c1', 'c2'});
+      expect(ids.where((id) => id == 'c1').length, 1);
+    });
+
+    test('toggleChildCategory auto-selects parent when all siblings selected', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.toggleChildCategory(categoryId: 'c1', parentId: 'parent', allSiblingIds: ['c1', 'c2']);
+      expect(container.read(accountFormProvider).restrictedCategoryIds, ['c1']);
+
+      notifier.toggleChildCategory(categoryId: 'c2', parentId: 'parent', allSiblingIds: ['c1', 'c2']);
+      expect(container.read(accountFormProvider).restrictedCategoryIds.toSet(), {'c1', 'c2', 'parent'});
+    });
+
+    test('toggleChildCategory deselects parent when a sibling is unchecked', () {
+      final container = createContainer();
+      final notifier = container.read(accountFormProvider.notifier);
+      notifier.toggleParentCategory('parent', ['c1', 'c2']);
+      expect(container.read(accountFormProvider).restrictedCategoryIds.toSet(), {'parent', 'c1', 'c2'});
+
+      notifier.toggleChildCategory(categoryId: 'c1', parentId: 'parent', allSiblingIds: ['c1', 'c2']);
+      final ids = container.read(accountFormProvider).restrictedCategoryIds;
+      expect(ids.toSet(), {'c2'});
+    });
   });
 }

--- a/test/unit/features/accounts/presentation/controllers/account_list_notifier_test.dart
+++ b/test/unit/features/accounts/presentation/controllers/account_list_notifier_test.dart
@@ -5,23 +5,33 @@ import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/core/enums.dart';
 import 'package:poka_ce/core/error/failure.dart';
 import 'package:poka_ce/core/error/result.dart';
+import 'package:poka_ce/features/accounts/domain/account_aggregate.dart';
 import 'package:poka_ce/features/accounts/domain/account_model.dart';
 import 'package:poka_ce/features/accounts/domain/i_account_repository.dart';
 import 'package:poka_ce/features/accounts/presentation/controllers/account_list_notifier.dart';
+import 'package:poka_ce/features/transactions/domain/i_transaction_repository.dart';
+import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
 
 class MockAccountRepository extends Mock implements IAccountRepository {}
+
+class MockTransactionRepository extends Mock implements ITransactionRepository {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late MockAccountRepository mockRepo;
+  late MockTransactionRepository mockTxRepo;
 
   setUp(() {
     mockRepo = MockAccountRepository();
+    mockTxRepo = MockTransactionRepository();
   });
 
   ProviderContainer createContainer() {
     final container = ProviderContainer(
-      overrides: [accountRepositoryProvider.overrideWithValue(mockRepo)],
+      overrides: [
+        accountRepositoryProvider.overrideWithValue(mockRepo),
+        transactionRepositoryProvider.overrideWithValue(mockTxRepo),
+      ],
     );
     container.listen(accountListProvider, (_, __) {});
     addTearDown(container.dispose);
@@ -35,6 +45,28 @@ void main() {
   }
 
   Future<void> wait() async => Future.delayed(const Duration(milliseconds: 50));
+
+  AccountModel acc(
+    String id, {
+    String? parentId,
+    AccountType type = AccountType.assets,
+    int balance = 0,
+    int sort = 0,
+    bool isActive = true,
+    String name = 'Account',
+  }) {
+    return AccountModel(
+      id: id,
+      name: name,
+      type: type,
+      balance: balance,
+      sort: sort,
+      parentId: parentId,
+      isActive: isActive,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    );
+  }
 
   group('AccountListNotifier', () {
     test('initial state is loading', () async {
@@ -138,6 +170,186 @@ void main() {
       final c = s.copyWith(accounts: []);
       expect(c.accounts, isEmpty);
       expect(c.aggregates, isEmpty);
+    });
+
+    test('state equality and activeAggregates', () {
+      final active = acc('a1', name: 'Active');
+      final inactive = acc('a2', name: 'Inactive', isActive: false);
+      final s1 = AccountListState(
+        accounts: [active],
+        aggregates: [
+          AccountAggregate(account: active),
+          AccountAggregate(account: inactive),
+        ],
+      );
+      expect(s1.activeAggregates.length, 1);
+      expect(s1.activeAggregates.first.account.id, 'a1');
+
+      final s2 = AccountListState(
+        accounts: [active],
+        aggregates: [
+          AccountAggregate(account: active),
+          AccountAggregate(account: inactive),
+        ],
+      );
+      expect(s1, s2);
+      expect(s1.hashCode, isNotNull);
+
+      final s3 = AccountListState(
+        accounts: [active],
+        aggregates: [AccountAggregate(account: active)],
+      );
+      expect(s1 == s3, isFalse);
+      expect(identical(s1, s1), isTrue);
+    });
+
+    test('deleteAccount calls repository', () async {
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(const Success([])));
+      when(() => mockRepo.deleteAccount(any())).thenAnswer((_) async => const Success(null));
+      final container = createContainer();
+      await wait();
+      await container.read(accountListProvider.notifier).deleteAccount('a1');
+      verify(() => mockRepo.deleteAccount('a1')).called(1);
+    });
+
+    test('reorderAccounts at root level', () async {
+      final a = acc('a1', sort: 0, name: 'A');
+      final b = acc('a2', sort: 1, name: 'B');
+      final c = acc('a3', sort: 2, name: 'C');
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([a, b, c])));
+      when(
+        () => mockRepo.reorderAccounts(any(), any(), parentId: any(named: 'parentId')),
+      ).thenAnswer((_) async => const Success(null));
+      final container = createContainer();
+      await wait();
+
+      await container.read(accountListProvider.notifier).reorderAccounts(0, 2);
+
+      final state = container.read(accountListProvider).value!;
+      expect(state.aggregates[0].account.id, 'a2');
+      expect(state.aggregates[1].account.id, 'a1');
+      verify(() => mockRepo.reorderAccounts(0, 2, parentId: null)).called(1);
+    });
+
+    test('reorderAccounts within pockets', () async {
+      final parent = acc('p0', name: 'Parent');
+      final pocketA = acc('pk1', parentId: 'p0', sort: 0);
+      final pocketB = acc('pk2', parentId: 'p0', sort: 1);
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([parent, pocketA, pocketB])));
+      when(
+        () => mockRepo.reorderAccounts(any(), any(), parentId: any(named: 'parentId')),
+      ).thenAnswer((_) async => const Success(null));
+      final container = createContainer();
+      await wait();
+
+      await container.read(accountListProvider.notifier).reorderAccounts(0, 2, parentId: 'p0');
+
+      final state = container.read(accountListProvider).value!;
+      final parentAgg = state.aggregates.firstWhere((a) => a.account.id == 'p0');
+      expect(parentAgg.pockets[0].id, 'pk2');
+      expect(parentAgg.pockets[1].id, 'pk1');
+      verify(() => mockRepo.reorderAccounts(0, 2, parentId: 'p0')).called(1);
+    });
+
+    test('reorderAccounts reverts via invalidateSelf on repo error', () async {
+      final a = acc('a1', sort: 0);
+      final b = acc('a2', sort: 1);
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([a, b])));
+      when(
+        () => mockRepo.reorderAccounts(any(), any(), parentId: any(named: 'parentId')),
+      ).thenAnswer((_) async => const ErrorResult<void, Failure>(DatabaseFailure('fail')));
+      final container = createContainer();
+      await wait();
+
+      await container.read(accountListProvider.notifier).reorderAccounts(0, 2);
+      await wait();
+
+      // After invalidation the stream re-yields original order
+      final state = container.read(accountListProvider).value!;
+      expect(state.aggregates[0].account.id, 'a1');
+      expect(state.aggregates[1].account.id, 'a2');
+    });
+
+    test('regularAccountList and goalAccountList split by type', () async {
+      final regular = acc('r1', name: 'Cash');
+      final goal = acc('g1', type: AccountType.goal, name: 'Trip');
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([regular, goal])));
+      final container = createContainer();
+      await wait();
+
+      final regularList = container.read(regularAccountListProvider).value!;
+      expect(regularList.accounts.map((a) => a.id), ['r1']);
+      expect(regularList.aggregates.length, 1);
+
+      final goalList = container.read(goalAccountListProvider).value!;
+      expect(goalList.accounts.map((a) => a.id), ['g1']);
+      expect(goalList.aggregates.length, 1);
+    });
+
+    test('accountMetrics computes net worth from accounts', () async {
+      final asset = acc('a1', balance: 5000);
+      final liability = acc('l1', type: AccountType.liability, balance: -1200);
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([asset, liability])));
+      final container = createContainer();
+      await wait();
+
+      final metrics = container.read(accountMetricsProvider);
+      expect(metrics.activeAccountCount, 2);
+      expect(metrics.totalAssets, 5000);
+      expect(metrics.totalLiabilities, 1200);
+      expect(metrics.netWorth, 3800);
+    });
+
+    test('accountAggregate returns aggregate for existing account', () async {
+      final parent = acc('p0', name: 'Parent');
+      final pocket = acc('pk1', parentId: 'p0');
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([parent, pocket])));
+      final container = createContainer();
+      await wait();
+
+      final aggregate = container.read(accountAggregateProvider('p0'));
+      expect(aggregate, isNotNull);
+      expect(aggregate!.pockets.length, 1);
+      expect(aggregate.totalBalance, parent.balance + pocket.balance);
+
+      expect(container.read(accountAggregateProvider('unknown')), isNull);
+    });
+
+    test('accountTransactions filters by source or destination account', () async {
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(const Success([])));
+      TransactionModel tx(String id, String accountId, {String? destination}) => TransactionModel(
+        id: id,
+        accountId: accountId,
+        destinationAccountId: destination,
+        type: TransactionType.transfer,
+        amount: 100,
+        transactionDate: DateTime.utc(2024, 1, 1),
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+      final txs = [tx('t1', 'a1'), tx('t2', 'a2', destination: 'a1'), tx('t3', 'a2')];
+      when(() => mockTxRepo.watchTransactions()).thenAnswer(
+        (_) => Stream.value(Success<List<TransactionModel>, Failure>(txs)).asBroadcastStream(),
+      );
+      final container = createContainer();
+      container.listen(recentTransactionsStreamProvider, (_, __) {});
+      await wait();
+
+      final result = container.read(accountTransactionsProvider({'a1'}));
+      expect(result.map((t) => t.id).toSet(), {'t1', 't2'});
+    });
+
+    test('accountMap indexes accounts by id', () async {
+      final a = acc('a1', name: 'One');
+      final b = acc('a2', name: 'Two');
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([a, b])));
+      final container = createContainer();
+      container.listen(accountsStreamProvider, (_, __) {});
+      await wait();
+
+      final map = container.read(accountMapProvider);
+      expect(map.keys.toSet(), {'a1', 'a2'});
+      expect(map['a1']!.name, 'One');
     });
   });
 }

--- a/test/unit/features/backup/presentation/controllers/backup_form_notifier_test.dart
+++ b/test/unit/features/backup/presentation/controllers/backup_form_notifier_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poka_ce/features/backup/presentation/controllers/backup_form_notifier.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  ProviderContainer createContainer() {
+    final c = ProviderContainer();
+    c.listen(backupFormProvider, (_, __) {});
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('BackupFormNotifier', () {
+    test('initial state', () {
+      final container = createContainer();
+      final s = container.read(backupFormProvider);
+      expect(s.passwordError, isNull);
+      expect(s.confirmError, isNull);
+      expect(s.isSubmitting, false);
+    });
+
+    test('reset clears errors', () {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+      notifier.submit(
+        password: '',
+        confirmPassword: '',
+        isBackup: true,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+      );
+      expect(container.read(backupFormProvider).passwordError, 'required');
+      notifier.reset();
+      final s = container.read(backupFormProvider);
+      expect(s.passwordError, isNull);
+      expect(s.confirmError, isNull);
+    });
+
+    test('submit backup with empty password fails', () async {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+      final ok = await notifier.submit(
+        password: '',
+        confirmPassword: '',
+        isBackup: true,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+      );
+      expect(ok, isFalse);
+      expect(container.read(backupFormProvider).passwordError, 'required');
+    });
+
+    test('submit backup with mismatched confirm fails', () async {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+      final ok = await notifier.submit(
+        password: 'secret',
+        confirmPassword: 'other',
+        isBackup: true,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+      );
+      expect(ok, isFalse);
+      expect(container.read(backupFormProvider).confirmError, 'mismatch');
+    });
+
+    test('submit backup success returns true', () async {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+      final ok = await notifier.submit(
+        password: 'secret',
+        confirmPassword: 'secret',
+        isBackup: true,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+      );
+      expect(ok, isTrue);
+      expect(container.read(backupFormProvider).isSubmitting, false);
+    });
+
+    test('submit restore validates password via callback', () async {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+
+      final ok = await notifier.submit(
+        password: 'secret',
+        confirmPassword: '',
+        isBackup: false,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+        onValidateRestore: (pw) async => pw == 'secret',
+      );
+      expect(ok, isTrue);
+      expect(container.read(backupFormProvider).passwordError, isNull);
+    });
+
+    test('submit restore with wrong password shows incorrect error', () async {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+
+      final ok = await notifier.submit(
+        password: 'wrong',
+        confirmPassword: '',
+        isBackup: false,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+        onValidateRestore: (pw) async => false,
+      );
+      expect(ok, isFalse);
+      expect(container.read(backupFormProvider).passwordError, 'incorrect');
+      expect(container.read(backupFormProvider).isSubmitting, false);
+    });
+
+    test('submit restore when callback throws shows incorrect error', () async {
+      final container = createContainer();
+      final notifier = container.read(backupFormProvider.notifier);
+
+      final ok = await notifier.submit(
+        password: 'wrong',
+        confirmPassword: '',
+        isBackup: false,
+        passwordRequiredText: 'required',
+        passwordsDoNotMatchText: 'mismatch',
+        incorrectPasswordText: 'incorrect',
+        onValidateRestore: (pw) async => throw Exception('decrypt failed'),
+      );
+      expect(ok, isFalse);
+      expect(container.read(backupFormProvider).passwordError, 'incorrect');
+      expect(container.read(backupFormProvider).isSubmitting, false);
+    });
+  });
+}

--- a/test/unit/features/goals/presentation/controllers/goal_list_notifier_test.dart
+++ b/test/unit/features/goals/presentation/controllers/goal_list_notifier_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/core/error/failure.dart';
+import 'package:poka_ce/core/enums.dart';
 import 'package:poka_ce/core/error/result.dart';
 import 'package:poka_ce/features/goals/domain/goal_model.dart';
 import 'package:poka_ce/features/goals/domain/i_goal_repository.dart';
@@ -10,9 +11,16 @@ import 'package:poka_ce/features/goals/presentation/controllers/goal_notifier.da
 
 class MockGoalRepository extends Mock implements IGoalRepository {}
 
+class FakeGoalModel extends Fake implements GoalModel {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late MockGoalRepository mockRepo;
+
+  setUpAll(() {
+    registerFallbackValue(FakeGoalModel());
+  });
+
   setUp(() => mockRepo = MockGoalRepository());
 
   ProviderContainer createContainer() {
@@ -77,6 +85,85 @@ void main() {
       await container.read(goalProvider.notifier).deleteGoal('1');
       await wait();
       verify(() => mockRepo.deleteGoal('1')).called(1);
+    });
+
+    test('updateGoal delegates to repository', () async {
+      when(() => mockRepo.watchGoals()).thenAnswer((_) => Stream.value(const <GoalModel>[]));
+      when(() => mockRepo.updateGoal(any())).thenAnswer((_) async => const Success(null));
+      final container = createContainer();
+      await wait();
+      clearInteractions(mockRepo);
+
+      final goal = GoalModel(
+        id: 'g1',
+        accountId: 'a1',
+        name: 'Updated Goal',
+        targetAmount: 100,
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+      await container.read(goalProvider.notifier).updateGoal(goal);
+      await wait();
+      verify(() => mockRepo.updateGoal(goal)).called(1);
+    });
+
+    test('updateGoal failure does not throw', () async {
+      when(() => mockRepo.watchGoals()).thenAnswer((_) => Stream.value(const <GoalModel>[]));
+      when(() => mockRepo.updateGoal(any())).thenAnswer((_) async => const ErrorResult(DatabaseFailure('fail')));
+      final container = createContainer();
+      await wait();
+
+      final goal = GoalModel(
+        id: 'g1',
+        accountId: 'a1',
+        name: 'Goal',
+        targetAmount: 100,
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+      await expectLater(
+        container.read(goalProvider.notifier).updateGoal(goal),
+        completes,
+      );
+    });
+  });
+
+  group('GoalItemState', () {
+    GoalModel goal({int targetAmount = 1000, GoalStatus status = GoalStatus.active}) => GoalModel(
+      id: 'g1',
+      accountId: 'a1',
+      name: 'Goal',
+      targetAmount: targetAmount,
+      status: status,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+    );
+
+    test('completed goal counts target as saved', () {
+      final item = GoalItemState(goal: goal(status: GoalStatus.completed), currentBalance: 200);
+      expect(item.isCompleted, isTrue);
+      expect(item.saved, 1000);
+      expect(item.progress, 1.0);
+      expect(item.isTargetReached, isTrue);
+      expect(item.remaining, 0);
+    });
+
+    test('active goal uses current balance', () {
+      final item = GoalItemState(goal: goal(), currentBalance: 400);
+      expect(item.isCompleted, isFalse);
+      expect(item.saved, 400);
+      expect(item.progress, closeTo(0.4, 0.001));
+      expect(item.isTargetReached, isFalse);
+      expect(item.remaining, 600);
+    });
+
+    test('progress clamps and handles zero target', () {
+      final over = GoalItemState(goal: goal(), currentBalance: 5000);
+      expect(over.progress, 1.0);
+      expect(over.isTargetReached, isTrue);
+
+      final zeroTarget = GoalItemState(goal: goal(targetAmount: 0), currentBalance: 0);
+      expect(zeroTarget.progress, 0.0);
     });
   });
 }

--- a/test/unit/features/recurring/presentation/controllers/recurring_list_notifier_test.dart
+++ b/test/unit/features/recurring/presentation/controllers/recurring_list_notifier_test.dart
@@ -11,9 +11,16 @@ import 'package:poka_ce/features/recurring/presentation/controllers/recurring_li
 
 class MockRecurringRepository extends Mock implements IRecurringRepository {}
 
+class FakeRecurringTransactionModel extends Fake implements RecurringTransactionModel {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late MockRecurringRepository mockRepo;
+
+  setUpAll(() {
+    registerFallbackValue(FakeRecurringTransactionModel());
+  });
+
   setUp(() => mockRepo = MockRecurringRepository());
 
   ProviderContainer createContainer() {
@@ -108,6 +115,67 @@ void main() {
     test('copyWith', () {
       const s = RecurringListState(recurrings: [], isLoading: false);
       expect(s.copyWith(isLoading: true).isLoading, true);
+    });
+
+    test('toggleActive flips optimistically and persists', () async {
+      final recurring = RecurringTransactionModel(
+        id: '1',
+        accountId: 'a1',
+        type: TransactionType.expense,
+        amount: 1000,
+        period: RecurringPeriod.monthly,
+        nextDate: DateTime.utc(2024, 1, 1),
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+      when(() => mockRepo.getRecurringTransactions()).thenAnswer((_) async => Success([recurring]));
+      when(() => mockRepo.updateRecurring(any())).thenAnswer((_) async => const Success(null));
+      final container = createContainer();
+      await wait();
+      clearInteractions(mockRepo);
+
+      await container.read(recurringListProvider.notifier).toggleActive('1');
+      await wait();
+
+      expect(container.read(recurringListProvider).recurrings.first.isActive, false);
+      final updated = verify(() => mockRepo.updateRecurring(captureAny())).captured.single as RecurringTransactionModel;
+      expect(updated.id, '1');
+      expect(updated.isActive, false);
+    });
+
+    test('toggleActive refreshes to repository state on failure', () async {
+      final recurring = RecurringTransactionModel(
+        id: '1',
+        accountId: 'a1',
+        type: TransactionType.expense,
+        amount: 1000,
+        period: RecurringPeriod.monthly,
+        nextDate: DateTime.utc(2024, 1, 1),
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+      when(() => mockRepo.getRecurringTransactions()).thenAnswer((_) async => Success([recurring]));
+      when(() => mockRepo.updateRecurring(any())).thenAnswer((_) async => const ErrorResult(DatabaseFailure('fail')));
+      final container = createContainer();
+      await wait();
+      clearInteractions(mockRepo);
+
+      await container.read(recurringListProvider.notifier).toggleActive('1');
+      await wait();
+
+      // After rollback the fresh repository state is shown (active again).
+      expect(container.read(recurringListProvider).recurrings.first.isActive, true);
+    });
+
+    test('toggleActive with unknown id does nothing', () async {
+      when(() => mockRepo.getRecurringTransactions()).thenAnswer((_) async => const Success([]));
+      final container = createContainer();
+      await wait();
+      clearInteractions(mockRepo);
+
+      await container.read(recurringListProvider.notifier).toggleActive('unknown');
+      await wait();
+      verifyNever(() => mockRepo.updateRecurring(any()));
     });
   });
 }

--- a/test/unit/features/reports/presentation/controllers/report_notifier_test.dart
+++ b/test/unit/features/reports/presentation/controllers/report_notifier_test.dart
@@ -18,6 +18,19 @@ void main() {
       expect(newState.period, ReportPeriod.last3Months);
       expect(newState.isLoading, false);
     });
+
+    test('previousPeriodLabel per period', () {
+      const thisMonth = ReportState(period: ReportPeriod.thisMonth);
+      expect(thisMonth.previousPeriodLabel, 'last month');
+      const lastMonth = ReportState(period: ReportPeriod.lastMonth);
+      expect(lastMonth.previousPeriodLabel, 'prev month');
+      const last3 = ReportState(period: ReportPeriod.last3Months);
+      expect(last3.previousPeriodLabel, 'prev 3 mo');
+      const last6 = ReportState(period: ReportPeriod.last6Months);
+      expect(last6.previousPeriodLabel, 'prev 6 mo');
+      const custom = ReportState(period: ReportPeriod.custom);
+      expect(custom.previousPeriodLabel, 'prev period');
+    });
   });
 
   group('ReportNotifier', () {
@@ -54,6 +67,25 @@ void main() {
 
       final state = container.read(reportProvider);
       expect(state.period, ReportPeriod.last3Months);
+    });
+
+    test('setPeriod to non-custom clears custom range', () async {
+      final container = makeContainer();
+      final notifier = container.read(reportProvider.notifier);
+
+      notifier.setCustomRange(DateTime.utc(2024, 1, 1), DateTime.utc(2024, 1, 31));
+      await Future.delayed(Duration.zero);
+      var state = container.read(reportProvider);
+      expect(state.period, ReportPeriod.custom);
+      expect(state.customDateStart, DateTime.utc(2024, 1, 1));
+      expect(state.customDateEnd, DateTime.utc(2024, 1, 31));
+
+      notifier.setPeriod(ReportPeriod.thisMonth);
+      await Future.delayed(Duration.zero);
+      state = container.read(reportProvider);
+      expect(state.period, ReportPeriod.thisMonth);
+      expect(state.customDateStart, isNull);
+      expect(state.customDateEnd, isNull);
     });
   });
 }

--- a/test/unit/features/transactions/domain/use_cases/transfer_funds_use_case_test.dart
+++ b/test/unit/features/transactions/domain/use_cases/transfer_funds_use_case_test.dart
@@ -12,104 +12,132 @@ class MockUnitOfWork extends Mock implements IUnitOfWork {}
 
 class MockTransactionRepository extends Mock implements ITransactionRepository {}
 
-class FakeTransactionModel extends Fake implements TransactionModel {}
-
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
+  late MockUnitOfWork unitOfWork;
+  late MockTransactionRepository repository;
   late TransferFundsUseCase useCase;
-  late MockUnitOfWork mockUoW;
-  late MockTransactionRepository mockTransactionRepo;
 
   setUpAll(() {
-    registerFallbackValue(FakeTransactionModel());
-    registerFallbackValue(() async => Success<TransactionModel, Failure>(FakeTransactionModel()));
+    registerFallbackValue(
+      TransactionModel(
+        id: 'fallback',
+        accountId: 'fallback',
+        type: TransactionType.transfer,
+        amount: 0,
+        transactionDate: DateTime.utc(2026),
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+        items: const [],
+      ),
+    );
+    registerFallbackValue(
+      () async => TransactionModel(
+        id: 'fallback',
+        accountId: 'fallback',
+        type: TransactionType.transfer,
+        amount: 0,
+        transactionDate: DateTime.utc(2026),
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+        items: const [],
+      ),
+    );
   });
 
   setUp(() {
-    mockUoW = MockUnitOfWork();
-    mockTransactionRepo = MockTransactionRepository();
-    useCase = TransferFundsUseCase(mockUoW, mockTransactionRepo);
-
-    when(() => mockUoW.execute<Result<TransactionModel, Failure>>(any())).thenAnswer((i) async {
-      final callback = i.positionalArguments[0] as Future<Result<TransactionModel, Failure>> Function();
-      return await callback();
+    unitOfWork = MockUnitOfWork();
+    repository = MockTransactionRepository();
+    useCase = TransferFundsUseCase(unitOfWork, repository);
+    when(() => unitOfWork.execute<Result<TransactionModel, Failure>>(any())).thenAnswer((inv) async {
+      final action = inv.positionalArguments.first as Future<Result<TransactionModel, Failure>> Function();
+      return action();
     });
   });
 
-  test('returns ValidationFailure if amount <= 0', () async {
-    final result = await useCase.execute(
-      amount: 0,
-      sourceAccountId: 'a1',
-      destinationAccountId: 'a2',
-    );
+  TransactionModel capturedTransaction() {
+    final result = verify(() => repository.createTransaction(captureAny())).captured.single as TransactionModel;
+    return result;
+  }
 
-    expect(result, isA<ErrorResult>());
-    expect((result as ErrorResult).error, isA<ValidationFailure>());
-  });
+  group('TransferFundsUseCase.execute', () {
+    test('rejects non-positive amount', () async {
+      final result = await useCase.execute(amount: 0, sourceAccountId: 'a', destinationAccountId: 'b');
+      expect(result, isA<ErrorResult<TransactionModel, Failure>>());
+      final error = (result as ErrorResult<TransactionModel, Failure>).error;
+      expect(error, isA<ValidationFailure>());
+      verifyNever(() => repository.createTransaction(any()));
+    });
 
-  test('returns ValidationFailure if amount is negative', () async {
-    final result = await useCase.execute(
-      amount: -5000,
-      sourceAccountId: 'a1',
-      destinationAccountId: 'a2',
-    );
+    test('rejects negative amount', () async {
+      final result = await useCase.execute(amount: -5, sourceAccountId: 'a', destinationAccountId: 'b');
+      expect(result, isA<ErrorResult<TransactionModel, Failure>>());
+    });
 
-    expect(result, isA<ErrorResult>());
-    expect((result as ErrorResult).error, isA<ValidationFailure>());
-  });
+    test('rejects same source and destination account', () async {
+      final result = await useCase.execute(amount: 100, sourceAccountId: 'same', destinationAccountId: 'same');
+      expect(result, isA<ErrorResult<TransactionModel, Failure>>());
+      final error = (result as ErrorResult<TransactionModel, Failure>).error;
+      expect(error, isA<ValidationFailure>());
+      verifyNever(() => repository.createTransaction(any()));
+    });
 
-  test('returns ValidationFailure if source == dest', () async {
-    final result = await useCase.execute(
-      amount: 1000,
-      sourceAccountId: 'a1',
-      destinationAccountId: 'a1',
-    );
+    test('creates transfer transaction with single matching item', () async {
+      when(() => repository.createTransaction(any())).thenAnswer((_) async => const Success<void, Failure>(null));
 
-    expect(result, isA<ErrorResult>());
-    expect((result as ErrorResult).error, isA<ValidationFailure>());
-  });
+      final date = DateTime.utc(2026, 1, 15, 10);
+      final result = await useCase.execute(
+        amount: 25000,
+        sourceAccountId: 'wallet',
+        destinationAccountId: 'pocket',
+        note: 'weekly top up',
+        transactionDate: date,
+      );
 
-  test('creates transfer transaction successfully', () async {
-    when(() => mockTransactionRepo.createTransaction(any())).thenAnswer((_) async => const Success(null));
+      expect(result, isA<Success<TransactionModel, Failure>>());
+      final tx = (result as Success<TransactionModel, Failure>).value;
+      expect(tx.type, TransactionType.transfer);
+      expect(tx.accountId, 'wallet');
+      expect(tx.destinationAccountId, 'pocket');
+      expect(tx.amount, 25000);
+      expect(tx.note, 'weekly top up');
+      expect(tx.transactionDate, date);
+      expect(tx.items.length, 1);
+      expect(tx.items.first.amount, 25000);
+      expect(tx.items.first.transactionId, tx.id);
+      expect(tx.id, isNotEmpty);
+    });
 
-    final result = await useCase.execute(
-      amount: 50000,
-      sourceAccountId: 'a1',
-      destinationAccountId: 'a2',
-      note: 'transfer note',
-    );
+    test('uses UTC current date when transactionDate omitted', () async {
+      when(() => repository.createTransaction(any())).thenAnswer((_) async => const Success<void, Failure>(null));
 
-    expect(result, isA<Success>());
+      final before = DateTime.now().toUtc();
+      final result = await useCase.execute(amount: 100, sourceAccountId: 'a', destinationAccountId: 'b');
+      final after = DateTime.now().toUtc();
 
-    final captured =
-        verify(() => mockTransactionRepo.createTransaction(captureAny())).captured.first as TransactionModel;
-    expect(captured.amount, 50000);
-    expect(captured.type, TransactionType.transfer);
-    expect(captured.accountId, 'a1');
-    expect(captured.destinationAccountId, 'a2');
-    expect(captured.note, 'transfer note');
-    expect(captured.items.length, 1);
-    expect(captured.items.first.amount, 50000);
-  });
+      final tx = (result as Success<TransactionModel, Failure>).value;
+      expect(tx.transactionDate.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+      expect(tx.transactionDate.isBefore(after.add(const Duration(seconds: 1))), isTrue);
+      expect(tx.transactionDate.isUtc, isTrue);
+    });
 
-  test('returns DatabaseFailure when repository fails inside transaction', () async {
-    when(
-      () => mockTransactionRepo.createTransaction(any()),
-    ).thenAnswer((_) async => const ErrorResult<void, Failure>(DatabaseFailure('transfer insert failed')));
+    test('propagates repository failure', () async {
+      when(() => repository.createTransaction(any())).thenAnswer(
+        (_) async => const ErrorResult<void, Failure>(DatabaseFailure('insert failed')),
+      );
 
-    final result = await useCase.execute(
-      amount: 50000,
-      sourceAccountId: 'a1',
-      destinationAccountId: 'a2',
-    );
+      final result = await useCase.execute(amount: 100, sourceAccountId: 'a', destinationAccountId: 'b');
+      expect(result, isA<ErrorResult<TransactionModel, Failure>>());
+      final error = (result as ErrorResult<TransactionModel, Failure>).error;
+      expect(error, isA<DatabaseFailure>());
+    });
 
-    // The use case must throw inside the unit of work so the DB transaction rolls back,
-    // then translate that exception into a DatabaseFailure for the caller.
-    expect(result, isA<ErrorResult<TransactionModel, Failure>>());
-    result.fold(
-      (_) => fail('Should not succeed'),
-      (error) => expect(error, isA<DatabaseFailure>()),
-    );
-    verify(() => mockTransactionRepo.createTransaction(any())).called(1);
+    test('wraps unexpected exception into DatabaseFailure', () async {
+      when(() => unitOfWork.execute<Result<TransactionModel, Failure>>(any())).thenThrow(Exception('boom'));
+
+      final result = await useCase.execute(amount: 100, sourceAccountId: 'a', destinationAccountId: 'b');
+      expect(result, isA<ErrorResult<TransactionModel, Failure>>());
+      final error = (result as ErrorResult<TransactionModel, Failure>).error;
+      expect(error, isA<DatabaseFailure>());
+    });
   });
 }

--- a/test/unit/features/transactions/presentation/controllers/transaction_form_notifier_test.dart
+++ b/test/unit/features/transactions/presentation/controllers/transaction_form_notifier_test.dart
@@ -6,14 +6,18 @@ import 'package:poka_ce/core/enums.dart';
 import 'package:poka_ce/core/error/failure.dart';
 import 'package:poka_ce/core/error/result.dart';
 import 'package:poka_ce/features/transactions/domain/i_transaction_repository.dart';
+import 'package:poka_ce/features/transactions/domain/split_item.dart';
 import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
 import 'package:poka_ce/features/transactions/domain/use_cases/create_transaction_use_case.dart';
 import 'package:poka_ce/features/transactions/domain/use_cases/transfer_funds_use_case.dart';
+import 'package:poka_ce/features/transactions/domain/use_cases/update_transaction_use_case.dart';
 import 'package:poka_ce/features/transactions/presentation/controllers/transaction_form_notifier.dart';
 import 'package:poka_ce/features/budgets/domain/budget_alert_service.dart';
 import 'package:poka_ce/features/budgets/domain/budget_alert_service_provider.dart';
 
 class MockCreateTransactionUseCase extends Mock implements CreateTransactionUseCase {}
+
+class MockUpdateTransactionUseCase extends Mock implements UpdateTransactionUseCase {}
 
 class MockTransferFundsUseCase extends Mock implements TransferFundsUseCase {}
 
@@ -24,6 +28,7 @@ class FakeTransactionModel extends Fake implements TransactionModel {}
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late MockCreateTransactionUseCase mockCreate;
+  late MockUpdateTransactionUseCase mockUpdate;
   late MockTransferFundsUseCase mockTransfer;
   late MockBudgetAlertService mockBudgetAlertService;
 
@@ -34,6 +39,7 @@ void main() {
 
   setUp(() {
     mockCreate = MockCreateTransactionUseCase();
+    mockUpdate = MockUpdateTransactionUseCase();
     mockTransfer = MockTransferFundsUseCase();
     mockBudgetAlertService = MockBudgetAlertService();
     when(() => mockBudgetAlertService.checkAlerts()).thenAnswer((_) async => null);
@@ -43,6 +49,7 @@ void main() {
     final c = ProviderContainer(
       overrides: [
         createTransactionUseCaseProvider.overrideWithValue(mockCreate),
+        updateTransactionUseCaseProvider.overrideWithValue(mockUpdate),
         transferFundsUseCaseProvider.overrideWithValue(mockTransfer),
         budgetAlertServiceProvider.overrideWithValue(mockBudgetAlertService),
       ],
@@ -61,6 +68,52 @@ void main() {
     updatedAt: DateTime.utc(2024, 1, 1),
   );
 
+  TransactionModel splitTx() => TransactionModel(
+    id: 't2',
+    accountId: 'a1',
+    type: TransactionType.expense,
+    amount: 700,
+    transactionDate: DateTime.utc(2024, 2, 2),
+    createdAt: DateTime.utc(2024, 2, 2),
+    updatedAt: DateTime.utc(2024, 2, 2),
+    note: 'receipt',
+    items: [
+      TransactionItemModel(
+        id: 'i1',
+        transactionId: 't2',
+        amount: 300,
+        categoryId: 'food',
+        note: 'lunch',
+        createdAt: DateTime.utc(2024, 2, 2),
+        updatedAt: DateTime.utc(2024, 2, 2),
+      ),
+      TransactionItemModel(
+        id: 'i2',
+        transactionId: 't2',
+        amount: 400,
+        categoryId: 'transport',
+        note: 'taxi',
+        createdAt: DateTime.utc(2024, 2, 2),
+        updatedAt: DateTime.utc(2024, 2, 2),
+      ),
+    ],
+  );
+
+  void stubCreateSuccess() {
+    when(
+      () => mockCreate.execute(
+        type: any(named: 'type'),
+        accountId: any(named: 'accountId'),
+        amount: any(named: 'amount'),
+        categoryId: any(named: 'categoryId'),
+        note: any(named: 'note'),
+        transactionDate: any(named: 'transactionDate'),
+        allocation: any(named: 'allocation'),
+        splitItems: any(named: 'splitItems'),
+      ),
+    ).thenAnswer((_) async => Success(sampleTx()));
+  }
+
   group('TransactionFormNotifier', () {
     const args = TransactionFormArgs();
 
@@ -73,18 +126,7 @@ void main() {
     });
 
     test('save expense success via create use case', () async {
-      when(
-        () => mockCreate.execute(
-          type: any(named: 'type'),
-          accountId: any(named: 'accountId'),
-          amount: any(named: 'amount'),
-          categoryId: any(named: 'categoryId'),
-          note: any(named: 'note'),
-          transactionDate: any(named: 'transactionDate'),
-          allocation: any(named: 'allocation'),
-          splitItems: any(named: 'splitItems'),
-        ),
-      ).thenAnswer((_) async => Success(sampleTx()));
+      stubCreateSuccess();
       final container = createContainer();
       final n = container.read(transactionFormProvider(args).notifier);
       n.setType(TransactionType.expense);
@@ -191,6 +233,404 @@ void main() {
       n.setCategory('c1');
       await n.save();
       expect(container.read(transactionFormProvider(args)).error, contains('boom'));
+    });
+  });
+
+  group('TransactionFormNotifier validation guards', () {
+    const args = TransactionFormArgs();
+
+    test('save with zero amount does nothing', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setAccount('a1');
+      n.setCategory('c1');
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).isLoading, false);
+      verifyNever(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          categoryId: any(named: 'categoryId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      );
+    });
+
+    test('save without account does nothing', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('5');
+      n.setCategory('c1');
+      await n.save();
+      verifyNever(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          categoryId: any(named: 'categoryId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      );
+    });
+
+    test('save transfer without destination does nothing', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setType(TransactionType.transfer);
+      n.setAccount('a1');
+      n.onKeyPressed('1');
+      await n.save();
+      verifyNever(
+        () => mockTransfer.execute(
+          amount: any(named: 'amount'),
+          sourceAccountId: any(named: 'sourceAccountId'),
+          destinationAccountId: any(named: 'destinationAccountId'),
+          note: any(named: 'note'),
+        ),
+      );
+    });
+
+    test('OK key is ignored by numpad', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('5');
+      n.onKeyPressed('OK');
+      expect(container.read(transactionFormProvider(args)).amountExpression, '5');
+    });
+
+    test('= key evaluates expression inline', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('5');
+      n.onKeyPressed('+');
+      n.onKeyPressed('3');
+      expect(container.read(transactionFormProvider(args)).amountExpression, '5+3');
+      n.onKeyPressed('=');
+      expect(container.read(transactionFormProvider(args)).amountExpression, '8');
+    });
+
+    test('= key shows history preview while typing unresolved expression', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('5');
+      n.onKeyPressed('+');
+      n.onKeyPressed('3');
+      final s = container.read(transactionFormProvider(args));
+      expect(s.amountExpression, '5+3');
+      expect(s.historyExpression, '8');
+    });
+
+    test('= key keeps expression when result equals snapshot', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('5');
+      n.onKeyPressed('=');
+      expect(container.read(transactionFormProvider(args)).amountExpression, '5');
+    });
+
+    test('setNote, setDate, setAllocation update state', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      final date = DateTime.utc(2024, 6, 15);
+      n.setNote('coffee');
+      n.setDate(date);
+      n.setAllocation(TransactionAllocation.want);
+      final s = container.read(transactionFormProvider(args));
+      expect(s.note, 'coffee');
+      expect(s.date, date);
+      expect(s.allocation, TransactionAllocation.want);
+    });
+
+    test('setCategory null clears category', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setCategory('c1');
+      expect(container.read(transactionFormProvider(args)).categoryId, 'c1');
+      n.setCategory(null);
+      expect(container.read(transactionFormProvider(args)).categoryId, isNull);
+    });
+
+    test('setType to income clears split items', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setSplitItems([
+        const SplitItem(amount: 100, categoryId: 'a'),
+        const SplitItem(amount: 200, categoryId: 'b'),
+      ]);
+      expect(container.read(transactionFormProvider(args)).splitItems, isNotNull);
+      n.setType(TransactionType.income);
+      expect(container.read(transactionFormProvider(args)).splitItems, isNull);
+    });
+
+    test('setSplitItems updates amount total and clears history', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('5+5');
+      n.setSplitItems([
+        const SplitItem(amount: 100, categoryId: 'a'),
+        const SplitItem(amount: 250, categoryId: 'b'),
+      ]);
+      final s = container.read(transactionFormProvider(args));
+      expect(s.splitItems!.length, 2);
+      expect(s.amountExpression, '350');
+      expect(s.historyExpression, isNull);
+    });
+
+    test('setSplitItems null resets expression', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setSplitItems([
+        const SplitItem(amount: 100, categoryId: 'a'),
+        const SplitItem(amount: 250, categoryId: 'b'),
+      ]);
+      n.setSplitItems(null);
+      final s = container.read(transactionFormProvider(args));
+      expect(s.splitItems, isNull);
+      expect(s.amountExpression, '');
+    });
+
+    test('swapAccounts exchanges source and destination', () {
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setAccount('src');
+      n.setDestinationAccount('dst');
+      n.swapAccounts();
+      final s = container.read(transactionFormProvider(args));
+      expect(s.accountId, 'dst');
+      expect(s.destinationAccountId, 'src');
+    });
+
+    test('TransactionFormArgs equality and hashCode', () {
+      const a = TransactionFormArgs(initialAccountId: 'a1', initialAmount: '100');
+      const b = TransactionFormArgs(initialAccountId: 'a1', initialAmount: '100');
+      const c = TransactionFormArgs(initialAccountId: 'a2');
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a == c, isFalse);
+      expect(a == 'not-args', isFalse);
+    });
+  });
+
+  group('TransactionFormNotifier edit mode', () {
+    const args = TransactionFormArgs();
+
+    test('build seeds state from initialTransaction', () {
+      final container = createContainer();
+      final tx = sampleTx().copyWith(note: 'edited');
+      final editArgs = TransactionFormArgs(initialTransaction: tx);
+      final s = container.read(transactionFormProvider(editArgs));
+      expect(s.type, TransactionType.expense);
+      expect(s.amountExpression, '500');
+      expect(s.note, 'edited');
+      expect(s.accountId, 'a1');
+      expect(s.date, tx.transactionDate.toLocal());
+    });
+
+    test('build seeds split items from multi-item transaction', () {
+      final container = createContainer();
+      final editArgs = TransactionFormArgs(initialTransaction: splitTx());
+      final s = container.read(transactionFormProvider(editArgs));
+      expect(s.splitItems!.length, 2);
+      expect(s.splitItems!.first.categoryId, 'food');
+      expect(s.splitItems!.first.amount, 300);
+      expect(s.amountExpression, '700');
+      expect(s.categoryId, 'food');
+    });
+
+    test('build seeds from args without transaction', () {
+      final container = createContainer();
+      const args = TransactionFormArgs(
+        initialType: TransactionType.income,
+        initialAmount: '99',
+        initialNote: 'bonus',
+        initialAccountId: 'a9',
+      );
+      final s = container.read(transactionFormProvider(args));
+      expect(s.type, TransactionType.income);
+      expect(s.amountExpression, '99');
+      expect(s.note, 'bonus');
+      expect(s.accountId, 'a9');
+    });
+
+    test('save via update use case for expense', () async {
+      when(
+        () => mockUpdate.execute(
+          any(),
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          categoryId: any(named: 'categoryId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          allocation: any(named: 'allocation'),
+        ),
+      ).thenAnswer((_) async => Success(sampleTx()));
+
+      final tx = sampleTx();
+      final container = createContainer();
+      final args = TransactionFormArgs(initialTransaction: tx);
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('9');
+      n.setCategory('c2');
+      await n.save();
+
+      expect(container.read(transactionFormProvider(args)).isSuccess, true);
+      final capturedTx =
+          verify(
+                () => mockUpdate.execute(
+                  captureAny(),
+                  type: any(named: 'type'),
+                  accountId: any(named: 'accountId'),
+                  amount: any(named: 'amount'),
+                  categoryId: any(named: 'categoryId'),
+                  note: any(named: 'note'),
+                  transactionDate: any(named: 'transactionDate'),
+                  allocation: any(named: 'allocation'),
+                ),
+              ).captured.single
+              as TransactionModel;
+      expect(capturedTx.id, 't1');
+    });
+
+    test('save via update use case for transfer', () async {
+      when(
+        () => mockUpdate.execute(
+          any(),
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          destinationAccountId: any(named: 'destinationAccountId'),
+          amount: any(named: 'amount'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+        ),
+      ).thenAnswer((_) async => Success(sampleTx().copyWith(type: TransactionType.transfer)));
+
+      final tx = sampleTx().copyWith(type: TransactionType.transfer, destinationAccountId: 'a2');
+      final container = createContainer();
+      final args = TransactionFormArgs(initialTransaction: tx);
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.onKeyPressed('8');
+      n.setDestinationAccount('a3');
+      await n.save();
+
+      expect(container.read(transactionFormProvider(args)).isSuccess, true);
+    });
+
+    test('update failure sets error', () async {
+      when(
+        () => mockUpdate.execute(
+          any(),
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          categoryId: any(named: 'categoryId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          allocation: any(named: 'allocation'),
+        ),
+      ).thenAnswer((_) async => const ErrorResult<TransactionModel, Failure>(DatabaseFailure('update fail')));
+
+      final container = createContainer();
+      final args = TransactionFormArgs(initialTransaction: sampleTx());
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setCategory('c1');
+      n.onKeyPressed('1');
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).error, 'update fail');
+    });
+
+    test('split save via create use case', () async {
+      when(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).thenAnswer((_) async => Success(splitTx()));
+
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setAccount('a1');
+      n.setSplitItems([
+        const SplitItem(amount: 300, categoryId: 'food', note: 'lunch'),
+        const SplitItem(amount: 400, categoryId: 'transport', note: 'taxi'),
+      ]);
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).isSuccess, true);
+      verify(
+        () => mockBudgetAlertService.checkAlerts(),
+      ).called(1);
+    });
+
+    test('split save via update use case', () async {
+      when(
+        () => mockUpdate.execute(
+          any(),
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          transactionDate: any(named: 'transactionDate'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).thenAnswer((_) async => Success(splitTx()));
+
+      final container = createContainer();
+      final args = TransactionFormArgs(initialTransaction: splitTx());
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setAccount('a1');
+      n.setSplitItems([
+        const SplitItem(amount: 300, categoryId: 'food'),
+        const SplitItem(amount: 400, categoryId: 'transport'),
+      ]);
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).isSuccess, true);
+    });
+
+    test('split save with fewer than 2 items does nothing', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setAccount('a1');
+      n.setSplitItems([const SplitItem(amount: 300, categoryId: 'food')]);
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).isLoading, false);
+    });
+
+    test('split save with zero-amount item does nothing', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setAccount('a1');
+      n.setSplitItems([
+        const SplitItem(amount: 300, categoryId: 'food'),
+        const SplitItem(amount: 0, categoryId: 'transport'),
+      ]);
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).isLoading, false);
+    });
+
+    test('split save without account does nothing', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setSplitItems([
+        const SplitItem(amount: 300, categoryId: 'food'),
+        const SplitItem(amount: 400, categoryId: 'transport'),
+      ]);
+      await n.save();
+      expect(container.read(transactionFormProvider(args)).isLoading, false);
     });
   });
 }

--- a/test/unit/features/transactions/presentation/controllers/transaction_list_notifier_test.dart
+++ b/test/unit/features/transactions/presentation/controllers/transaction_list_notifier_test.dart
@@ -148,6 +148,263 @@ void main() {
         focusedDate: DateTime.utc(2024, 1, 1),
       );
       expect(s.copyWith(isLoading: true).isLoading, true);
+      expect(s.copyWith(errorMessage: 'oops').errorMessage, 'oops');
+      expect(s.copyWith(viewMode: TransactionViewMode.month).viewMode, TransactionViewMode.month);
+      expect(s.copyWith(focusedDate: DateTime.utc(2025)).focusedDate, DateTime.utc(2025));
+    });
+
+    test('TransactionFilter isActive and copyWith', () {
+      const empty = TransactionFilter();
+      expect(empty.isActive, isFalse);
+      const withType = TransactionFilter(types: {TransactionType.income});
+      expect(withType.isActive, isTrue);
+      const withAccount = TransactionFilter(accountIds: {'a1'});
+      expect(withAccount.isActive, isTrue);
+      const withCategory = TransactionFilter(categoryIds: {'c1'});
+      expect(withCategory.isActive, isTrue);
+      const withQuery = TransactionFilter(searchQuery: 'x');
+      expect(withQuery.isActive, isTrue);
+
+      final copied = withType.copyWith(types: {TransactionType.expense}, searchQuery: 'q');
+      expect(copied.types, {TransactionType.expense});
+      expect(copied.searchQuery, 'q');
+      expect(copied.accountIds, isEmpty);
+      expect(copied.copyWith().types, {TransactionType.expense});
+    });
+
+    test('period summary getters sum income and expense', () {
+      TransactionModel tx(String id, TransactionType type, int amount, {String? note, int? itemAmount}) {
+        return TransactionModel(
+          id: id,
+          accountId: 'a1',
+          type: type,
+          amount: amount,
+          transactionDate: DateTime.utc(2024, 1, 1),
+          createdAt: DateTime.utc(2024, 1, 1),
+          updatedAt: DateTime.utc(2024, 1, 1),
+          note: note,
+          items: [
+            TransactionItemModel(
+              id: '$id-item',
+              transactionId: id,
+              amount: itemAmount ?? amount,
+              createdAt: DateTime.utc(2024, 1, 1),
+              updatedAt: DateTime.utc(2024, 1, 1),
+            ),
+          ],
+        );
+      }
+
+      final s = TransactionListState(
+        focusedDate: DateTime.utc(2024, 1, 1),
+        isLoading: false,
+        transactions: [
+          tx('1', TransactionType.income, 1000),
+          tx('2', TransactionType.expense, 400, itemAmount: 150),
+          tx('3', TransactionType.transfer, 100),
+        ],
+      );
+      expect(s.periodIncome, 1000);
+      expect(s.periodExpense, 400);
+      expect(s.periodNet, 600);
+    });
+
+    test('periodLabel for day/week/month modes', () {
+      final monday = DateTime(2024, 1, 8); // a Monday
+      final dayState = TransactionListState(focusedDate: monday, viewMode: TransactionViewMode.day);
+      expect(dayState.periodLabel, isNotEmpty);
+
+      final weekState = TransactionListState(focusedDate: monday, viewMode: TransactionViewMode.week);
+      expect(weekState.periodLabel, startsWith('Week '));
+      expect(weekState.periodLabel, contains('Jan 2024'));
+
+      final monthState = TransactionListState(focusedDate: monday, viewMode: TransactionViewMode.month);
+      expect(monthState.periodLabel, 'January 2024');
+    });
+
+    test('periodShortLabel per view mode', () {
+      final s = TransactionListState(focusedDate: DateTime.utc(2024, 1, 1));
+      expect(s.periodShortLabel, 'Daily');
+      expect(s.copyWith(viewMode: TransactionViewMode.week).periodShortLabel, 'Weekly');
+      expect(s.copyWith(viewMode: TransactionViewMode.month).periodShortLabel, 'Monthly');
+    });
+
+    test('isCurrentPeriod for today vs past', () {
+      final now = DateTime.now();
+      final todayState = TransactionListState(focusedDate: now, viewMode: TransactionViewMode.day);
+      expect(todayState.isCurrentPeriod, isTrue);
+
+      final pastState = TransactionListState(
+        focusedDate: DateTime(now.year - 1, 1, 1),
+        viewMode: TransactionViewMode.day,
+      );
+      expect(pastState.isCurrentPeriod, isFalse);
+
+      final pastWeek = TransactionListState(
+        focusedDate: DateTime(now.year - 1, 1, 1),
+        viewMode: TransactionViewMode.week,
+      );
+      expect(pastWeek.isCurrentPeriod, isFalse);
+
+      final pastMonth = TransactionListState(
+        focusedDate: DateTime(now.year - 1, 1, 1),
+        viewMode: TransactionViewMode.month,
+      );
+      expect(pastMonth.isCurrentPeriod, isFalse);
+    });
+
+    test('setViewMode switches window and reloads', () async {
+      stubWatch(const Success([]));
+      final container = createContainer();
+      await wait();
+      container.read(transactionListNotifierProvider.notifier).setViewMode(TransactionViewMode.week);
+      await wait();
+      expect(container.read(transactionListNotifierProvider).viewMode, TransactionViewMode.week);
+      expect(container.read(transactionListNotifierProvider).periodShortLabel, 'Weekly');
+    });
+
+    test('navigatePrev and navigateNext move focused date', () async {
+      stubWatch(const Success([]));
+      final container = createContainer();
+      await wait();
+
+      final notifier = container.read(transactionListNotifierProvider.notifier);
+      final before = container.read(transactionListNotifierProvider).focusedDate;
+
+      notifier.navigatePrev();
+      await wait();
+      final afterPrev = container.read(transactionListNotifierProvider).focusedDate;
+      expect(afterPrev.isBefore(before), isTrue);
+
+      notifier.navigateNext();
+      await wait();
+      final afterNext = container.read(transactionListNotifierProvider).focusedDate;
+      expect(afterNext.isAfter(afterPrev), isTrue);
+    });
+
+    test('navigateNext is blocked at current period', () async {
+      stubWatch(const Success([]));
+      final container = createContainer();
+      await wait();
+
+      final notifier = container.read(transactionListNotifierProvider.notifier);
+      final before = container.read(transactionListNotifierProvider).focusedDate;
+      notifier.navigateNext();
+      await wait();
+      expect(container.read(transactionListNotifierProvider).focusedDate, before);
+    });
+
+    test('goToToday and jumpToDate re-anchor', () async {
+      stubWatch(const Success([]));
+      final container = createContainer();
+      await wait();
+
+      final notifier = container.read(transactionListNotifierProvider.notifier);
+      notifier.jumpToDate(DateTime(2020, 6, 15));
+      await wait();
+      expect(container.read(transactionListNotifierProvider).focusedDate, DateTime(2020, 6, 15));
+
+      notifier.goToToday();
+      await wait();
+      final focused = container.read(transactionListNotifierProvider).focusedDate;
+      final now = DateTime.now();
+      expect(focused.year, now.year);
+      expect(focused.month, now.month);
+      expect(focused.day, now.day);
+    });
+
+    test('clearFilter resets filter', () async {
+      stubWatch(const Success([]));
+      final container = createContainer();
+      await wait();
+
+      final notifier = container.read(transactionListNotifierProvider.notifier);
+      notifier.applyFilter(const TransactionFilter(accountIds: {'a1'}));
+      await wait();
+      expect(container.read(transactionListNotifierProvider).filter.isActive, isTrue);
+
+      notifier.clearFilter();
+      await wait();
+      expect(container.read(transactionListNotifierProvider).filter.isActive, isFalse);
+    });
+
+    test('search matches item notes and amounts', () async {
+      final txs = [
+        TransactionModel(
+          id: '1',
+          accountId: 'a1',
+          type: TransactionType.expense,
+          amount: 999,
+          transactionDate: DateTime.utc(2024, 1, 1),
+          createdAt: DateTime.utc(2024, 1, 1),
+          updatedAt: DateTime.utc(2024, 1, 1),
+          items: [
+            TransactionItemModel(
+              id: 'i1',
+              transactionId: '1',
+              amount: 500,
+              createdAt: DateTime.utc(2024, 1, 1),
+              updatedAt: DateTime.utc(2024, 1, 1),
+              note: 'chicken rice',
+            ),
+            TransactionItemModel(
+              id: 'i2',
+              transactionId: '1',
+              amount: 499,
+              createdAt: DateTime.utc(2024, 1, 1),
+              updatedAt: DateTime.utc(2024, 1, 1),
+            ),
+          ],
+        ),
+      ];
+      stubWatch(Success(txs));
+      final container = createContainer();
+      await container.read(transactionListNotifierProvider.notifier).refresh();
+      await wait();
+
+      final notifier = container.read(transactionListNotifierProvider.notifier);
+      notifier.applyFilter(const TransactionFilter(searchQuery: 'chicken'));
+      await wait();
+      expect(container.read(transactionListNotifierProvider).transactions.length, 1);
+
+      notifier.applyFilter(const TransactionFilter(searchQuery: '499'));
+      await wait();
+      expect(container.read(transactionListNotifierProvider).transactions.length, 1);
+
+      notifier.applyFilter(const TransactionFilter(searchQuery: 'nomatch'));
+      await wait();
+      expect(container.read(transactionListNotifierProvider).transactions, isEmpty);
+    });
+
+    test('search matches header amount', () async {
+      final txs = [
+        TransactionModel(
+          id: '1',
+          accountId: 'a1',
+          type: TransactionType.expense,
+          amount: 777,
+          transactionDate: DateTime.utc(2024, 1, 1),
+          createdAt: DateTime.utc(2024, 1, 1),
+          updatedAt: DateTime.utc(2024, 1, 1),
+        ),
+      ];
+      stubWatch(Success(txs));
+      final container = createContainer();
+      await container.read(transactionListNotifierProvider.notifier).refresh();
+      await wait();
+
+      container.read(transactionListNotifierProvider.notifier).applyFilter(const TransactionFilter(searchQuery: '777'));
+      await wait();
+      expect(container.read(transactionListNotifierProvider).transactions.length, 1);
+    });
+
+    test('deleteTransaction delegates to repository', () async {
+      stubWatch(const Success([]));
+      when(() => mockRepo.deleteTransaction('t1')).thenAnswer((_) async => const Success<void, Failure>(null));
+      final container = createContainer();
+      await wait();
+      await container.read(transactionListNotifierProvider.notifier).deleteTransaction('t1');
+      verify(() => mockRepo.deleteTransaction('t1')).called(1);
     });
   });
 }

--- a/test/unit/shared/utils/math_evaluator_test.dart
+++ b/test/unit/shared/utils/math_evaluator_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poka_ce/shared/utils/math_evaluator.dart';
+
+void main() {
+  group('MathEvaluator.evaluate', () {
+    test('empty expression returns null', () {
+      expect(MathEvaluator.evaluate(''), isNull);
+    });
+
+    test('plain number without operator returns null', () {
+      expect(MathEvaluator.evaluate('125'), isNull);
+    });
+
+    test('trailing operator is stripped, leaving no operator -> null', () {
+      expect(MathEvaluator.evaluate('125+'), isNull);
+    });
+
+    test('leading negative only is not an operator expression', () {
+      expect(MathEvaluator.evaluate('-125'), isNull);
+    });
+
+    test('simple addition', () {
+      expect(MathEvaluator.evaluate('5+3'), '8');
+    });
+
+    test('simple subtraction', () {
+      expect(MathEvaluator.evaluate('10-4'), '6');
+    });
+
+    test('multiplication', () {
+      expect(MathEvaluator.evaluate('2*3'), '6');
+    });
+
+    test('÷ symbol is treated as operator but not parseable, returns null', () {
+      expect(MathEvaluator.evaluate('10÷2'), isNull);
+    });
+
+    test('division with / symbol', () {
+      expect(MathEvaluator.evaluate('7/2'), '3.5');
+    });
+
+    test('result ending in .0 is normalized to integer string', () {
+      expect(MathEvaluator.evaluate('1.5+1.5'), '3');
+    });
+
+    test('malformed expression returns null', () {
+      expect(MathEvaluator.evaluate('5++*'), isNull);
+      expect(MathEvaluator.evaluate('abc+1'), isNull);
+    });
+  });
+
+  group('MathEvaluator.isOperator', () {
+    test('recognizes all operators', () {
+      expect(MathEvaluator.isOperator('+'), isTrue);
+      expect(MathEvaluator.isOperator('-'), isTrue);
+      expect(MathEvaluator.isOperator('*'), isTrue);
+      expect(MathEvaluator.isOperator('÷'), isTrue);
+      expect(MathEvaluator.isOperator('/'), isTrue);
+    });
+
+    test('rejects non-operators', () {
+      expect(MathEvaluator.isOperator('5'), isFalse);
+      expect(MathEvaluator.isOperator('.'), isFalse);
+      expect(MathEvaluator.isOperator('C'), isFalse);
+    });
+  });
+
+  group('MathEvaluator.hasUnresolvedOperator', () {
+    test('empty expression has no operator', () {
+      expect(MathEvaluator.hasUnresolvedOperator(''), isFalse);
+    });
+
+    test('leading negative does not count as unresolved', () {
+      expect(MathEvaluator.hasUnresolvedOperator('-5'), isFalse);
+    });
+
+    test('number only has no operator', () {
+      expect(MathEvaluator.hasUnresolvedOperator('1500'), isFalse);
+    });
+
+    test('expression with operator returns true', () {
+      expect(MathEvaluator.hasUnresolvedOperator('15+5'), isTrue);
+      expect(MathEvaluator.hasUnresolvedOperator('15*5'), isTrue);
+    });
+  });
+
+  group('MathEvaluator.handleKeyPress', () {
+    test('C clears expression', () {
+      expect(MathEvaluator.handleKeyPress('123+456', 'C'), '');
+    });
+
+    test('backspace removes last char', () {
+      expect(MathEvaluator.handleKeyPress('123', '⌫'), '12');
+    });
+
+    test('backspace on empty stays empty', () {
+      expect(MathEvaluator.handleKeyPress('', '⌫'), '');
+    });
+
+    test('= evaluates expression', () {
+      expect(MathEvaluator.handleKeyPress('5+3', '='), '8');
+    });
+
+    test('OK evaluates expression', () {
+      expect(MathEvaluator.handleKeyPress('10*2', 'OK'), '20');
+    });
+
+    test('= keeps expression when not evaluable', () {
+      expect(MathEvaluator.handleKeyPress('5', '='), '5');
+    });
+
+    test('plus-minus negates plain number', () {
+      expect(MathEvaluator.handleKeyPress('5', '+/-'), '-5');
+    });
+
+    test('plus-minus evaluates then negates', () {
+      expect(MathEvaluator.handleKeyPress('5+3', '+/-'), '-8');
+    });
+
+    test('plus-minus removes leading minus', () {
+      expect(MathEvaluator.handleKeyPress('-5', '+/-'), '5');
+    });
+
+    test('plus-minus evaluates negative result then strips minus', () {
+      expect(MathEvaluator.handleKeyPress('-5+3', '+/-'), '2');
+    });
+
+    test('plus-minus ignored when last char is operator', () {
+      expect(MathEvaluator.handleKeyPress('5+', '+/-'), '5+');
+    });
+
+    test('operator on empty expression only allows minus', () {
+      expect(MathEvaluator.handleKeyPress('', '-'), '-');
+      expect(MathEvaluator.handleKeyPress('', '+'), '');
+    });
+
+    test('operator replaces previous operator', () {
+      expect(MathEvaluator.handleKeyPress('5+', '*'), '5*');
+      expect(MathEvaluator.handleKeyPress('5*', '÷'), '5÷');
+    });
+
+    test('operator appends after number', () {
+      expect(MathEvaluator.handleKeyPress('5', '+'), '5+');
+    });
+
+    test('first digit replaces leading zero', () {
+      expect(MathEvaluator.handleKeyPress('0', '5'), '5');
+    });
+
+    test('triple zero on leading zero stays zero', () {
+      expect(MathEvaluator.handleKeyPress('0', '000'), '0');
+    });
+
+    test('digit after operator on trailing zero replaces the zero', () {
+      expect(MathEvaluator.handleKeyPress('5+0', '7'), '5+7');
+    });
+
+    test('triple zero after operator on trailing zero keeps single zero', () {
+      expect(MathEvaluator.handleKeyPress('5+0', '000'), '5+0');
+    });
+
+    test('digit appends to normal number', () {
+      expect(MathEvaluator.handleKeyPress('12', '3'), '123');
+    });
+
+    test('digit is capped at 20 characters', () {
+      const maxExpression = '12345678901234567890';
+      expect(MathEvaluator.handleKeyPress(maxExpression, '9'), maxExpression);
+    });
+
+    test('decimal point appends to number', () {
+      expect(MathEvaluator.handleKeyPress('5', '.'), '5.');
+    });
+
+    test('second decimal point in same part is ignored', () {
+      expect(MathEvaluator.handleKeyPress('5.', '.'), '5.');
+    });
+
+    test('decimal point after operator inserts leading zero', () {
+      expect(MathEvaluator.handleKeyPress('5+', '.'), '5+0.');
+    });
+
+    test('decimal point in earlier part still allowed', () {
+      expect(MathEvaluator.handleKeyPress('5.5+2', '.'), '5.5+2.');
+    });
+  });
+}

--- a/test/unit/theme/theme_test.dart
+++ b/test/unit/theme/theme_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart' show FontWeight;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:poka_ce/theme/theme.dart';
@@ -58,14 +59,101 @@ void main() {
       expect(lightColors.app.transfer, TWind.indigo600);
     });
 
-    test('FStyle extensions', () {
-      final light = lightTheme;
-      expect(light.style.app.iconBgOpacity, 0.12);
+    test('AppStyle spacing scale getters', () {
+      const s = AppStyle();
+      expect(s.xs, 8);
+      expect(s.sm, 12);
+      expect(s.md, 16);
+      expect(s.lg, 20);
+      expect(s.xl, 24);
+      expect(s.xxl, 32);
+      expect(s.xl3, 40);
+      expect(s.xl4, 48);
+      expect(s.section, 20);
+      expect(s.sectionContent, 16);
     });
 
-    test('TW categories', () {
-      expect(TWind.slate900, isNotNull);
-      expect(TWind.white, isNotNull);
+    test('AppStyle copyWith only iconBorderOpacity keeps iconBgOpacity', () {
+      const s = AppStyle(iconBgOpacity: 0.3, iconBorderOpacity: 0.4);
+      final s2 = s.copyWith(iconBorderOpacity: 0.9);
+      expect(s2.iconBgOpacity, 0.3);
+      expect(s2.iconBorderOpacity, 0.9);
+    });
+
+    test('AppStyle equality considers iconBorderOpacity', () {
+      const a = AppStyle(iconBgOpacity: 0.1, iconBorderOpacity: 0.2);
+      const b = AppStyle(iconBgOpacity: 0.1, iconBorderOpacity: 0.3);
+      expect(a == b, isFalse);
+      const c = AppStyle(iconBgOpacity: 0.1, iconBorderOpacity: 0.2);
+      expect(a == c, isTrue);
+    });
+
+    test('FColors copyWith keeps other fields', () {
+      const a = AppColors(
+        income: TWind.emerald600,
+        expense: TWind.red600,
+        transfer: TWind.blue500,
+        success: TWind.emerald500,
+        warning: TWind.amber500,
+      );
+      final b = a.copyWith(expense: TWind.red400);
+      expect(b.expense, TWind.red400);
+      expect(b.income, TWind.emerald600);
+    });
+  });
+
+  group('PokaTypographyRoles', () {
+    final typography = lightTheme.typography;
+
+    test('amountHero is display.xl2 bold with tight tracking', () {
+      final style = typography.amountHero;
+      expect(style.fontSize, typography.display.xl2.fontSize);
+      expect(style.fontWeight, FontWeight.w800);
+      expect(style.letterSpacing, -1);
+      expect(style.height, 1);
+    });
+
+    test('amountSection is display.xl bold', () {
+      final style = typography.amountSection;
+      expect(style.fontSize, typography.display.xl.fontSize);
+      expect(style.fontWeight, FontWeight.w700);
+      expect(style.letterSpacing, -0.5);
+      expect(style.height, 1);
+    });
+
+    test('title roles derive from display/body scales', () {
+      expect(typography.titleScreen.fontWeight, FontWeight.w600);
+      expect(typography.titleCard.fontWeight, FontWeight.w600);
+      expect(typography.titleItem.fontWeight, FontWeight.w600);
+      expect(typography.titleScreen.fontSize, typography.display.lg.fontSize);
+    });
+
+    test('body roles map to body scale', () {
+      expect(typography.bodyPrimary, typography.body.sm);
+      expect(typography.bodySecondary, typography.body.xs);
+    });
+
+    test('label roles have semantic styling', () {
+      expect(typography.labelSection.fontSize, 12);
+      expect(typography.labelSection.fontWeight, FontWeight.w700);
+      expect(typography.labelField.fontSize, 12);
+      expect(typography.labelField.fontWeight, FontWeight.w600);
+      expect(typography.caption, typography.body.xs2);
+      expect(typography.labelBadge.fontSize, 9);
+    });
+
+    test('amount roles have semantic styling', () {
+      expect(typography.amountTile.fontSize, 13);
+      expect(typography.amountTile.fontWeight, FontWeight.w600);
+      expect(typography.amountCard.fontSize, 15);
+      expect(typography.amountCard.fontWeight, FontWeight.w700);
+    });
+
+    test('dark theme exposes the same roles', () {
+      final dark = darkTheme.typography;
+      expect(dark.amountHero.fontWeight, FontWeight.w800);
+      expect(dark.amountSection.fontWeight, FontWeight.w700);
+      expect(dark.titleScreen.fontWeight, FontWeight.w600);
     });
   });
 }


### PR DESCRIPTION
## 🎯 Description

Raises overall test coverage from **80.1% to 85.20%** (excluding generated `.g.dart` / `.freezed.dart` files). Work was prioritized from simple to complex: pure logic → controllers → widgets & screens. No production code was changed — test-only diff.

## 🚀 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💄 UI/UX update
- [ ] ♻️ Refactoring
- [ ] 💥 Breaking change
- [x] 🧪 Test coverage improvement (test-only changes)

## 🛠️ Testing Instructions

1. `flutter test test/unit test/feature` — all 1316 tests pass
2. `flutter test --coverage test/unit test/feature` — total line coverage ≥ 85% (excluding generated files)
3. `make fix && make check` — clean, "No issues found!"

### Files added (10)
- `test/unit/shared/utils/math_evaluator_test.dart` — full numpad/evaluator coverage
- `test/unit/core/services/notification_service_test.dart`
- `test/unit/features/transactions/domain/use_cases/transfer_funds_use_case_test.dart`
- `test/unit/features/backup/presentation/controllers/backup_form_notifier_test.dart`
- `test/feature/features/debts/presentation/widgets/debt_repayment_sheet_test.dart`
- `test/feature/features/settings/presentation/screens/lock_screen_test.dart`
- `test/feature/features/settings/presentation/widgets/easter_egg_icon_test.dart`
- `test/feature/features/transactions/presentation/widgets/tile/transaction_tile_expanded_test.dart`
- `test/feature/features/categories/presentation/widgets/views/category_list_tab_test.dart`
- `test/feature/features/accounts/presentation/widgets/sections/goal_account_section_test.dart`

### Files extended (13)
Transaction form/list, account form/list, recurring, goal, report notifiers; theme; string extension; preferences service; recurring & accounts DAOs; settings sheets; transfer use case.

## ✅ Checklist

### Mandatory

- [x] `make fix` — dart fix + format applied
- [x] `make check` — reports **"No issues found!"**
- [x] `make generate` — not needed (no annotated files changed)
- [x] `make test` — all tests pass (unit + feature suites)
- [x] Every new `lib/` file has a matching `test/` file (no `lib/` changes)
- [x] My commit messages follow the Conventional Commits format

### Code Quality

- [x] No Material widgets in `lib/` (test scaffolding only)
- [x] No shadows / hardcoded colors / inline typography in `lib/`
- [x] No `throw` inside a Repository or Notifier
- [x] No `print()` or `debugPrint()` — uses `talker`
- [x] No `dynamic` type anywhere
- [x] No sync logic, cloud integration, or multi-currency support
- [x] No Drift `*Data` class passed to or imported in a Widget/Screen