### PR TITLE
feat: add background trend sparkline to net worth card

### DIFF
--- a/lib/features/accounts/presentation/widgets/cards/account_networth_card.dart
+++ b/lib/features/accounts/presentation/widgets/cards/account_networth_card.dart
@@ -5,6 +5,7 @@ import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visi
 import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/poka_hero_card.dart';
+import 'package:poka_ce/shared/widgets/poka_sparkline.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 class AccountNetworthCard extends ConsumerWidget {
@@ -13,6 +14,7 @@ class AccountNetworthCard extends ConsumerWidget {
     required this.totalAssets,
     required this.totalLiabilities,
     required this.activeAccountCount,
+    this.sparklineData,
     super.key,
   });
 
@@ -20,6 +22,7 @@ class AccountNetworthCard extends ConsumerWidget {
   final double totalAssets;
   final double totalLiabilities;
   final int activeAccountCount;
+  final List<double>? sparklineData;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -32,6 +35,18 @@ class AccountNetworthCard extends ConsumerWidget {
     final localeFormat = settingsState.settings?.numberFormat ?? 'system';
 
     return PokaHeroCard(
+      background: sparklineData != null && sparklineData!.isNotEmpty
+          ? Align(
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(
+                height: 90,
+                child: PokaSparkline(
+                  points: sparklineData!,
+                  padding: const EdgeInsets.only(top: 8, bottom: 8),
+                ),
+              ),
+            )
+          : null,
       pills: [
         PokaHeroCardPill(
           icon: FPhosphorIcons.wallet,

--- a/lib/features/dashboard/domain/services/dashboard_analytics_service.dart
+++ b/lib/features/dashboard/domain/services/dashboard_analytics_service.dart
@@ -160,4 +160,49 @@ class DashboardAnalyticsService {
       incomeDelta: incomeDelta,
     );
   }
+
+  /// Calculates the cumulative Net Worth trend across the specified number of days (default: 7).
+  /// Reconstructs historical points by subtracting income and adding back expenses
+  /// that occurred between each historical day and the present.
+  static List<double> calculateNetWorthTrend({
+    required double currentNetWorth,
+    required List<TransactionModel> transactions,
+    int days = 7,
+  }) {
+    if (days <= 0) return const [];
+
+    final now = DateTime.now().toUtc();
+    final todayMidnight = DateTime.utc(now.year, now.month, now.day);
+
+    // Group transactions by daysAgo (0 = today, 1 = yesterday, ..., days - 1 = days - 1 days ago)
+    final dailyNetChanges = List<double>.filled(days, 0);
+
+    for (final tx in transactions) {
+      final txDate = tx.transactionDate.toUtc();
+      final txMidnight = DateTime.utc(txDate.year, txDate.month, txDate.day);
+      final daysAgo = todayMidnight.difference(txMidnight).inDays;
+
+      if (daysAgo >= 0 && daysAgo < days) {
+        if (tx.type == TransactionType.income) {
+          dailyNetChanges[daysAgo] += tx.amount;
+        } else if (tx.type == TransactionType.expense) {
+          dailyNetChanges[daysAgo] -= tx.amount;
+        }
+      }
+    }
+
+    final result = List<double>.filled(days, 0);
+    var runningNetWorth = currentNetWorth;
+    // Today's end-of-day net worth is currentNetWorth
+    result[days - 1] = runningNetWorth;
+
+    // Moving backward in time:
+    for (var i = 1; i < days; i++) {
+      final daysAgo = i - 1; // transactions of day (i - 1)
+      runningNetWorth -= dailyNetChanges[daysAgo];
+      result[days - 1 - i] = runningNetWorth;
+    }
+
+    return result;
+  }
 }

--- a/lib/features/dashboard/presentation/controllers/dashboard_notifier.dart
+++ b/lib/features/dashboard/presentation/controllers/dashboard_notifier.dart
@@ -25,6 +25,7 @@ class DashboardState {
     this.dailySpending = const [0, 0, 0, 0, 0, 0, 0],
     this.maxDailySpending = 0.0,
     this.normalizedDailySpending = const [0, 0, 0, 0, 0, 0, 0],
+    this.netWorthTrend = const [0, 0, 0, 0, 0, 0, 0],
     this.expenseDelta = 0.0,
     this.incomeDelta = 0.0,
     this.categoriesById = const {},
@@ -45,6 +46,7 @@ class DashboardState {
   final List<double> dailySpending;
   final double maxDailySpending;
   final List<double> normalizedDailySpending;
+  final List<double> netWorthTrend;
   final double expenseDelta;
   final double incomeDelta;
   final Map<String, CategoryModel> categoriesById;
@@ -65,6 +67,7 @@ class DashboardState {
     List<double>? dailySpending,
     double? maxDailySpending,
     List<double>? normalizedDailySpending,
+    List<double>? netWorthTrend,
     double? expenseDelta,
     double? incomeDelta,
     Map<String, CategoryModel>? categoriesById,
@@ -85,6 +88,7 @@ class DashboardState {
       dailySpending: dailySpending ?? this.dailySpending,
       maxDailySpending: maxDailySpending ?? this.maxDailySpending,
       normalizedDailySpending: normalizedDailySpending ?? this.normalizedDailySpending,
+      netWorthTrend: netWorthTrend ?? this.netWorthTrend,
       expenseDelta: expenseDelta ?? this.expenseDelta,
       incomeDelta: incomeDelta ?? this.incomeDelta,
       categoriesById: categoriesById ?? this.categoriesById,
@@ -109,6 +113,10 @@ class DashboardNotifier extends _$DashboardNotifier {
 
     final accountMetrics = DashboardAnalyticsService.calculateAccountMetrics(accounts);
     final txMetrics = DashboardAnalyticsService.calculateTransactionMetrics(transactions, categories);
+    final netWorthTrend = DashboardAnalyticsService.calculateNetWorthTrend(
+      currentNetWorth: accountMetrics.netWorth,
+      transactions: transactions,
+    );
 
     return DashboardState(
       accounts: accounts,
@@ -125,6 +133,7 @@ class DashboardNotifier extends _$DashboardNotifier {
       dailySpending: txMetrics.dailySpending,
       maxDailySpending: txMetrics.maxDailySpending,
       normalizedDailySpending: txMetrics.normalizedDailySpending,
+      netWorthTrend: netWorthTrend,
       expenseDelta: txMetrics.expenseDelta,
       incomeDelta: txMetrics.incomeDelta,
       categoriesById: {for (final c in categories) c.id: c},

--- a/lib/features/dashboard/presentation/screens/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/screens/dashboard_page.dart
@@ -44,6 +44,7 @@ class DashboardPage extends HookConsumerWidget {
                       totalAssets: state.totalAssets,
                       totalLiabilities: state.totalLiabilities,
                       activeAccountCount: state.activeAccountCount,
+                      sparklineData: state.netWorthTrend,
                     ).animate().fade(duration: 400.ms).slideY(begin: 0.05, end: 0),
                     const SizedBox(height: 20),
                     const DashboardQuickActions()

--- a/lib/shared/widgets/poka_hero_card.dart
+++ b/lib/shared/widgets/poka_hero_card.dart
@@ -15,6 +15,7 @@ class PokaHeroCard extends StatelessWidget {
     this.trailing,
     this.progress,
     this.cardColor,
+    this.background,
     super.key,
   });
 
@@ -42,6 +43,9 @@ class PokaHeroCard extends StatelessWidget {
   /// The primary color of the card gradient. Defaults to theme primary color.
   final Color? cardColor;
 
+  /// Optional background widget layered behind the card content (e.g., sparkline chart).
+  final Widget? background;
+
   @override
   Widget build(BuildContext context) {
     final theme = context.theme;
@@ -59,54 +63,65 @@ class PokaHeroCard extends StatelessWidget {
         titleTextStyle: theme.cardStyle.titleTextStyle,
         subtitleTextStyle: theme.cardStyle.subtitleTextStyle,
       ),
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: Stack(
           children: [
-            // ── Top Row (Pills & Trailing) ───────────────────────────────
-            Row(
-              children: [
-                ...pills,
-                const Spacer(),
-                ?trailing,
-              ],
-            ),
-            const SizedBox(height: 16),
-
-            // ── Middle Section (Label & Amount) ──────────────────────────
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: theme.typography.bodySecondary.copyWith(
-                    color: theme.colors.primaryForeground.withValues(alpha: 0.7),
+            if (background != null)
+              Positioned.fill(
+                child: background!,
+              ),
+            Container(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // ── Top Row (Pills & Trailing) ───────────────────────────────
+                  Row(
+                    children: [
+                      ...pills,
+                      const Spacer(),
+                      ?trailing,
+                    ],
                   ),
-                ),
-                const SizedBox(height: 6),
-                amount,
-              ],
-            ),
+                  const SizedBox(height: 16),
 
-            // ── Progress & Spacing ───────────────────────────────────────
-            if (progress != null) ...[
-              const SizedBox(height: 12),
-              _HeroCardProgressBar(progress: progress!),
-              const SizedBox(height: 12),
-            ] else ...[
-              // Maintain the exact height of (12 + 6 + 12 = 30) for cards without progress
-              const SizedBox(height: 30),
-            ],
+                  // ── Middle Section (Label & Amount) ──────────────────────────
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: theme.typography.bodySecondary.copyWith(
+                          color: theme.colors.primaryForeground.withValues(alpha: 0.7),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      amount,
+                    ],
+                  ),
 
-            // ── Bottom Row (Sub Amounts) ─────────────────────────────────
-            Row(
-              children: [
-                Expanded(child: leftSubAmount),
-                const SizedBox(width: 24),
-                Expanded(child: rightSubAmount),
-              ],
+                  // ── Progress & Spacing ───────────────────────────────────────
+                  if (progress != null) ...[
+                    const SizedBox(height: 12),
+                    _HeroCardProgressBar(progress: progress!),
+                    const SizedBox(height: 12),
+                  ] else ...[
+                    // Maintain the exact height of (12 + 6 + 12 = 30) for cards without progress
+                    const SizedBox(height: 30),
+                  ],
+
+                  // ── Bottom Row (Sub Amounts) ─────────────────────────────────
+                  Row(
+                    children: [
+                      Expanded(child: leftSubAmount),
+                      const SizedBox(width: 24),
+                      Expanded(child: rightSubAmount),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/shared/widgets/poka_sparkline.dart
+++ b/lib/shared/widgets/poka_sparkline.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+/// A lightweight, custom-painted sparkline widget for displaying smooth trend curves.
+/// Designed specifically for background layering in hero cards and summary panels.
+class PokaSparkline extends StatelessWidget {
+  /// Creates a [PokaSparkline].
+  const PokaSparkline({
+    required this.points,
+    this.lineColor,
+    this.fillGradient,
+    this.strokeWidth = 2.0,
+    this.showEndDot = true,
+    this.isCurved = true,
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
+    super.key,
+  });
+
+  /// The series of numeric values to plot.
+  final List<double> points;
+
+  /// The color of the sparkline stroke. Defaults to theme's primaryForeground with 0.30 alpha.
+  final Color? lineColor;
+
+  /// The gradient used to fill the area under the curve. Defaults to [PokaGradients.sparklineFill].
+  final Gradient? fillGradient;
+
+  /// Width of the line stroke.
+  final double strokeWidth;
+
+  /// Whether to display a subtle glowing indicator dot at the latest (last) data point.
+  final bool showEndDot;
+
+  /// Whether to use smooth cubic Bézier curves (spline interpolation) instead of straight lines.
+  final bool isCurved;
+
+  /// Insets from the bounding box to keep the line strokes and dots within bounds.
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    if (points.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = context.theme;
+    final strokeColor = lineColor ?? theme.colors.primaryForeground.withValues(alpha: 0.30);
+    final gradient = fillGradient ?? PokaGradients.sparklineFill(theme.colors.primaryForeground);
+
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(begin: 0, end: 1),
+      duration: const Duration(milliseconds: 700),
+      curve: Curves.easeOutCubic,
+      builder: (context, animValue, child) {
+        return CustomPaint(
+          size: Size.infinite,
+          painter: _PokaSparklinePainter(
+            points: points,
+            lineColor: strokeColor,
+            fillGradient: gradient,
+            strokeWidth: strokeWidth,
+            showEndDot: showEndDot,
+            isCurved: isCurved,
+            padding: padding,
+            animationProgress: animValue,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PokaSparklinePainter extends CustomPainter {
+  _PokaSparklinePainter({
+    required this.points,
+    required this.lineColor,
+    required this.fillGradient,
+    required this.strokeWidth,
+    required this.showEndDot,
+    required this.isCurved,
+    required this.padding,
+    required this.animationProgress,
+  });
+
+  final List<double> points;
+  final Color lineColor;
+  final Gradient fillGradient;
+  final double strokeWidth;
+  final bool showEndDot;
+  final bool isCurved;
+  final EdgeInsets padding;
+  final double animationProgress;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (points.isEmpty) return;
+
+    final contentWidth = size.width - padding.left - padding.right;
+    final contentHeight = size.height - padding.top - padding.bottom;
+    if (contentWidth <= 0 || contentHeight <= 0) return;
+
+    var minVal = points.first;
+    var maxVal = points.first;
+    for (final p in points) {
+      if (p < minVal) minVal = p;
+      if (p > maxVal) maxVal = p;
+    }
+    final range = maxVal - minVal;
+
+    final pts = <Offset>[];
+    for (var i = 0; i < points.length; i++) {
+      final x = points.length == 1
+          ? padding.left + contentWidth / 2
+          : padding.left + (i / (points.length - 1)) * contentWidth;
+      final normalizedY = range == 0 ? 0.5 : (points[i] - minVal) / range;
+      final targetY = padding.top + (1.0 - normalizedY) * contentHeight;
+      // Animate upward from bottom baseline
+      final baselineY = size.height - padding.bottom;
+      final y = baselineY - (baselineY - targetY) * animationProgress;
+      pts.add(Offset(x, y));
+    }
+
+    if (pts.length == 1) {
+      if (showEndDot) {
+        _drawEndDot(canvas, pts.first);
+      }
+      return;
+    }
+
+    final linePath = Path()..moveTo(pts.first.dx, pts.first.dy);
+
+    if (isCurved) {
+      for (var i = 1; i < pts.length; i++) {
+        final p0 = pts[i - 1];
+        final p1 = pts[i];
+        final cp1 = Offset(p0.dx + (p1.dx - p0.dx) / 2, p0.dy);
+        final cp2 = Offset(p0.dx + (p1.dx - p0.dx) / 2, p1.dy);
+        linePath.cubicTo(cp1.dx, cp1.dy, cp2.dx, cp2.dy, p1.dx, p1.dy);
+      }
+    } else {
+      for (var i = 1; i < pts.length; i++) {
+        linePath.lineTo(pts[i].dx, pts[i].dy);
+      }
+    }
+
+    // 1. Draw area gradient fill under the line
+    final fillPath = Path.from(linePath)
+      ..lineTo(pts.last.dx, size.height)
+      ..lineTo(pts.first.dx, size.height)
+      ..close();
+
+    final fillPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..shader = fillGradient.createShader(Rect.fromLTWH(0, 0, size.width, size.height));
+
+    canvas.drawPath(fillPath, fillPaint);
+
+    // 2. Draw line stroke
+    final strokePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..color = lineColor;
+
+    canvas.drawPath(linePath, strokePaint);
+
+    // 3. Draw end dot (indicator for the latest point)
+    if (showEndDot && animationProgress > 0.5) {
+      final dotProgress = ((animationProgress - 0.5) / 0.5).clamp(0.0, 1.0);
+      _drawEndDot(canvas, pts.last, progress: dotProgress);
+    }
+  }
+
+  void _drawEndDot(Canvas canvas, Offset position, {double progress = 1.0}) {
+    canvas
+      // Outer glow / aura
+      ..drawCircle(
+        position,
+        5.0 * progress,
+        Paint()..color = lineColor.withValues(alpha: 0.25 * progress),
+      )
+      // Inner bright dot
+      ..drawCircle(
+        position,
+        3.0 * progress,
+        Paint()..color = lineColor.withValues(alpha: 0.85 * progress),
+      );
+  }
+
+  @override
+  bool shouldRepaint(covariant _PokaSparklinePainter oldDelegate) {
+    return oldDelegate.animationProgress != animationProgress ||
+        oldDelegate.points != points ||
+        oldDelegate.lineColor != lineColor ||
+        oldDelegate.strokeWidth != strokeWidth ||
+        oldDelegate.showEndDot != showEndDot ||
+        oldDelegate.isCurved != isCurved;
+  }
+}

--- a/lib/theme/gradients.dart
+++ b/lib/theme/gradients.dart
@@ -39,4 +39,16 @@ abstract final class PokaGradients {
       Color(0xFFFF0000), // 360
     ],
   );
+
+  /// Vertical fade-out gradient for sparklines on hero cards and background charts.
+  static LinearGradient sparklineFill(Color color) {
+    return LinearGradient(
+      colors: [
+        color.withValues(alpha: 0.18),
+        color.withValues(alpha: 0),
+      ],
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+    );
+  }
 }

--- a/test/feature/features/accounts/presentation/widgets/cards/account_networth_card_test.dart
+++ b/test/feature/features/accounts/presentation/widgets/cards/account_networth_card_test.dart
@@ -4,10 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:forui_phosphor/forui_phosphor.dart';
 import 'package:poka_ce/features/accounts/presentation/widgets/cards/account_networth_card.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
-import 'package:poka_ce/i18n/strings.g.dart';
-import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
-import 'package:poka_ce/features/settings/domain/settings_model.dart';
 import 'package:poka_ce/features/settings/domain/currency_model.dart';
+import 'package:poka_ce/features/settings/domain/settings_model.dart';
+import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_sparkline.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 void main() {
@@ -24,6 +25,7 @@ void main() {
     int activeAccountCount = 2,
     String currency = 'USD',
     bool isBalanceVisible = true,
+    List<double>? sparklineData,
   }) {
     return ProviderScope(
       overrides: [
@@ -43,6 +45,7 @@ void main() {
                 totalAssets: totalAssets,
                 totalLiabilities: totalLiabilities,
                 activeAccountCount: activeAccountCount,
+                sparklineData: sparklineData,
               ),
             ),
           ),
@@ -175,6 +178,17 @@ void main() {
         findsOneWidget,
       );
       // divider removed from UI
+    });
+
+    testWidgets('renders sparkline in background when sparklineData is provided', (tester) async {
+      await tester.pumpWidget(
+        createWidgetUnderTest(
+          sparklineData: [1000, 1100, 1050, 1200, 1150, 1300, 1400],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PokaSparkline), findsOneWidget);
     });
   });
 }

--- a/test/feature/shared/widgets/poka_sparkline_test.dart
+++ b/test/feature/shared/widgets/poka_sparkline_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:poka_ce/shared/widgets/poka_sparkline.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+Widget wrap(Widget child) => MaterialApp(
+  builder: (context, c) => FTheme(data: lightTheme, child: c!),
+  home: Scaffold(
+    body: Center(child: SizedBox(width: 300, height: 100, child: child)),
+  ),
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Finder sparklinePaint() => find.descendant(
+    of: find.byType(PokaSparkline),
+    matching: find.byType(CustomPaint),
+  );
+
+  group('PokaSparkline', () {
+    testWidgets('renders SizedBox.shrink when points is empty', (tester) async {
+      await tester.pumpWidget(wrap(const PokaSparkline(points: [])));
+      await tester.pumpAndSettle();
+
+      expect(sparklinePaint(), findsNothing);
+    });
+
+    testWidgets('renders CustomPaint when points are provided', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaSparkline(
+            points: [100, 150, 120, 200, 180, 250, 300],
+          ),
+        ),
+      );
+
+      expect(sparklinePaint(), findsOneWidget);
+      await tester.pumpAndSettle();
+      expect(sparklinePaint(), findsOneWidget);
+    });
+
+    testWidgets('renders properly with flat line (identical values)', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaSparkline(
+            points: [200, 200, 200, 200],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(sparklinePaint(), findsOneWidget);
+    });
+
+    testWidgets('renders single point without crash', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaSparkline(
+            points: [100],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(sparklinePaint(), findsOneWidget);
+    });
+
+    testWidgets('renders with isCurved false (straight lines)', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaSparkline(
+            points: [10, 50, 30, 80],
+            isCurved: false,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(sparklinePaint(), findsOneWidget);
+    });
+
+    testWidgets('respects showEndDot false', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaSparkline(
+            points: [10, 20, 30],
+            showEndDot: false,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(sparklinePaint(), findsOneWidget);
+    });
+  });
+}

--- a/test/unit/features/dashboard/domain/services/dashboard_analytics_service_test.dart
+++ b/test/unit/features/dashboard/domain/services/dashboard_analytics_service_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/features/accounts/domain/account_model.dart';
+import 'package:poka_ce/features/categories/domain/category_model.dart';
+import 'package:poka_ce/features/dashboard/domain/services/dashboard_analytics_service.dart';
+import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
+
+void main() {
+  group('DashboardAnalyticsService', () {
+    group('calculateAccountMetrics', () {
+      test('computes netWorth, totalAssets, and totalLiabilities correctly', () {
+        final now = DateTime.now();
+        final accounts = [
+          AccountModel(
+            id: '1',
+            name: 'Cash',
+            icon: 'wallet',
+            color: '#000000',
+            type: AccountType.assets,
+            balance: 500,
+            initialBalance: 500,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+          ),
+          AccountModel(
+            id: '2',
+            name: 'Debt Account',
+            icon: 'card',
+            color: '#000000',
+            type: AccountType.liability,
+            balance: -200,
+            initialBalance: 0,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+          ),
+          AccountModel(
+            id: '3',
+            name: 'Archived',
+            icon: 'archive',
+            color: '#000000',
+            type: AccountType.assets,
+            balance: 1000,
+            initialBalance: 1000,
+            isActive: false,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ];
+
+        final metrics = DashboardAnalyticsService.calculateAccountMetrics(accounts);
+        expect(metrics.activeAccountCount, 2);
+        expect(metrics.totalAssets, 500.0);
+        expect(metrics.totalLiabilities, 200.0);
+        expect(metrics.netWorth, 300.0);
+      });
+    });
+
+    group('calculateNetWorthTrend', () {
+      test('returns constant array when there are no transactions', () {
+        final trend = DashboardAnalyticsService.calculateNetWorthTrend(
+          currentNetWorth: 1000,
+          transactions: const [],
+          days: 7,
+        );
+
+        expect(trend.length, 7);
+        for (final val in trend) {
+          expect(val, 1000.0);
+        }
+      });
+
+      test('returns empty list when days is zero or negative', () {
+        final trend = DashboardAnalyticsService.calculateNetWorthTrend(
+          currentNetWorth: 1000,
+          transactions: const [],
+          days: 0,
+        );
+        expect(trend, isEmpty);
+      });
+
+      test('reconstructs historical net worth accurately based on income and expenses', () {
+        final now = DateTime.now().toUtc();
+        final today = DateTime.utc(now.year, now.month, now.day, 12);
+        final yesterday = today.subtract(const Duration(days: 1));
+
+        final transactions = [
+          // Today: expense of 200
+          TransactionModel(
+            id: 'tx1',
+            accountId: 'acc1',
+            type: TransactionType.expense,
+            amount: 200,
+            transactionDate: today,
+            items: const [],
+            createdAt: today,
+            updatedAt: today,
+          ),
+          // Yesterday: income of 500
+          TransactionModel(
+            id: 'tx2',
+            accountId: 'acc1',
+            type: TransactionType.income,
+            amount: 500,
+            transactionDate: yesterday,
+            items: const [],
+            createdAt: yesterday,
+            updatedAt: yesterday,
+          ),
+        ];
+
+        // Current net worth today is 1000
+        final trend = DashboardAnalyticsService.calculateNetWorthTrend(
+          currentNetWorth: 1000,
+          transactions: transactions,
+          days: 7,
+        );
+
+        expect(trend.length, 7);
+        // Index 6 is today: 1000
+        expect(trend[6], 1000.0);
+        // Index 5 is yesterday: today net worth was 1000, but today we had an expense of 200,
+        // so yesterday's closing net worth was 1000 - (-200) = 1200
+        expect(trend[5], 1200.0);
+        // Index 4 is 2 days ago: yesterday's closing was 1200, but yesterday we had income of 500,
+        // so 2 days ago closing net worth was 1200 - 500 = 700
+        expect(trend[4], 700.0);
+        // Earlier days (indices 0, 1, 2, 3) should remain 700 because no older transactions
+        expect(trend[0], 700.0);
+        expect(trend[1], 700.0);
+        expect(trend[2], 700.0);
+        expect(trend[3], 700.0);
+      });
+    });
+
+    group('calculateTransactionMetrics', () {
+      test('calculates income, expense, and daily spending properly', () {
+        final now = DateTime.now().toUtc();
+        final today = DateTime.utc(now.year, now.month, now.day, 10);
+        final cat = CategoryModel(
+          id: 'cat1',
+          name: 'Food',
+          icon: 'fork',
+          color: '#FF0000',
+          type: CategoryType.expense,
+          sort: 1,
+          isActive: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        final transactions = [
+          TransactionModel(
+            id: 't1',
+            accountId: 'a1',
+            type: TransactionType.income,
+            amount: 1500,
+            transactionDate: today,
+            items: const [],
+            createdAt: today,
+            updatedAt: today,
+          ),
+          TransactionModel(
+            id: 't2',
+            accountId: 'a1',
+            type: TransactionType.expense,
+            amount: 300,
+            transactionDate: today,
+            items: [
+              TransactionItemModel(
+                id: 'item1',
+                transactionId: 't2',
+                categoryId: 'cat1',
+                allocation: TransactionAllocation.need,
+                amount: 300,
+                createdAt: today,
+                updatedAt: today,
+              ),
+            ],
+            createdAt: today,
+            updatedAt: today,
+          ),
+        ];
+
+        final metrics = DashboardAnalyticsService.calculateTransactionMetrics(transactions, [cat]);
+        expect(metrics.totalIncome, 1500.0);
+        expect(metrics.totalExpense, 300.0);
+        expect(metrics.dailySpending.last, 300.0);
+        expect(metrics.categoryExpenses, isNotEmpty);
+        expect(metrics.categoryExpenses.first.name, 'Food');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 🎯 Description

Adds a subtle, smooth background sparkline (line chart with vertical fade-out gradient) to the Net Worth hero card on the Home dashboard (`AccountNetworthCard`), providing glanceable 7-day trend visualization while preserving high contrast and typography readability.

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 UI/UX update (changes to styling, animations, or layouts)

## 🛠️ Testing Instructions

1. Run `make check` to ensure static analysis passes with 0 issues.
2. Run `flutter test test/feature/shared/widgets/poka_sparkline_test.dart` to verify sparkline widget rendering.
3. Run `flutter test test/unit/features/dashboard/domain/services/dashboard_analytics_service_test.dart` to verify net worth trend calculation.
4. Launch the app and observe the Net Worth card on the Home screen: a subtle cubic Bézier curve with an end dot smoothly animates into place at the bottom of the card.

## ✅ Checklist

### Mandatory

- [x] `make fix` — dart fix + format applied
- [x] `make check` — reports **"No issues found!"**
- [x] `make generate` — codegen up to date
- [x] `make test` — all tests pass
- [x] Every new `lib/` file has a matching `test/` file
- [x] My commit messages follow the Conventional Commits format (`feat:`, `fix:`, `ui:`)

### Code Quality

- [x] No Material widgets (`Scaffold`, `AppBar`, `ElevatedButton`, `Card`) — ForUI only
- [x] No shadows (`boxShadow`, `elevation > 0`, `PhysicalModel`)
- [x] No hardcoded colors (`Color(0xFF...)`, `Colors.white/black/grey`) outside `lib/theme/`
- [x] No inline typography (`TextStyle(fontSize: N)`, `fontWeight`) outside `lib/theme/`
- [x] No ForUI component styled inline
- [x] No `throw` inside a Repository or Notifier
- [x] No `print()` or `debugPrint()` — uses `talker`
- [x] No `dynamic` type anywhere
- [x] No sync logic, cloud integration, or multi-currency support
- [x] No Drift `*Data` class passed to or imported in a Widget/Screen