### PR TITLE
fix: preserve quick action shortcut icons in release builds

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -13,3 +13,10 @@
 
 -dontwarn io.flutter.plugin.**
 -dontwarn com.google.android.play.core.**
+
+# Quick Actions and Shortcuts
+-keep class io.flutter.plugins.quickactions.** { *; }
+-keep class androidx.core.content.pm.ShortcutInfoCompat** { *; }
+-keep class androidx.core.content.pm.ShortcutManagerCompat** { *; }
+-keep class androidx.core.graphics.drawable.IconCompat** { *; }
+

--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ic_shortcut_*,@drawable/ic_shortcut_add_account,@drawable/ic_shortcut_add_category,@drawable/ic_shortcut_add_goal,@drawable/ic_shortcut_add_transaction" />

--- a/lib/core/services/quick_actions_service.dart
+++ b/lib/core/services/quick_actions_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:poka_ce/app/router/router.dart';
 import 'package:poka_ce/core/logger/poka_logger.dart';
 import 'package:poka_ce/features/accounts/presentation/widgets/forms/account_form_sheet.dart';
@@ -6,14 +7,18 @@ import 'package:poka_ce/features/goals/presentation/widgets/goal_form_sheet.dart
 import 'package:poka_ce/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart';
 import 'package:quick_actions/quick_actions.dart';
 
+/// Service responsible for managing app shortcuts (Quick Actions).
 class QuickActionsService {
-  QuickActionsService._();
+  /// Creates a [QuickActionsService] instance.
+  QuickActionsService({QuickActions? quickActions}) : _quickActions = quickActions ?? const QuickActions();
 
-  static final QuickActionsService instance = QuickActionsService._();
-  final QuickActions _quickActions = const QuickActions();
+  /// Global singleton instance.
+  static final QuickActionsService instance = QuickActionsService();
+  final QuickActions _quickActions;
 
   bool _initialized = false;
 
+  /// Initializes quick actions and registers shortcuts.
   void initialize() {
     if (_initialized) return;
 
@@ -22,50 +27,56 @@ class QuickActionsService {
       _handleAction(shortcutType);
     });
 
-    _quickActions.setShortcutItems(<ShortcutItem>[
-      const ShortcutItem(
-        type: 'action_add_transaction',
-        localizedTitle: 'Add Transaction',
-        icon: 'ic_shortcut_add_transaction',
-      ),
-      const ShortcutItem(
-        type: 'action_add_account',
-        localizedTitle: 'Add Account',
-        icon: 'ic_shortcut_add_account',
-      ),
-      const ShortcutItem(
-        type: 'action_add_category',
-        localizedTitle: 'Add Category',
-        icon: 'ic_shortcut_add_category',
-      ),
-      const ShortcutItem(
-        type: 'action_add_goal',
-        localizedTitle: 'Add Goal',
-        icon: 'ic_shortcut_add_goal',
-      ),
-    ]);
+    _quickActions
+        .setShortcutItems(<ShortcutItem>[
+          const ShortcutItem(
+            type: 'action_add_transaction',
+            localizedTitle: 'Add Transaction',
+            icon: 'ic_shortcut_add_transaction',
+          ),
+          const ShortcutItem(
+            type: 'action_add_account',
+            localizedTitle: 'Add Account',
+            icon: 'ic_shortcut_add_account',
+          ),
+          const ShortcutItem(
+            type: 'action_add_category',
+            localizedTitle: 'Add Category',
+            icon: 'ic_shortcut_add_category',
+          ),
+          const ShortcutItem(
+            type: 'action_add_goal',
+            localizedTitle: 'Add Goal',
+            icon: 'ic_shortcut_add_goal',
+          ),
+        ])
+        .catchError((Object e, StackTrace st) {
+          talker.error('Failed to set shortcut items', e, st);
+        });
 
     _initialized = true;
   }
 
   void _handleAction(String type) {
-    final context = rootNavigatorKey.currentContext;
-    if (context == null) {
-      talker.warning('Cannot handle QuickAction: rootNavigatorKey.currentContext is null');
-      return;
-    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final context = rootNavigatorKey.currentContext;
+      if (context == null) {
+        talker.warning('Cannot handle QuickAction: rootNavigatorKey.currentContext is null');
+        return;
+      }
 
-    switch (type) {
-      case 'action_add_transaction':
-        TransactionFormSheet.show(context);
-      case 'action_add_account':
-        AccountFormSheet.show(context);
-      case 'action_add_category':
-        CategoryFormSheet.show(context);
-      case 'action_add_goal':
-        GoalFormSheet.show(context);
-      default:
-        talker.warning('Unknown QuickAction type: $type');
-    }
+      switch (type) {
+        case 'action_add_transaction':
+          TransactionFormSheet.show(context);
+        case 'action_add_account':
+          AccountFormSheet.show(context);
+        case 'action_add_category':
+          CategoryFormSheet.show(context);
+        case 'action_add_goal':
+          GoalFormSheet.show(context);
+        default:
+          talker.warning('Unknown QuickAction type: $type');
+      }
+    });
   }
 }

