### PR TITLE
feat(transactions): refine UI balance and add collapsible daily groups

### DIFF
--- a/lib/app/shell/main_shell_page.dart
+++ b/lib/app/shell/main_shell_page.dart
@@ -136,17 +136,26 @@ class _AddTransactionFab extends StatelessWidget {
         HapticFeedback.lightImpact();
         TransactionFormSheet.show(context);
       },
+      // Outer ring in card color creates a visual halo that separates
+      // the FAB from same-colored chart elements behind it.
       child: Container(
-        width: 48,
-        height: 48,
+        padding: const EdgeInsets.all(3),
         decoration: BoxDecoration(
-          color: theme.colors.primary,
+          color: theme.colors.card,
           shape: BoxShape.circle,
         ),
-        child: Icon(
-          FPhosphorIcons.plus,
-          size: 20,
-          color: theme.colors.primaryForeground,
+        child: Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            color: theme.colors.primary,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            FPhosphorIcons.plus,
+            size: 20,
+            color: theme.colors.primaryForeground,
+          ),
         ),
       ),
     );

--- a/lib/features/accounts/presentation/widgets/cards/account_hero_card.dart
+++ b/lib/features/accounts/presentation/widgets/cards/account_hero_card.dart
@@ -76,11 +76,8 @@ class AccountHeroCard extends ConsumerWidget {
         amount: balance,
         type: balance >= 0 ? TransactionType.income : TransactionType.expense,
         isObscured: !isVisible,
-        style: theme.typography.display.sm.copyWith(
+        style: theme.typography.amountSection.copyWith(
           color: Colors.white,
-          fontWeight: FontWeight.w800,
-          letterSpacing: -1,
-          height: 1,
         ),
       ),
       leftSubAmount: PokaHeroCardSubAmount(

--- a/lib/features/reports/presentation/widgets/category_item_tile.dart
+++ b/lib/features/reports/presentation/widgets/category_item_tile.dart
@@ -48,7 +48,7 @@ class CategoryItemTile extends StatelessWidget {
         Expanded(
           child: Text(
             item.name,
-            style: theme.typography.titleItem,
+            style: theme.typography.bodyPrimary.copyWith(fontWeight: FontWeight.w500),
             overflow: TextOverflow.ellipsis,
           ),
         ),
@@ -63,7 +63,7 @@ class CategoryItemTile extends StatelessWidget {
             ),
             Text(
               '${(item.ratio * 100).toStringAsFixed(1)}%',
-              style: theme.typography.labelBadge.copyWith(color: theme.colors.mutedForeground),
+              style: theme.typography.caption.copyWith(color: theme.colors.mutedForeground),
             ),
           ],
         ),

--- a/lib/features/reports/presentation/widgets/report_cashflow_chart.dart
+++ b/lib/features/reports/presentation/widgets/report_cashflow_chart.dart
@@ -130,7 +130,7 @@ class _CashflowBarChart extends StatelessWidget {
                   padding: const EdgeInsets.only(right: 4),
                   child: Text(
                     value.toCompactFormat(),
-                    style: theme.typography.labelBadge.copyWith(
+                    style: theme.typography.caption.copyWith(
                       color: theme.colors.mutedForeground,
                     ),
                     textAlign: TextAlign.right,
@@ -150,7 +150,7 @@ class _CashflowBarChart extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 6),
                   child: Text(
                     points[idx].label,
-                    style: theme.typography.labelBadge.copyWith(
+                    style: theme.typography.caption.copyWith(
                       color: theme.colors.mutedForeground,
                     ),
                   ),
@@ -220,7 +220,7 @@ class _LegendDot extends StatelessWidget {
         const SizedBox(width: 4),
         Text(
           label,
-          style: theme.typography.bodySecondary.copyWith(color: theme.colors.mutedForeground),
+          style: theme.typography.bodyPrimary.copyWith(color: theme.colors.mutedForeground),
         ),
       ],
     );
@@ -248,7 +248,7 @@ class _QuickStat extends StatelessWidget {
       children: [
         Text(
           label,
-          style: theme.typography.bodySecondary.copyWith(color: theme.colors.mutedForeground),
+          style: theme.typography.caption.copyWith(color: theme.colors.mutedForeground),
         ),
         Text(
           value,

--- a/lib/features/reports/presentation/widgets/report_category_chart.dart
+++ b/lib/features/reports/presentation/widgets/report_category_chart.dart
@@ -237,69 +237,26 @@ class _CategoryPieChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The ranked list below already serves as the full legend (dot + name + amount + %).
+    // Removing the duplicate legend panel here lets the pie chart use the full width.
     return SizedBox(
-      height: 140,
-      child: Row(
-        children: [
-          // Pie chart
-          Expanded(
-            child: PieChart(
-              PieChartData(
-                sectionsSpace: 2,
-                centerSpaceRadius: 36,
-                startDegreeOffset: -90,
-                sections: items.map((item) {
-                  return PieChartSectionData(
-                    value: item.ratio,
-                    color: _parseColor(context, item.color),
-                    radius: 30,
-                    showTitle: false,
-                  );
-                }).toList(),
-              ),
-              duration: const Duration(milliseconds: 600),
-              curve: Curves.easeOutCubic,
-            ),
-          ),
-          const SizedBox(width: 16),
-
-          // Legend
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: items.take(5).map((item) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 6),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 8,
-                        height: 8,
-                        decoration: BoxDecoration(
-                          color: _parseColor(context, item.color),
-                          shape: BoxShape.circle,
-                        ),
-                      ),
-                      const SizedBox(width: 6),
-                      Expanded(
-                        child: Text(
-                          item.name,
-                          style: theme.typography.labelBadge,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      Text(
-                        '${(item.ratio * 100).toStringAsFixed(0)}%',
-                        style: theme.typography.bodySecondary.copyWith(color: theme.colors.mutedForeground),
-                      ),
-                    ],
-                  ),
-                );
-              }).toList(),
-            ),
-          ),
-        ],
+      height: 160,
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: 2,
+          centerSpaceRadius: 44,
+          startDegreeOffset: -90,
+          sections: items.map((item) {
+            return PieChartSectionData(
+              value: item.ratio,
+              color: _parseColor(context, item.color),
+              radius: 38,
+              showTitle: false,
+            );
+          }).toList(),
+        ),
+        duration: const Duration(milliseconds: 600),
+        curve: Curves.easeOutCubic,
       ),
     );
   }

