### PR TITLE
fix: resolve sparkline dot clipping and expose reusable FAB

### DIFF
--- a/lib/app/shell/main_shell_page.dart
+++ b/lib/app/shell/main_shell_page.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:forui/forui.dart';
 import 'package:forui_phosphor/forui_phosphor.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/features/recurring/presentation/controllers/recurring_runner_notifier.dart';
-import 'package:poka_ce/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_add_transaction_fab.dart';
 
 /// Main shell page hosting the bottom navigation bar.
 /// Also triggers the recurring automation runner on every app startup.
@@ -113,49 +112,11 @@ class MainShellPage extends HookConsumerWidget {
                     duration: const Duration(milliseconds: 300),
                     curve: Curves.easeOutCubic,
                     opacity: isFabVisible.value ? 1.0 : 0.0,
-                    child: _AddTransactionFab(),
+                    child: const PokaAddTransactionFab(),
                   ),
                 ),
               ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Circular FAB for adding a new transaction, using the theme primary color.
-class _AddTransactionFab extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final theme = context.theme;
-
-    return GestureDetector(
-      key: const Key('transaction-add-button'),
-      onTap: () {
-        HapticFeedback.lightImpact();
-        TransactionFormSheet.show(context);
-      },
-      // Outer ring in card color creates a visual halo that separates
-      // the FAB from same-colored chart elements behind it.
-      child: Container(
-        padding: const EdgeInsets.all(3),
-        decoration: BoxDecoration(
-          color: theme.colors.card,
-          shape: BoxShape.circle,
-        ),
-        child: Container(
-          width: 48,
-          height: 48,
-          decoration: BoxDecoration(
-            color: theme.colors.primary,
-            shape: BoxShape.circle,
-          ),
-          child: Icon(
-            FPhosphorIcons.plus,
-            size: 20,
-            color: theme.colors.primaryForeground,
-          ),
         ),
       ),
     );

--- a/lib/features/accounts/presentation/widgets/cards/account_networth_card.dart
+++ b/lib/features/accounts/presentation/widgets/cards/account_networth_card.dart
@@ -42,7 +42,7 @@ class AccountNetworthCard extends ConsumerWidget {
                 height: 90,
                 child: PokaSparkline(
                   points: sparklineData!,
-                  padding: const EdgeInsets.only(top: 8, bottom: 8),
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
                 ),
               ),
             )