--- a/test/unit/core/services/quick_actions_service_test.dart
+++ b/test/unit/core/services/quick_actions_service_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:poka_ce/core/services/quick_actions_service.dart';
+import 'package:quick_actions/quick_actions.dart';
+
+class MockQuickActions extends Mock implements QuickActions {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockQuickActions mockQuickActions;
+  late QuickActionsService service;
+
+  setUp(() {
+    mockQuickActions = MockQuickActions();
+    when(() => mockQuickActions.initialize(any())).thenAnswer((_) async {});
+    when(() => mockQuickActions.setShortcutItems(any())).thenAnswer((_) async {});
+    service = QuickActionsService(quickActions: mockQuickActions);
+  });
+
+  group('QuickActionsService', () {
+    test('is a singleton via instance getter', () {
+      expect(QuickActionsService.instance, isNotNull);
+      expect(identical(QuickActionsService.instance, QuickActionsService.instance), isTrue);
+    });
+
+    test('initialize registers action handler and sets shortcut items', () async {
+      service.initialize();
+
+      verify(() => mockQuickActions.initialize(any())).called(1);
+      verify(() => mockQuickActions.setShortcutItems(any())).called(1);
+    });
+
+    test('initialize is idempotent', () async {
+      service.initialize();
+      service.initialize();
+
+      verify(() => mockQuickActions.initialize(any())).called(1);
+      verify(() => mockQuickActions.setShortcutItems(any())).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## 🎯 Description

- Closes #20: Fix quick action launcher shortcuts disappearing or missing icons in release builds.
- Adds `keep.xml` in `android/app/src/main/res/raw/` to prevent R8/Android Resource Shrinker from stripping `@drawable/ic_shortcut_*` assets during release compilation (`isShrinkResources = true`).
- Adds ProGuard keep rules for QuickActions and AndroidX shortcut classes.
- Adds error handling (`talker.error`) and post-frame callback execution to `QuickActionsService`.
- Adds unit tests in `test/unit/core/services/quick_actions_service_test.dart`.

## 🚀 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🛠️ Testing Instructions

1. Run `make check` -> Reports "No issues found!".
2. Run `make test:unit` -> All unit tests pass.
3. Build release APK with `make build` (or `flutter build apk`).
4. Install the release APK on an Android device or emulator.
5. Long-press app icon on launcher -> Verify quick actions appear with icons.

## ✅ Checklist

### Mandatory

- [x] `make fix` — dart fix + format applied
- [x] `make check` — reports **"No issues found!"**
- [x] `make generate` — codegen up to date (if annotated files changed)
- [x] `make test` — all tests pass
- [x] Every new `lib/` file has a matching `test/` file
- [x] My commit messages follow the Conventional Commits format (`fix:`)

### Code Quality

- [x] No Material widgets (`Scaffold`, `AppBar`, `ElevatedButton`, `Card`) — ForUI only
- [x] No shadows (`boxShadow`, `elevation > 0`, `PhysicalModel`)
- [x] No hardcoded colors (`Color(0xFF...)`, `Colors.white/black/grey`) outside `lib/theme/`
- [x] No inline typography (`TextStyle(fontSize: N)`, `fontWeight`) outside `lib/theme/`
- [x] No ForUI component styled inline — used `dart run forui style create <component>` instead
- [x] No `throw` inside a Repository or Notifier
- [x] No `print()` or `debugPrint()` — uses `talker`
- [x] No `dynamic` type anywhere
- [x] No sync logic, cloud integration, or multi-currency support
- [x] No Drift `*Data` class passed to or imported in a Widget/Screen — use Freezed domain models from `domain/` instead

---
<!-- pr-agent:describe -->