--- a/lib/features/reports/presentation/widgets/report_period_selector.dart
+++ b/lib/features/reports/presentation/widgets/report_period_selector.dart
@@ -24,7 +24,7 @@ class ReportPeriodSelector extends ConsumerWidget {
     ];
 
     return SizedBox(
-      height: 36,
+      height: 30,
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -147,7 +147,7 @@ class _PeriodChip extends StatelessWidget {
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
         alignment: Alignment.center,
-        padding: const EdgeInsets.symmetric(horizontal: 14),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
         decoration: BoxDecoration(
           color: isSelected ? theme.colors.primary : theme.colors.muted,
           borderRadius: BorderRadius.circular(20),
@@ -157,7 +157,7 @@ class _PeriodChip extends StatelessWidget {
         ),
         child: Text(
           label,
-          style: theme.typography.bodySecondary.copyWith(
+          style: theme.typography.caption.copyWith(
             color: isSelected ? theme.colors.primaryForeground : theme.colors.mutedForeground,
             fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
           ),

--- a/lib/features/reports/presentation/widgets/report_summary_card.dart
+++ b/lib/features/reports/presentation/widgets/report_summary_card.dart
@@ -77,9 +77,7 @@ class ReportSummaryCard extends ConsumerWidget {
               children: [
                 Text(
                   t.cashflow,
-                  style: theme.typography.bodyPrimary.copyWith(
-                    color: theme.colors.mutedForeground,
-                  ),
+                  style: theme.typography.titleCard,
                 ),
                 _StatusBadge(isOnTrack: isOnTrack),
               ],
@@ -91,27 +89,27 @@ class ReportSummaryCard extends ConsumerWidget {
               children: [
                 // Donut (fl_chart PieChart)
                 SizedBox(
-                  width: 90,
-                  height: 90,
+                  width: 100,
+                  height: 100,
                   child: Stack(
                     alignment: Alignment.center,
                     children: [
                       PieChart(
                         PieChartData(
                           sectionsSpace: 2,
-                          centerSpaceRadius: 30,
+                          centerSpaceRadius: 34,
                           startDegreeOffset: -90,
                           sections: [
                             PieChartSectionData(
                               value: incomeVal,
                               color: incomeColor,
-                              radius: 14,
+                              radius: 16,
                               showTitle: false,
                             ),
                             PieChartSectionData(
                               value: expenseVal,
                               color: expenseColor,
-                              radius: 14,
+                              radius: 16,
                               showTitle: false,
                             ),
                           ],

--- a/lib/features/reports/presentation/widgets/stat_row_tile.dart
+++ b/lib/features/reports/presentation/widgets/stat_row_tile.dart
@@ -28,13 +28,13 @@ class StatRowTile extends StatelessWidget {
     return Row(
       children: [
         Container(
-          width: 28,
-          height: 28,
+          width: 34,
+          height: 34,
           decoration: BoxDecoration(
             color: iconColor.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(7),
+            borderRadius: BorderRadius.circular(8),
           ),
-          child: Icon(icon, size: 14, color: iconColor),
+          child: Icon(icon, size: 16, color: iconColor),
         ),
         const SizedBox(width: 8),
         Expanded(
@@ -43,15 +43,21 @@ class StatRowTile extends StatelessWidget {
             children: [
               Text(
                 label,
-                style: theme.typography.labelBadge.copyWith(color: theme.colors.mutedForeground),
+                style: theme.typography.caption.copyWith(
+                  color: theme.colors.mutedForeground,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
               Text(
                 value,
                 style: theme.typography.bodyPrimary.copyWith(fontWeight: FontWeight.w700),
                 overflow: TextOverflow.ellipsis,
               ),
-              if (delta != 0)
-                Padding(
+              // Always reserve the delta row height to prevent layout shift
+              // when switching between periods with and without comparison data.
+              Opacity(
+                opacity: delta != 0 ? 1.0 : 0.0,
+                child: Padding(
                   padding: const EdgeInsets.only(top: 2),
                   child: Row(
                     children: [
@@ -64,6 +70,7 @@ class StatRowTile extends StatelessWidget {
                     ],
                   ),
                 ),
+              ),
             ],
           ),
         ),

--- a/lib/features/transactions/presentation/screens/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/screens/transaction_list_page.dart
@@ -555,12 +555,12 @@ class _DateHeader extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Container(
-          margin: const EdgeInsets.only(top: 6),
-          width: 8,
-          height: 8,
+          margin: const EdgeInsets.only(top: 2),
+          width: 4,
+          height: 16,
           decoration: BoxDecoration(
             color: theme.colors.primary,
-            shape: BoxShape.circle,
+            borderRadius: theme.style.borderRadius.xs,
           ),
         ),
         const SizedBox(width: 8),

--- a/lib/features/transactions/presentation/screens/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/screens/transaction_list_page.dart
@@ -443,7 +443,7 @@ class _StickyNavDelegate extends SliverPersistentHeaderDelegate {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Renders transactions as grouped date sections inside a [SliverList].
-class _TransactionGroupSliver extends StatelessWidget {
+class _TransactionGroupSliver extends HookWidget {
   const _TransactionGroupSliver({
     required this.transactions,
     required this.categoriesById,
@@ -456,16 +456,28 @@ class _TransactionGroupSliver extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final collapsedDates = useState<Set<String>>({});
     final groups = TransactionGroupingService.groupTransactions(transactions);
 
     return SliverList.builder(
       itemCount: groups.length,
       itemBuilder: (context, index) {
         final group = groups[index];
+        final isExpanded = !collapsedDates.value.contains(group.dateStr);
 
         return _DateGroupSection(
           key: ValueKey(group.dateStr),
           group: group,
+          isExpanded: isExpanded,
+          onToggle: () {
+            final next = Set<String>.from(collapsedDates.value);
+            if (next.contains(group.dateStr)) {
+              next.remove(group.dateStr);
+            } else {
+              next.add(group.dateStr);
+            }
+            collapsedDates.value = next;
+          },
           categoriesById: categoriesById,
           accountsById: accountsById,
           groupIndex: index,
@@ -475,9 +487,11 @@ class _TransactionGroupSliver extends StatelessWidget {
   }
 }
 
-class _DateGroupSection extends HookConsumerWidget {
+class _DateGroupSection extends ConsumerWidget {
   const _DateGroupSection({
     required this.group,
+    required this.isExpanded,
+    required this.onToggle,
     required this.categoriesById,
     required this.accountsById,
     required this.groupIndex,
@@ -485,14 +499,14 @@ class _DateGroupSection extends HookConsumerWidget {
   });
 
   final TransactionGroup group;
+  final bool isExpanded;
+  final VoidCallback onToggle;
   final Map<String, CategoryModel> categoriesById;
   final Map<String, AccountModel> accountsById;
   final int groupIndex;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isExpanded = useState(true);
-
     return Padding(
       padding: const EdgeInsets.only(bottom: 20),
       child: Column(
@@ -503,14 +517,14 @@ class _DateGroupSection extends HookConsumerWidget {
             dateStr: group.dateStr,
             income: group.totalIncome,
             expense: group.totalExpense,
-            isExpanded: isExpanded.value,
+            isExpanded: isExpanded,
             itemCount: group.transactions.length,
-            onToggle: () => isExpanded.value = !isExpanded.value,
+            onToggle: onToggle,
           ).animate().fade(duration: 250.ms, delay: (groupIndex * 50).ms).slideY(begin: 0.05, end: 0),
 
           // ── Collapsible Tiles ────────────────────────────────────
           TweenAnimationBuilder<double>(
-            tween: Tween<double>(begin: 1, end: isExpanded.value ? 1.0 : 0.0),
+            tween: Tween<double>(begin: isExpanded ? 1.0 : 0.0, end: isExpanded ? 1.0 : 0.0),
             duration: const Duration(milliseconds: 250),
             curve: Curves.easeInOut,
             builder: (context, value, child) {

--- a/lib/features/transactions/presentation/screens/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/screens/transaction_list_page.dart
@@ -443,7 +443,7 @@ class _StickyNavDelegate extends SliverPersistentHeaderDelegate {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Renders transactions as grouped date sections inside a [SliverList].
-class _TransactionGroupSliver extends ConsumerWidget {
+class _TransactionGroupSliver extends StatelessWidget {
   const _TransactionGroupSliver({
     required this.transactions,
     required this.categoriesById,
@@ -455,7 +455,7 @@ class _TransactionGroupSliver extends ConsumerWidget {
   final Map<String, AccountModel> accountsById;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final groups = TransactionGroupingService.groupTransactions(transactions);
 
     return SliverList.builder(
@@ -463,68 +463,113 @@ class _TransactionGroupSliver extends ConsumerWidget {
       itemBuilder: (context, index) {
         final group = groups[index];
 
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // ── Date group header ───────────────────────────────────
-              _DateHeader(
-                dateStr: group.dateStr,
-                income: group.totalIncome,
-                expense: group.totalExpense,
-              ).animate().fade(duration: 250.ms, delay: (index * 50).ms).slideY(begin: 0.05, end: 0),
-              const SizedBox(height: 8),
-
-              // ── Tiles ───────────────────────────────────────────────
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: List.generate(group.transactions.length, (i) {
-                  final tx = group.transactions[i];
-                  final firstCatId = tx.items.isNotEmpty ? tx.items.first.categoryId : null;
-                  final category = firstCatId != null ? categoriesById[firstCatId] : null;
-                  final account = accountsById[tx.accountId];
-
-                  final tile = RecentTransactionTile(
-                    transaction: tx,
-                    isBalanceVisible: true,
-                    categoriesById: categoriesById,
-                    category: category,
-                    account: account,
-                    isFirst: i == 0,
-                    isLast: i == group.transactions.length - 1,
-                    onEdit: () {
-                      TransactionFormSheet.show(context, initialTransaction: tx);
-                    },
-                    onDelete: () async {
-                      final confirmed = await showPokaConfirmDialog(
-                        context,
-                        title: t.transactions.deleteTransaction,
-                        body: t.transactions.deleteTransactionWarning,
-                      );
-                      if (confirmed == true) {
-                        await ref.read(transactionListNotifierProvider.notifier).deleteTransaction(tx.id);
-                      }
-                    },
-                  );
-
-                  final tileWidget = i < group.transactions.length - 1
-                      ? Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: tile,
-                        )
-                      : tile;
-
-                  return tileWidget
-                      .animate()
-                      .fade(duration: 250.ms, delay: (80 + i * 40).ms)
-                      .slideX(begin: 0.05, end: 0, duration: 250.ms, delay: (80 + i * 40).ms);
-                }),
-              ),
-            ],
-          ),
+        return _DateGroupSection(
+          key: ValueKey(group.dateStr),
+          group: group,
+          categoriesById: categoriesById,
+          accountsById: accountsById,
+          groupIndex: index,
         );
       },
+    );
+  }
+}
+
+class _DateGroupSection extends HookConsumerWidget {
+  const _DateGroupSection({
+    required this.group,
+    required this.categoriesById,
+    required this.accountsById,
+    required this.groupIndex,
+    super.key,
+  });
+
+  final TransactionGroup group;
+  final Map<String, CategoryModel> categoriesById;
+  final Map<String, AccountModel> accountsById;
+  final int groupIndex;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isExpanded = useState(true);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // ── Date group header ───────────────────────────────────
+          _DateHeader(
+            dateStr: group.dateStr,
+            income: group.totalIncome,
+            expense: group.totalExpense,
+            isExpanded: isExpanded.value,
+            itemCount: group.transactions.length,
+            onToggle: () => isExpanded.value = !isExpanded.value,
+          ).animate().fade(duration: 250.ms, delay: (groupIndex * 50).ms).slideY(begin: 0.05, end: 0),
+
+          // ── Collapsible Tiles ────────────────────────────────────
+          TweenAnimationBuilder<double>(
+            tween: Tween<double>(begin: 1, end: isExpanded.value ? 1.0 : 0.0),
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOut,
+            builder: (context, value, child) {
+              if (value == 0.0) return const SizedBox.shrink();
+              return FCollapsible(
+                value: value,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: child,
+                ),
+              );
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: List.generate(group.transactions.length, (i) {
+                final tx = group.transactions[i];
+                final firstCatId = tx.items.isNotEmpty ? tx.items.first.categoryId : null;
+                final category = firstCatId != null ? categoriesById[firstCatId] : null;
+                final account = accountsById[tx.accountId];
+
+                final tile = RecentTransactionTile(
+                  transaction: tx,
+                  isBalanceVisible: true,
+                  categoriesById: categoriesById,
+                  category: category,
+                  account: account,
+                  isFirst: i == 0,
+                  isLast: i == group.transactions.length - 1,
+                  onEdit: () {
+                    TransactionFormSheet.show(context, initialTransaction: tx);
+                  },
+                  onDelete: () async {
+                    final confirmed = await showPokaConfirmDialog(
+                      context,
+                      title: t.transactions.deleteTransaction,
+                      body: t.transactions.deleteTransactionWarning,
+                    );
+                    if (confirmed == true) {
+                      await ref.read(transactionListNotifierProvider.notifier).deleteTransaction(tx.id);
+                    }
+                  },
+                );
+
+                final tileWidget = i < group.transactions.length - 1
+                    ? Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: tile,
+                      )
+                    : tile;
+
+                return tileWidget
+                    .animate()
+                    .fade(duration: 250.ms, delay: (80 + i * 40).ms)
+                    .slideX(begin: 0.05, end: 0, duration: 250.ms, delay: (80 + i * 40).ms);
+              }),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -539,11 +584,17 @@ class _DateHeader extends StatelessWidget {
     required this.dateStr,
     required this.income,
     required this.expense,
+    this.isExpanded = true,
+    this.itemCount = 0,
+    this.onToggle,
   });
 
   final String dateStr;
   final int income;
   final int expense;
+  final bool isExpanded;
+  final int itemCount;
+  final VoidCallback? onToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -551,79 +602,107 @@ class _DateHeader extends StatelessWidget {
     final total = income - expense;
     final totalType = total >= 0 ? TransactionType.income : TransactionType.expense;
 
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          margin: const EdgeInsets.only(top: 2),
-          width: 4,
-          height: 16,
-          decoration: BoxDecoration(
-            color: theme.colors.primary,
-            borderRadius: theme.style.borderRadius.xs,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onToggle,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            margin: const EdgeInsets.only(top: 2),
+            width: 4,
+            height: 16,
+            decoration: BoxDecoration(
+              color: theme.colors.primary,
+              borderRadius: theme.style.borderRadius.xs,
+            ),
           ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                dateStr,
-                style: theme.typography.titleItem,
-              ),
-              if (income > 0 || expense > 0) ...[
-                const SizedBox(height: 2),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 Row(
                   children: [
-                    if (income > 0) ...[
-                      Text(
-                        t.transactions.incoming,
-                        style: theme.typography.labelBadge.copyWith(
-                          color: theme.colors.app.income,
-                        ),
-                      ),
-                      PokaAmountText(
-                        amount: income,
-                        type: TransactionType.income,
-                        style: theme.typography.amountTile,
-                      ),
-                    ],
-                    if (income > 0 && expense > 0) const SizedBox(width: 8),
-                    if (expense > 0) ...[
-                      Text(
-                        t.transactions.out,
-                        style: theme.typography.labelBadge.copyWith(
-                          color: theme.colors.app.expense,
-                        ),
-                      ),
-                      PokaAmountText(
-                        amount: expense,
-                        type: TransactionType.expense,
-                        style: theme.typography.amountTile,
-                      ),
-                    ],
-                    const Spacer(),
-                    if (total != 0) ...[
-                      Icon(
-                        FPhosphorIcons.sigma,
-                        size: 12,
+                    Text(
+                      dateStr,
+                      style: theme.typography.titleItem,
+                    ),
+                    const SizedBox(width: 4),
+                    AnimatedRotation(
+                      turns: isExpanded ? 0 : -0.25,
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeInOut,
+                      child: Icon(
+                        FPhosphorIcons.caretDown,
+                        size: 13,
                         color: theme.colors.mutedForeground,
                       ),
-                      const SizedBox(width: 4),
-                      PokaAmountText(
-                        amount: total.abs(),
-                        type: totalType,
-                        style: theme.typography.amountTile,
+                    ),
+                    if (!isExpanded && itemCount > 0) ...[
+                      const SizedBox(width: 6),
+                      Text(
+                        '•  ${t.transactions.itemsCount(count: itemCount)}',
+                        style: theme.typography.caption.copyWith(
+                          color: theme.colors.mutedForeground,
+                        ),
                       ),
                     ],
                   ],
                 ),
+                if (income > 0 || expense > 0) ...[
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      if (income > 0) ...[
+                        Text(
+                          t.transactions.incoming,
+                          style: theme.typography.labelBadge.copyWith(
+                            color: theme.colors.app.income,
+                          ),
+                        ),
+                        PokaAmountText(
+                          amount: income,
+                          type: TransactionType.income,
+                          style: theme.typography.amountTile,
+                        ),
+                      ],
+                      if (income > 0 && expense > 0) const SizedBox(width: 8),
+                      if (expense > 0) ...[
+                        Text(
+                          t.transactions.out,
+                          style: theme.typography.labelBadge.copyWith(
+                            color: theme.colors.app.expense,
+                          ),
+                        ),
+                        PokaAmountText(
+                          amount: expense,
+                          type: TransactionType.expense,
+                          style: theme.typography.amountTile,
+                        ),
+                      ],
+                      const Spacer(),
+                      if (total != 0) ...[
+                        Icon(
+                          FPhosphorIcons.sigma,
+                          size: 12,
+                          color: theme.colors.mutedForeground,
+                        ),
+                        const SizedBox(width: 4),
+                        PokaAmountText(
+                          amount: total.abs(),
+                          type: totalType,
+                          style: theme.typography.amountTile,
+                        ),
+                      ],
+                    ],
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/features/transactions/presentation/widgets/filter/transaction_filter_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/filter/transaction_filter_sheet.dart
@@ -82,30 +82,26 @@ class TransactionFilterSheet extends HookConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           // ── Transaction type ──────────────────────────────────────────────
-          FLabel(
-            layout: FLabelLayout.vertical,
-            label: Text(t.transactions.transactionType),
-            child: Row(
-              children: TransactionType.values.map((type) {
-                final isSelected = selectedTypes.value.contains(type);
-                return Expanded(
-                  child: Padding(
-                    padding: EdgeInsets.only(
-                      right: type != TransactionType.values.last ? 8 : 0,
-                    ),
-                    child: TransactionTypeChip(
-                      type: type,
-                      isSelected: isSelected,
-                      onTap: () {
-                        final next = Set<TransactionType>.from(selectedTypes.value);
-                        isSelected ? next.remove(type) : next.add(type);
-                        selectedTypes.value = next;
-                      },
-                    ),
+          Row(
+            children: TransactionType.values.map((type) {
+              final isSelected = selectedTypes.value.contains(type);
+              return Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    right: type != TransactionType.values.last ? 8 : 0,
                   ),
-                );
-              }).toList(),
-            ),
+                  child: TransactionTypeChip(
+                    type: type,
+                    isSelected: isSelected,
+                    onTap: () {
+                      final next = Set<TransactionType>.from(selectedTypes.value);
+                      isSelected ? next.remove(type) : next.add(type);
+                      selectedTypes.value = next;
+                    },
+                  ),
+                ),
+              );
+            }).toList(),
           ),
 
           // ── Account ───────────────────────────────────────────────────────

--- a/lib/features/transactions/presentation/widgets/filter/transaction_type_chip.dart
+++ b/lib/features/transactions/presentation/widgets/filter/transaction_type_chip.dart
@@ -46,7 +46,7 @@ class TransactionTypeChip extends StatelessWidget {
           borderRadius: theme.style.borderRadius.sm,
           border: Border.all(
             color: isSelected ? color : theme.colors.border,
-            width: isSelected ? 1.5 : theme.style.borderWidth,
+            width: theme.style.borderWidth,
           ),
         ),
         child: Column(

--- a/lib/features/transactions/presentation/widgets/list/transaction_date_header.dart
+++ b/lib/features/transactions/presentation/widgets/list/transaction_date_header.dart
@@ -10,12 +10,18 @@ class TransactionDateHeader extends StatelessWidget {
     required this.dateStr,
     required this.income,
     required this.expense,
+    this.isExpanded = true,
+    this.itemCount = 0,
+    this.onToggle,
     super.key,
   });
 
   final String dateStr;
   final int income;
   final int expense;
+  final bool isExpanded;
+  final int itemCount;
+  final VoidCallback? onToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -23,78 +29,107 @@ class TransactionDateHeader extends StatelessWidget {
     final total = income - expense;
     final totalType = total >= 0 ? TransactionType.income : TransactionType.expense;
 
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          margin: const EdgeInsets.only(top: 2),
-          width: 4,
-          height: 16,
-          decoration: BoxDecoration(
-            color: theme.colors.primary,
-            borderRadius: theme.style.borderRadius.xs,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onToggle,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            margin: const EdgeInsets.only(top: 2),
+            width: 4,
+            height: 16,
+            decoration: BoxDecoration(
+              color: theme.colors.primary,
+              borderRadius: theme.style.borderRadius.xs,
+            ),
           ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                dateStr,
-                style: theme.typography.bodyPrimary.copyWith(
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: -0.2,
-                ),
-              ),
-              if (income > 0 || expense > 0) ...[
-                const SizedBox(height: 2),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 Row(
                   children: [
-                    if (income > 0) ...[
-                      Text(
-                        t.transactions.incoming,
-                        style: theme.typography.bodySecondary.copyWith(color: theme.colors.app.income),
-                      ),
-                      PokaAmountText(
-                        amount: income,
-                        type: TransactionType.income,
-                        style: theme.typography.caption,
-                      ),
-                    ],
-                    if (income > 0 && expense > 0) const SizedBox(width: 8),
-                    if (expense > 0) ...[
-                      Text(
-                        t.transactions.out,
-                        style: theme.typography.bodySecondary.copyWith(color: theme.colors.app.expense),
-                      ),
-                      PokaAmountText(
-                        amount: expense,
-                        type: TransactionType.expense,
-                        style: theme.typography.caption,
-                      ),
-                    ],
-                    const Spacer(),
-                    if (total != 0) ...[
-                      Icon(
-                        FPhosphorIcons.sigma,
-                        size: 12,
+                    Text(
+                      dateStr,
+                      style: theme.typography.titleItem,
+                    ),
+                    const SizedBox(width: 4),
+                    AnimatedRotation(
+                      turns: isExpanded ? 0 : -0.25,
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeInOut,
+                      child: Icon(
+                        FPhosphorIcons.caretDown,
+                        size: 13,
                         color: theme.colors.mutedForeground,
                       ),
-                      const SizedBox(width: 4),
-                      PokaAmountText(
-                        amount: total.abs(),
-                        type: totalType,
-                        style: theme.typography.caption,
+                    ),
+                    if (!isExpanded && itemCount > 0) ...[
+                      const SizedBox(width: 6),
+                      Text(
+                        '•  ${t.transactions.itemsCount(count: itemCount)}',
+                        style: theme.typography.caption.copyWith(
+                          color: theme.colors.mutedForeground,
+                        ),
                       ),
                     ],
                   ],
                 ),
+                if (income > 0 || expense > 0) ...[
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      if (income > 0) ...[
+                        Text(
+                          t.transactions.incoming,
+                          style: theme.typography.labelBadge.copyWith(
+                            color: theme.colors.app.income,
+                          ),
+                        ),
+                        PokaAmountText(
+                          amount: income,
+                          type: TransactionType.income,
+                          style: theme.typography.amountTile,
+                        ),
+                      ],
+                      if (income > 0 && expense > 0) const SizedBox(width: 8),
+                      if (expense > 0) ...[
+                        Text(
+                          t.transactions.out,
+                          style: theme.typography.labelBadge.copyWith(
+                            color: theme.colors.app.expense,
+                          ),
+                        ),
+                        PokaAmountText(
+                          amount: expense,
+                          type: TransactionType.expense,
+                          style: theme.typography.amountTile,
+                        ),
+                      ],
+                      const Spacer(),
+                      if (total != 0) ...[
+                        Icon(
+                          FPhosphorIcons.sigma,
+                          size: 12,
+                          color: theme.colors.mutedForeground,
+                        ),
+                        const SizedBox(width: 4),
+                        PokaAmountText(
+                          amount: total.abs(),
+                          type: totalType,
+                          style: theme.typography.amountTile,
+                        ),
+                      ],
+                    ],
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/features/transactions/presentation/widgets/list/transaction_date_header.dart
+++ b/lib/features/transactions/presentation/widgets/list/transaction_date_header.dart
@@ -27,12 +27,12 @@ class TransactionDateHeader extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Container(
-          margin: const EdgeInsets.only(top: 6),
-          width: 8,
-          height: 8,
+          margin: const EdgeInsets.only(top: 2),
+          width: 4,
+          height: 16,
           decoration: BoxDecoration(
             color: theme.colors.primary,
-            shape: BoxShape.circle,
+            borderRadius: theme.style.borderRadius.xs,
           ),
         ),
         const SizedBox(width: 8),

--- a/lib/features/transactions/presentation/widgets/list/transaction_group_sliver.dart
+++ b/lib/features/transactions/presentation/widgets/list/transaction_group_sliver.dart
@@ -14,7 +14,7 @@ import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
 
 /// Renders transactions as grouped date sections inside a [SliverList].
-class TransactionGroupSliver extends StatelessWidget {
+class TransactionGroupSliver extends HookWidget {
   const TransactionGroupSliver({
     required this.transactions,
     required this.categoriesById,
@@ -28,16 +28,28 @@ class TransactionGroupSliver extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final collapsedDates = useState<Set<String>>({});
     final groups = TransactionGroupingService.groupTransactions(transactions);
 
     return SliverList.builder(
       itemCount: groups.length,
       itemBuilder: (context, index) {
         final group = groups[index];
+        final isExpanded = !collapsedDates.value.contains(group.dateStr);
 
         return _SliverDateGroupSection(
           key: ValueKey(group.dateStr),
           group: group,
+          isExpanded: isExpanded,
+          onToggle: () {
+            final next = Set<String>.from(collapsedDates.value);
+            if (next.contains(group.dateStr)) {
+              next.remove(group.dateStr);
+            } else {
+              next.add(group.dateStr);
+            }
+            collapsedDates.value = next;
+          },
           categoriesById: categoriesById,
           accountsById: accountsById,
         );
@@ -46,22 +58,24 @@ class TransactionGroupSliver extends StatelessWidget {
   }
 }
 
-class _SliverDateGroupSection extends HookConsumerWidget {
+class _SliverDateGroupSection extends ConsumerWidget {
   const _SliverDateGroupSection({
     required this.group,
+    required this.isExpanded,
+    required this.onToggle,
     required this.categoriesById,
     required this.accountsById,
     super.key,
   });
 
   final TransactionGroup group;
+  final bool isExpanded;
+  final VoidCallback onToggle;
   final Map<String, CategoryModel> categoriesById;
   final Map<String, AccountModel> accountsById;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isExpanded = useState(true);
-
     return Padding(
       padding: const EdgeInsets.only(bottom: 20),
       child: Column(
@@ -72,14 +86,14 @@ class _SliverDateGroupSection extends HookConsumerWidget {
             dateStr: group.dateStr,
             income: group.totalIncome,
             expense: group.totalExpense,
-            isExpanded: isExpanded.value,
+            isExpanded: isExpanded,
             itemCount: group.transactions.length,
-            onToggle: () => isExpanded.value = !isExpanded.value,
+            onToggle: onToggle,
           ),
 
           // ── Collapsible Tiles ────────────────────────────────────
           TweenAnimationBuilder<double>(
-            tween: Tween<double>(begin: 1, end: isExpanded.value ? 1.0 : 0.0),
+            tween: Tween<double>(begin: isExpanded ? 1.0 : 0.0, end: isExpanded ? 1.0 : 0.0),
             duration: const Duration(milliseconds: 250),
             curve: Curves.easeInOut,
             builder: (context, value, child) {

--- a/lib/features/transactions/presentation/widgets/list/transaction_group_sliver.dart
+++ b/lib/features/transactions/presentation/widgets/list/transaction_group_sliver.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:forui/forui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/features/accounts/domain/account_model.dart';
 import 'package:poka_ce/features/categories/domain/category_model.dart';
@@ -12,7 +14,7 @@ import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
 
 /// Renders transactions as grouped date sections inside a [SliverList].
-class TransactionGroupSliver extends ConsumerWidget {
+class TransactionGroupSliver extends StatelessWidget {
   const TransactionGroupSliver({
     required this.transactions,
     required this.categoriesById,
@@ -25,7 +27,7 @@ class TransactionGroupSliver extends ConsumerWidget {
   final Map<String, AccountModel> accountsById;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final groups = TransactionGroupingService.groupTransactions(transactions);
 
     return SliverList.builder(
@@ -33,64 +35,106 @@ class TransactionGroupSliver extends ConsumerWidget {
       itemBuilder: (context, index) {
         final group = groups[index];
 
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // ── Date group header ───────────────────────────────────
-              TransactionDateHeader(
-                dateStr: group.dateStr,
-                income: group.totalIncome,
-                expense: group.totalExpense,
-              ),
-              const SizedBox(height: 8),
-
-              // ── Tiles ───────────────────────────────────────────────
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: List.generate(group.transactions.length, (i) {
-                  final tx = group.transactions[i];
-                  final firstCatId = tx.items.isNotEmpty ? tx.items.first.categoryId : null;
-                  final category = firstCatId != null ? categoriesById[firstCatId] : null;
-                  final account = accountsById[tx.accountId];
-
-                  final tile = RecentTransactionTile(
-                    transaction: tx,
-                    isBalanceVisible: true,
-                    categoriesById: categoriesById,
-                    category: category,
-                    account: account,
-                    isFirst: i == 0,
-                    isLast: i == group.transactions.length - 1,
-                    onEdit: () {
-                      TransactionFormSheet.show(context, initialTransaction: tx);
-                    },
-                    onDelete: () async {
-                      final confirmed = await showPokaConfirmDialog(
-                        context,
-                        title: t.transactions.deleteTransaction,
-                        body: t.transactions.deleteTransactionWarning,
-                      );
-                      if (confirmed == true) {
-                        await ref.read(transactionListNotifierProvider.notifier).deleteTransaction(tx.id);
-                      }
-                    },
-                  );
-
-                  if (i < group.transactions.length - 1) {
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: tile,
-                    );
-                  }
-                  return tile;
-                }),
-              ),
-            ],
-          ),
+        return _SliverDateGroupSection(
+          key: ValueKey(group.dateStr),
+          group: group,
+          categoriesById: categoriesById,
+          accountsById: accountsById,
         );
       },
+    );
+  }
+}
+
+class _SliverDateGroupSection extends HookConsumerWidget {
+  const _SliverDateGroupSection({
+    required this.group,
+    required this.categoriesById,
+    required this.accountsById,
+    super.key,
+  });
+
+  final TransactionGroup group;
+  final Map<String, CategoryModel> categoriesById;
+  final Map<String, AccountModel> accountsById;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isExpanded = useState(true);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // ── Date group header ───────────────────────────────────
+          TransactionDateHeader(
+            dateStr: group.dateStr,
+            income: group.totalIncome,
+            expense: group.totalExpense,
+            isExpanded: isExpanded.value,
+            itemCount: group.transactions.length,
+            onToggle: () => isExpanded.value = !isExpanded.value,
+          ),
+
+          // ── Collapsible Tiles ────────────────────────────────────
+          TweenAnimationBuilder<double>(
+            tween: Tween<double>(begin: 1, end: isExpanded.value ? 1.0 : 0.0),
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOut,
+            builder: (context, value, child) {
+              if (value == 0.0) return const SizedBox.shrink();
+              return FCollapsible(
+                value: value,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: child,
+                ),
+              );
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: List.generate(group.transactions.length, (i) {
+                final tx = group.transactions[i];
+                final firstCatId = tx.items.isNotEmpty ? tx.items.first.categoryId : null;
+                final category = firstCatId != null ? categoriesById[firstCatId] : null;
+                final account = accountsById[tx.accountId];
+
+                final tile = RecentTransactionTile(
+                  transaction: tx,
+                  isBalanceVisible: true,
+                  categoriesById: categoriesById,
+                  category: category,
+                  account: account,
+                  isFirst: i == 0,
+                  isLast: i == group.transactions.length - 1,
+                  onEdit: () {
+                    TransactionFormSheet.show(context, initialTransaction: tx);
+                  },
+                  onDelete: () async {
+                    final confirmed = await showPokaConfirmDialog(
+                      context,
+                      title: t.transactions.deleteTransaction,
+                      body: t.transactions.deleteTransactionWarning,
+                    );
+                    if (confirmed == true) {
+                      await ref.read(transactionListNotifierProvider.notifier).deleteTransaction(tx.id);
+                    }
+                  },
+                );
+
+                if (i < group.transactions.length - 1) {
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: tile,
+                  );
+                }
+                return tile;
+              }),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/transactions/presentation/widgets/list/transaction_list_summary_card.dart
+++ b/lib/features/transactions/presentation/widgets/list/transaction_list_summary_card.dart
@@ -54,10 +54,8 @@ class TransactionListSummaryCard extends ConsumerWidget {
       amount: PokaAmountText(
         amount: net.abs(),
         type: isPositive ? TransactionType.income : TransactionType.expense,
-        style: theme.typography.display.sm.copyWith(
+        style: theme.typography.amountSection.copyWith(
           color: theme.colors.primaryForeground,
-          fontWeight: FontWeight.bold,
-          height: 1,
         ),
       ),
       // No progress bar

--- a/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
+++ b/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
@@ -293,16 +293,7 @@ class RecentTransactionTile extends HookConsumerWidget with FTileMixin {
         FCollapsible(
           value: isExpanded.value ? 1.0 : 0.0,
           child: Container(
-            margin: const EdgeInsets.only(left: 37, top: 8),
-            padding: const EdgeInsets.only(left: 16),
-            decoration: BoxDecoration(
-              border: Border(
-                left: BorderSide(
-                  color: theme.colors.border,
-                  width: 1.2,
-                ),
-              ),
-            ),
+            margin: const EdgeInsets.only(left: 16, top: 8),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/transactions/presentation/widgets/tile/transaction_tile_content.dart
+++ b/lib/features/transactions/presentation/widgets/tile/transaction_tile_content.dart
@@ -69,7 +69,7 @@ class TransactionTileContent extends StatelessWidget {
                       catLabel,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: theme.typography.titleItem,
+                      style: theme.typography.bodySecondary.copyWith(fontWeight: FontWeight.w600),
                     ),
                   ),
                   if (hasMultipleItems) ...[

--- a/test/feature/features/reports/presentation/widgets/report_category_chart_test.dart
+++ b/test/feature/features/reports/presentation/widgets/report_category_chart_test.dart
@@ -56,8 +56,8 @@ void main() {
 
       expect(find.text('Food'), findsWidgets);
       expect(find.text('Transport'), findsWidgets);
-      expect(find.text('50%'), findsWidgets);
-      expect(find.text('30%'), findsWidgets);
+      expect(find.text('50.0%'), findsWidgets);
+      expect(find.text('30.0%'), findsWidgets);
       expect(find.text('500'), findsOneWidget);
       expect(find.text('300'), findsOneWidget);
     });
@@ -105,7 +105,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Broken'), findsWidgets);
-      expect(find.text('100%'), findsWidgets);
+      expect(find.text('100.0%'), findsWidgets);
     });
   });
 }

--- a/test/feature/features/settings/presentation/widgets/sections/data_management_section_test.dart
+++ b/test/feature/features/settings/presentation/widgets/sections/data_management_section_test.dart
@@ -68,6 +68,9 @@ base class MyPlatformFile extends PlatformFile {
   Future<int> length() async => 1024;
 
   @override
+  int? lengthSync() => 1024;
+
+  @override
   XFile get xFile => XFile('/mock/path/file.json');
 
   @override

--- a/test/feature/features/transactions/presentation/screens/transaction_list_page_test.dart
+++ b/test/feature/features/transactions/presentation/screens/transaction_list_page_test.dart
@@ -111,4 +111,62 @@ void main() {
     // Test that something is rendered, e.g. the transaction amount
     expect(find.byType(CustomScrollView), findsWidgets);
   });
+
+  testWidgets('TransactionListPage collapses and expands date group on tap', (tester) async {
+    final now = DateTime.now();
+    final transaction = TransactionModel(
+      id: 't1',
+      accountId: 'a1',
+      type: TransactionType.expense,
+      amount: 500,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        TransactionItemModel(
+          id: 'i1',
+          transactionId: 't1',
+          categoryId: 'c1',
+          amount: 500,
+          allocation: TransactionAllocation.need,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        transactionListNotifierProvider.overrideWith(() => MockTransactionListNotifier([transaction], false)),
+        categoryListProvider.overrideWith(() => MockCategoryListNotifier()),
+        categoriesStreamProvider.overrideWith((ref) => const Stream.empty()),
+        accountsStreamProvider.overrideWith((ref) => const Stream.empty()),
+      ],
+    );
+    await tester.pumpWidget(buildTestApp(container));
+    await tester.pumpAndSettle();
+
+    // Default: expanded, FCollapsible has value: 1.0, tile is visible
+    expect(find.byType(FCollapsible), findsOneWidget);
+    final collapsible = tester.widget<FCollapsible>(find.byType(FCollapsible));
+    expect(collapsible.value, 1.0);
+
+    // Tap header to collapse
+    final headerFinder = find.ancestor(
+      of: find.byIcon(FPhosphorIcons.caretDown),
+      matching: find.byType(GestureDetector),
+    );
+    await tester.tap(headerFinder);
+    await tester.pumpAndSettle();
+
+    // Now collapsed, item count badge appears
+    expect(find.textContaining('1 item'), findsOneWidget);
+
+    // Tap header again to re-expand
+    await tester.tap(headerFinder);
+    await tester.pumpAndSettle();
+
+    final reExpanded = tester.widget<FCollapsible>(find.byType(FCollapsible));
+    expect(reExpanded.value, 1.0);
+  });
 }

--- a/test/feature/features/transactions/presentation/widgets/filter/transaction_filter_sheet_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/filter/transaction_filter_sheet_test.dart
@@ -75,7 +75,6 @@ void main() {
       await tester.tap(find.text('Show'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Transaction Type'), findsOneWidget);
       expect(find.byType(TransactionTypeChip), findsNWidgets(3)); // 3 types
       expect(find.byType(TransactionFilterAccountGroup), findsOneWidget);
       expect(find.byType(TransactionFilterCategoryGroup), findsOneWidget);


### PR DESCRIPTION
## Summary
This PR introduces visual refinements across dashboard, transactions, and reports cards, and adds a collapsible interaction for daily transaction groups.

### 🎨 UI Refinements
- **Hero & Balance Cards**: Standardized main balance text sizes to 22px (`amountSection`) across Home Net Worth card, Account Detail hero card, and Transaction Net Balance card for consistent visual height.
- **Transaction Tile**: Tweaked category label to 14px semibold (`bodySecondary w600`) and replaced tree border lines with clean 16px YAML-style indentation.
- **Filter Sheet**: Removed redundant "Transaction Type" heading and normalized chip border width on selection.
- **Date Header Bar**: Updated date section indicator bar to match `PokaSectionLabel` specifications (4×16px, `borderRadius.xs`).
- **Reports & Navigation**: Added contrast halo ring to FAB to separate from chart bars, compacted period pills, and removed duplicate pie chart legend.

### ✨ New Feature: Collapsible Daily Groups
- Tapping any date header toggles expand/collapse for that specific day.
- **Default State**: All date groups start expanded (`isExpanded = true`).
- **Header State when Collapsed**: Financial summary (income, expense, net $\Sigma$) remains visible; caret rotates 90° and displays item count indicator (e.g. `• 3 items`).
- **Smooth Animation**: 250ms height transition using `FCollapsible` + `TweenAnimationBuilder`.

## Test Results
- `make check`: No issues found!
- `flutter test`: All widget tests passing (4/4 on `transaction_list_page_test.dart`).