--- a/lib/shared/widgets/poka_add_transaction_fab.dart
+++ b/lib/shared/widgets/poka_add_transaction_fab.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:forui/forui.dart';
+import 'package:forui_phosphor/forui_phosphor.dart';
+import 'package:poka_ce/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart';
+
+/// Floating action button for adding a new transaction.
+///
+/// Features an outer ring in card color that creates a visual halo separating
+/// the FAB from same-colored chart elements behind it.
+class PokaAddTransactionFab extends StatelessWidget {
+  /// Creates a [PokaAddTransactionFab].
+  const PokaAddTransactionFab({
+    this.onTap,
+    super.key,
+  });
+
+  /// Optional tap callback. Defaults to opening [TransactionFormSheet].
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+
+    return GestureDetector(
+      key: const Key('transaction-add-button'),
+      onTap: () {
+        HapticFeedback.lightImpact();
+        if (onTap != null) {
+          onTap!();
+        } else {
+          TransactionFormSheet.show(context);
+        }
+      },
+      // Outer ring in card color creates a visual halo that separates
+      // the FAB from same-colored chart elements behind it.
+      child: Container(
+        padding: const EdgeInsets.all(3),
+        decoration: BoxDecoration(
+          color: theme.colors.card,
+          shape: BoxShape.circle,
+        ),
+        child: Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            color: theme.colors.primary,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            FPhosphorIcons.plus,
+            size: 20,
+            color: theme.colors.primaryForeground,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/poka_sparkline.dart
+++ b/lib/shared/widgets/poka_sparkline.dart
@@ -12,7 +12,7 @@ class PokaSparkline extends StatelessWidget {
     this.strokeWidth = 2.0,
     this.showEndDot = true,
     this.isCurved = true,
-    this.padding = const EdgeInsets.symmetric(vertical: 12),
+    this.padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
     super.key,
   });
 

--- a/test/feature/shared/widgets/poka_add_transaction_fab_test.dart
+++ b/test/feature/shared/widgets/poka_add_transaction_fab_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:forui_phosphor/forui_phosphor.dart';
+import 'package:poka_ce/shared/widgets/poka_add_transaction_fab.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      builder: (context, c) => FTheme(data: lightTheme, child: c!),
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  group('PokaAddTransactionFab', () {
+    testWidgets('renders key and plus icon properly', (tester) async {
+      await tester.pumpWidget(wrap(const PokaAddTransactionFab()));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('transaction-add-button')), findsOneWidget);
+      expect(find.byIcon(FPhosphorIcons.plus), findsOneWidget);
+    });
+
+    testWidgets('calls custom onTap when provided', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        wrap(
+          PokaAddTransactionFab(
+            onTap: () {
+              tapped = true;
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('transaction-add-button')));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('renders outer ring halo in card color', (tester) async {
+      await tester.pumpWidget(wrap(const PokaAddTransactionFab()));
+      await tester.pumpAndSettle();
+
+      final containers = tester
+          .widgetList<Container>(
+            find.descendant(
+              of: find.byKey(const Key('transaction-add-button')),
+              matching: find.byType(Container),
+            ),
+          )
+          .toList();
+
+      expect(containers.length, greaterThanOrEqualTo(2));
+      final outerContainer = containers.first;
+      final outerDecoration = outerContainer.decoration as BoxDecoration?;
+      expect(outerDecoration?.shape, BoxShape.circle);
+      expect(outerDecoration?.color, lightTheme.colors.card);
+      expect(outerContainer.padding, const EdgeInsets.all(3));
+    });
+  });
+}


### PR DESCRIPTION
## 🎯 Description

- Closes #17: Fix sparkline end dot clipping at right boundary on hero cards by adding horizontal insets to default `PokaSparkline` padding and `AccountNetworthCard`.
- Closes #18: Extract and export reusable `PokaAddTransactionFab` with halo ring into `lib/shared/widgets/poka_add_transaction_fab.dart` so external packages (like Poka PE) can compose/extend the FAB without duplicating UI code.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 UI/UX update (changes to styling, animations, or layouts)
- [x] ♻️ Refactoring (no functional changes, no API changes)

## 🛠️ Testing Instructions

1. Run `make check` -> Reports "No issues found!".
2. Run `make test` -> All unit, feature, and e2e tests pass.
3. Inspect `AccountNetworthCard` background sparkline to verify the end indicator dot renders fully without right-edge clipping.
4. Verify `MainShellPage` FAB renders and behaves identically with the newly extracted `PokaAddTransactionFab`.

## ✅ Checklist

### Mandatory

- [x] `make fix` — dart fix + format applied
- [x] `make check` — reports **"No issues found!"**
- [x] `make generate` — codegen up to date (if annotated files changed)
- [x] `make test` — all tests pass
- [x] Every new `lib/` file has a matching `test/` file
- [x] My commit messages follow the Conventional Commits format (`feat:`, `fix:`, `ui:`)

### Code Quality

- [x] No Material widgets (`Scaffold`, `AppBar`, `ElevatedButton`, `Card`) — ForUI only
- [x] No shadows (`boxShadow`, `elevation > 0`, `PhysicalModel`)
- [x] No hardcoded colors (`Color(0xFF...)`, `Colors.white/black/grey`) outside `lib/theme/`
- [x] No inline typography (`TextStyle(fontSize: N)`, `fontWeight`) outside `lib/theme/`
- [x] No ForUI component styled inline — used `dart run forui style create <component>` instead
- [x] No `throw` inside a Repository or Notifier
- [x] No `print()` or `debugPrint()` — uses `talker`
- [x] No `dynamic` type anywhere
- [x] No sync logic, cloud integration, or multi-currency support
- [x] No Drift `*Data` class passed to or imported in a Widget/Screen — use Freezed domain models from `domain/` instead

---
<!-- pr-agent:describe -->