### PR TITLE
feat: support initial prefill values across creation form sheets

### DIFF
--- a/lib/features/budgets/presentation/controllers/budget_form_notifier.dart
+++ b/lib/features/budgets/presentation/controllers/budget_form_notifier.dart
@@ -36,7 +36,14 @@ class BudgetFormNotifier extends _$BudgetFormNotifier {
     return const BudgetFormState();
   }
 
-  void init(BudgetModel? budget) {
+  void init(
+    BudgetModel? budget, {
+    String? initialName,
+    int? initialAmount,
+    BudgetPeriod? initialPeriod,
+    String? initialCategoryId,
+    String? initialAccountId,
+  }) {
     if (budget != null) {
       state = BudgetFormState(
         initialBudget: budget,
@@ -50,7 +57,13 @@ class BudgetFormNotifier extends _$BudgetFormNotifier {
         accountId: budget.accountId,
       );
     } else {
-      state = const BudgetFormState();
+      state = BudgetFormState(
+        name: initialName ?? '',
+        amount: initialAmount ?? 0,
+        period: initialPeriod ?? BudgetPeriod.monthly,
+        categoryId: initialCategoryId,
+        accountId: initialAccountId,
+      );
     }
   }
 

--- a/lib/features/budgets/presentation/widgets/forms/budget_form_sheet.dart
+++ b/lib/features/budgets/presentation/widgets/forms/budget_form_sheet.dart
@@ -22,14 +22,42 @@ import 'package:poka_ce/shared/widgets/poka_pocket_selector.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 
 class BudgetFormSheet extends HookConsumerWidget {
-  const BudgetFormSheet({super.key, this.initialBudget});
+  const BudgetFormSheet({
+    super.key,
+    this.initialBudget,
+    this.initialName,
+    this.initialAmount,
+    this.initialPeriod,
+    this.initialCategoryId,
+    this.initialAccountId,
+  });
 
   final BudgetModel? initialBudget;
+  final String? initialName;
+  final int? initialAmount;
+  final BudgetPeriod? initialPeriod;
+  final String? initialCategoryId;
+  final String? initialAccountId;
 
-  static Future<void> show(BuildContext context, {BudgetModel? initialBudget}) {
+  static Future<void> show(
+    BuildContext context, {
+    BudgetModel? initialBudget,
+    String? initialName,
+    int? initialAmount,
+    BudgetPeriod? initialPeriod,
+    String? initialCategoryId,
+    String? initialAccountId,
+  }) {
     return showPokaSheet(
       context: context,
-      builder: (context) => BudgetFormSheet(initialBudget: initialBudget),
+      builder: (context) => BudgetFormSheet(
+        initialBudget: initialBudget,
+        initialName: initialName,
+        initialAmount: initialAmount,
+        initialPeriod: initialPeriod,
+        initialCategoryId: initialCategoryId,
+        initialAccountId: initialAccountId,
+      ),
     );
   }
 
@@ -39,15 +67,26 @@ class BudgetFormSheet extends HookConsumerWidget {
     final state = ref.watch(budgetFormProvider);
 
     useEffect(() {
-      Future.microtask(() => notifier.init(initialBudget));
+      Future.microtask(
+        () => notifier.init(
+          initialBudget,
+          initialName: initialName,
+          initialAmount: initialAmount,
+          initialPeriod: initialPeriod,
+          initialCategoryId: initialCategoryId,
+          initialAccountId: initialAccountId,
+        ),
+      );
       return null;
-    }, [initialBudget]);
+    }, [initialBudget, initialName, initialAmount, initialPeriod, initialCategoryId, initialAccountId]);
 
-    final nameController = useTextEditingController(text: initialBudget?.name ?? state.name);
+    final nameController = useTextEditingController(text: initialBudget?.name ?? initialName ?? state.name);
     final amountController = useTextEditingController(
       text: initialBudget != null && initialBudget!.amount > 0
           ? initialBudget!.amount.toString()
-          : (state.amount > 0 ? state.amount.toString() : ''),
+          : (initialAmount != null && initialAmount! > 0
+                ? initialAmount.toString()
+                : (state.amount > 0 ? state.amount.toString() : '')),
     );
     final resetDayController = useTextEditingController(
       text: initialBudget?.resetDay?.toString() ?? (state.resetDay != null ? state.resetDay.toString() : ''),

--- a/lib/features/categories/presentation/controllers/category_form_notifier.dart
+++ b/lib/features/categories/presentation/controllers/category_form_notifier.dart
@@ -44,6 +44,7 @@ class CategoryFormNotifier extends _$CategoryFormNotifier {
     CategoryModel? category, {
     String? parentId,
     CategoryType? type,
+    String? initialName,
   }) {
     if (category != null) {
       state = CategoryFormState(
@@ -56,6 +57,7 @@ class CategoryFormNotifier extends _$CategoryFormNotifier {
       );
     } else {
       state = CategoryFormState(
+        name: initialName ?? '',
         parentId: parentId,
         type: type ?? CategoryType.expense,
       );

--- a/lib/features/categories/presentation/widgets/forms/category_form_sheet.dart
+++ b/lib/features/categories/presentation/widgets/forms/category_form_sheet.dart
@@ -16,18 +16,21 @@ class CategoryFormSheet extends HookConsumerWidget {
     this.initialCategory,
     this.parentId,
     this.initialType,
+    this.initialName,
     super.key,
   });
 
   final CategoryModel? initialCategory;
   final String? parentId;
   final CategoryType? initialType;
+  final String? initialName;
 
   static Future<void> show(
     BuildContext context, {
     CategoryModel? category,
     String? parentId,
     CategoryType? initialType,
+    String? initialName,
   }) {
     return showPokaSheet(
       context: context,
@@ -35,6 +38,7 @@ class CategoryFormSheet extends HookConsumerWidget {
         initialCategory: category,
         parentId: parentId,
         initialType: initialType,
+        initialName: initialName,
       ),
     );
   }
@@ -50,12 +54,13 @@ class CategoryFormSheet extends HookConsumerWidget {
           initialCategory,
           parentId: parentId,
           type: initialType,
+          initialName: initialName,
         );
       });
       return null;
-    }, [initialCategory, parentId, initialType]);
+    }, [initialCategory, parentId, initialType, initialName]);
 
-    final nameController = useTextEditingController(text: initialCategory?.name ?? state.name);
+    final nameController = useTextEditingController(text: initialCategory?.name ?? initialName ?? state.name);
 
     useEffect(() {
       void listener() {

--- a/lib/features/debts/presentation/controllers/debt_form_notifier.dart
+++ b/lib/features/debts/presentation/controllers/debt_form_notifier.dart
@@ -35,7 +35,16 @@ class DebtForm extends _$DebtForm {
     return const DebtFormState();
   }
 
-  void init(DebtModel? debt) {
+  void init(
+    DebtModel? debt, {
+    String? initialPersonName,
+    DebtType? initialType,
+    int? initialAmount,
+    DateTime? initialDueDate,
+    String? initialNote,
+    String? initialAccountId,
+    String? initialCategoryId,
+  }) {
     if (debt != null) {
       state = DebtFormState(
         initialDebt: debt,
@@ -47,7 +56,15 @@ class DebtForm extends _$DebtForm {
         note: debt.note,
       );
     } else {
-      state = const DebtFormState();
+      state = DebtFormState(
+        accountId: initialAccountId ?? '',
+        categoryId: initialCategoryId ?? '',
+        personName: initialPersonName ?? '',
+        type: initialType ?? DebtType.debt,
+        amount: initialAmount ?? 0,
+        dueDate: initialDueDate,
+        note: initialNote,
+      );
     }
   }
 

--- a/lib/features/debts/presentation/widgets/debt_form_sheet.dart
+++ b/lib/features/debts/presentation/widgets/debt_form_sheet.dart
@@ -19,14 +19,50 @@ import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 class DebtFormSheet extends HookConsumerWidget {
-  const DebtFormSheet({super.key, this.initialDebt});
+  const DebtFormSheet({
+    super.key,
+    this.initialDebt,
+    this.initialPersonName,
+    this.initialType,
+    this.initialAmount,
+    this.initialDueDate,
+    this.initialNote,
+    this.initialAccountId,
+    this.initialCategoryId,
+  });
 
   final DebtModel? initialDebt;
+  final String? initialPersonName;
+  final DebtType? initialType;
+  final int? initialAmount;
+  final DateTime? initialDueDate;
+  final String? initialNote;
+  final String? initialAccountId;
+  final String? initialCategoryId;
 
-  static Future<void> show(BuildContext context, {DebtModel? initialDebt}) {
+  static Future<void> show(
+    BuildContext context, {
+    DebtModel? initialDebt,
+    String? initialPersonName,
+    DebtType? initialType,
+    int? initialAmount,
+    DateTime? initialDueDate,
+    String? initialNote,
+    String? initialAccountId,
+    String? initialCategoryId,
+  }) {
     return showPokaSheet(
       context: context,
-      builder: (context) => DebtFormSheet(initialDebt: initialDebt),
+      builder: (context) => DebtFormSheet(
+        initialDebt: initialDebt,
+        initialPersonName: initialPersonName,
+        initialType: initialType,
+        initialAmount: initialAmount,
+        initialDueDate: initialDueDate,
+        initialNote: initialNote,
+        initialAccountId: initialAccountId,
+        initialCategoryId: initialCategoryId,
+      ),
     );
   }
 
@@ -35,18 +71,47 @@ class DebtFormSheet extends HookConsumerWidget {
     final notifier = ref.read(debtFormProvider.notifier);
     final state = ref.watch(debtFormProvider);
 
-    useEffect(() {
-      Future.microtask(() => notifier.init(initialDebt));
-      return null;
-    }, [initialDebt]);
+    useEffect(
+      () {
+        Future.microtask(
+          () => notifier.init(
+            initialDebt,
+            initialPersonName: initialPersonName,
+            initialType: initialType,
+            initialAmount: initialAmount,
+            initialDueDate: initialDueDate,
+            initialNote: initialNote,
+            initialAccountId: initialAccountId,
+            initialCategoryId: initialCategoryId,
+          ),
+        );
+        return null;
+      },
+      [
+        initialDebt,
+        initialPersonName,
+        initialType,
+        initialAmount,
+        initialDueDate,
+        initialNote,
+        initialAccountId,
+        initialCategoryId,
+      ],
+    );
 
-    final personController = useTextEditingController(text: initialDebt?.personName ?? state.personName);
+    final personController = useTextEditingController(
+      text: initialDebt?.personName ?? initialPersonName ?? state.personName,
+    );
     final amountController = useTextEditingController(
       text: initialDebt != null && initialDebt!.amount > 0
           ? initialDebt!.amount.toString()
-          : (state.amount > 0 ? state.amount.toString() : ''),
+          : (initialAmount != null && initialAmount! > 0
+                ? initialAmount.toString()
+                : (state.amount > 0 ? state.amount.toString() : '')),
     );
-    final noteController = useTextEditingController(text: initialDebt?.note ?? state.note ?? '');
+    final noteController = useTextEditingController(
+      text: initialDebt?.note ?? initialNote ?? state.note ?? '',
+    );
 
     useEffect(() {
       void onPerson() {

--- a/lib/features/goals/presentation/controllers/goal_form_notifier.dart
+++ b/lib/features/goals/presentation/controllers/goal_form_notifier.dart
@@ -54,7 +54,12 @@ class GoalFormNotifier extends _$GoalFormNotifier {
     return const GoalFormState();
   }
 
-  void init(GoalModel? goal) {
+  void init(
+    GoalModel? goal, {
+    String? initialName,
+    int? initialTargetAmount,
+    DateTime? initialTargetDate,
+  }) {
     if (goal != null) {
       state = GoalFormState(
         initialGoal: goal,
@@ -63,7 +68,11 @@ class GoalFormNotifier extends _$GoalFormNotifier {
         targetDate: goal.targetDate,
       );
     } else {
-      state = const GoalFormState();
+      state = GoalFormState(
+        name: initialName ?? '',
+        targetAmount: initialTargetAmount ?? 0,
+        targetDate: initialTargetDate,
+      );
     }
   }
 

--- a/lib/features/goals/presentation/widgets/goal_form_sheet.dart
+++ b/lib/features/goals/presentation/widgets/goal_form_sheet.dart
@@ -11,15 +11,35 @@ import 'package:poka_ce/theme/theme.dart';
 /// Bottom sheet for creating or editing a savings goal.
 /// When creating, the system automatically generates a linked Pocket account.
 class GoalFormSheet extends HookConsumerWidget {
-  const GoalFormSheet({super.key, this.initialGoal});
+  const GoalFormSheet({
+    super.key,
+    this.initialGoal,
+    this.initialName,
+    this.initialTargetAmount,
+    this.initialTargetDate,
+  });
 
   final GoalModel? initialGoal;
+  final String? initialName;
+  final int? initialTargetAmount;
+  final DateTime? initialTargetDate;
 
   /// Shows the sheet and returns when the user dismisses or saves.
-  static Future<void> show(BuildContext context, {GoalModel? initialGoal}) {
+  static Future<void> show(
+    BuildContext context, {
+    GoalModel? initialGoal,
+    String? initialName,
+    int? initialTargetAmount,
+    DateTime? initialTargetDate,
+  }) {
     return showPokaSheet(
       context: context,
-      builder: (context) => GoalFormSheet(initialGoal: initialGoal),
+      builder: (context) => GoalFormSheet(
+        initialGoal: initialGoal,
+        initialName: initialName,
+        initialTargetAmount: initialTargetAmount,
+        initialTargetDate: initialTargetDate,
+      ),
     );
   }
 
@@ -30,15 +50,24 @@ class GoalFormSheet extends HookConsumerWidget {
 
     // Initialise the notifier once with the given goal.
     useEffect(() {
-      Future.microtask(() => notifier.init(initialGoal));
+      Future.microtask(
+        () => notifier.init(
+          initialGoal,
+          initialName: initialName,
+          initialTargetAmount: initialTargetAmount,
+          initialTargetDate: initialTargetDate,
+        ),
+      );
       return null;
-    }, [initialGoal]);
+    }, [initialGoal, initialName, initialTargetAmount, initialTargetDate]);
 
-    final nameController = useTextEditingController(text: initialGoal?.name ?? state.name);
+    final nameController = useTextEditingController(text: initialGoal?.name ?? initialName ?? state.name);
     final amountController = useTextEditingController(
       text: initialGoal != null && initialGoal!.targetAmount > 0
           ? initialGoal!.targetAmount.toString()
-          : (state.targetAmount > 0 ? state.targetAmount.toString() : ''),
+          : (initialTargetAmount != null && initialTargetAmount! > 0
+                ? initialTargetAmount.toString()
+                : (state.targetAmount > 0 ? state.targetAmount.toString() : '')),
     );
 
     // Sync controllers → notifier.

--- a/lib/features/transactions/presentation/controllers/transaction_form_notifier.dart
+++ b/lib/features/transactions/presentation/controllers/transaction_form_notifier.dart
@@ -19,6 +19,9 @@ class TransactionFormArgs {
     this.initialAmount,
     this.initialNote,
     this.initialAccountId,
+    this.initialDestinationAccountId,
+    this.initialCategoryId,
+    this.initialDate,
   });
 
   final TransactionType? initialType;
@@ -26,6 +29,9 @@ class TransactionFormArgs {
   final String? initialAmount;
   final String? initialNote;
   final String? initialAccountId;
+  final String? initialDestinationAccountId;
+  final String? initialCategoryId;
+  final DateTime? initialDate;
 
   @override
   bool operator ==(Object other) =>
@@ -36,7 +42,10 @@ class TransactionFormArgs {
           initialTransaction == other.initialTransaction &&
           initialAmount == other.initialAmount &&
           initialNote == other.initialNote &&
-          initialAccountId == other.initialAccountId;
+          initialAccountId == other.initialAccountId &&
+          initialDestinationAccountId == other.initialDestinationAccountId &&
+          initialCategoryId == other.initialCategoryId &&
+          initialDate == other.initialDate;
 
   @override
   int get hashCode =>
@@ -44,7 +53,10 @@ class TransactionFormArgs {
       initialTransaction.hashCode ^
       initialAmount.hashCode ^
       initialNote.hashCode ^
-      initialAccountId.hashCode;
+      initialAccountId.hashCode ^
+      initialDestinationAccountId.hashCode ^
+      initialCategoryId.hashCode ^
+      initialDate.hashCode;
 }
 
 @immutable
@@ -136,7 +148,7 @@ class TransactionFormNotifier extends _$TransactionFormNotifier {
         ? initialTransaction.items.first.allocation
         : null;
 
-    final initialDate = initialTransaction?.transactionDate.toLocal() ?? DateTime.now();
+    final initialDate = initialTransaction?.transactionDate.toLocal() ?? args.initialDate ?? DateTime.now();
 
     return TransactionFormState(
       type: initialTransaction?.type ?? args.initialType ?? TransactionType.expense,
@@ -144,8 +156,10 @@ class TransactionFormNotifier extends _$TransactionFormNotifier {
       note: initialTransaction?.note ?? args.initialNote ?? '',
       date: initialDate,
       accountId: initialTransaction?.accountId ?? args.initialAccountId,
-      destinationAccountId: initialTransaction?.destinationAccountId,
-      categoryId: initialTransaction?.items.isNotEmpty == true ? initialTransaction?.items.first.categoryId : null,
+      destinationAccountId: initialTransaction?.destinationAccountId ?? args.initialDestinationAccountId,
+      categoryId: initialTransaction?.items.isNotEmpty == true
+          ? initialTransaction?.items.first.categoryId
+          : args.initialCategoryId,
       allocation: initialAllocation,
       splitItems: initialSplits,
     );

--- a/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
@@ -31,6 +31,9 @@ class TransactionFormSheet extends HookConsumerWidget {
     this.initialAmount,
     this.initialNote,
     this.initialAccountId,
+    this.initialDestinationAccountId,
+    this.initialCategoryId,
+    this.initialDate,
   });
 
   final TransactionType? initialType;
@@ -38,6 +41,9 @@ class TransactionFormSheet extends HookConsumerWidget {
   final String? initialAmount;
   final String? initialNote;
   final String? initialAccountId;
+  final String? initialDestinationAccountId;
+  final String? initialCategoryId;
+  final DateTime? initialDate;
 
   static Future<bool?> show(
     BuildContext context, {
@@ -46,6 +52,9 @@ class TransactionFormSheet extends HookConsumerWidget {
     String? initialAmount,
     String? initialNote,
     String? initialAccountId,
+    String? initialDestinationAccountId,
+    String? initialCategoryId,
+    DateTime? initialDate,
   }) {
     return showPokaSheet<bool>(
       context: context,
@@ -59,6 +68,9 @@ class TransactionFormSheet extends HookConsumerWidget {
           initialAmount: initialAmount,
           initialNote: initialNote,
           initialAccountId: initialAccountId,
+          initialDestinationAccountId: initialDestinationAccountId,
+          initialCategoryId: initialCategoryId,
+          initialDate: initialDate,
         ),
       ),
     );
@@ -74,6 +86,9 @@ class TransactionFormSheet extends HookConsumerWidget {
       initialAmount: initialAmount,
       initialNote: initialNote,
       initialAccountId: initialAccountId,
+      initialDestinationAccountId: initialDestinationAccountId,
+      initialCategoryId: initialCategoryId,
+      initialDate: initialDate,
     );
 
     final provider = transactionFormProvider(args);

--- a/test/feature/features/budgets/presentation/widgets/forms/budget_form_sheet_test.dart
+++ b/test/feature/features/budgets/presentation/widgets/forms/budget_form_sheet_test.dart
@@ -458,7 +458,14 @@ class _FakeBudgetFormNotifier extends BudgetFormNotifier {
   @override
   BudgetFormState build() => _state;
   @override
-  void init(BudgetModel? budget) {}
+  void init(
+    BudgetModel? budget, {
+    String? initialName,
+    int? initialAmount,
+    BudgetPeriod? initialPeriod,
+    String? initialCategoryId,
+    String? initialAccountId,
+  }) {}
   @override
   Future<void> save() async {}
 }

--- a/test/feature/features/debts/presentation/widgets/debt_form_sheet_test.dart
+++ b/test/feature/features/debts/presentation/widgets/debt_form_sheet_test.dart
@@ -409,7 +409,16 @@ class _FakeDebtFormNotifier extends DebtForm {
   @override
   DebtFormState build() => _state;
   @override
-  void init(DebtModel? debt) {}
+  void init(
+    DebtModel? debt, {
+    String? initialPersonName,
+    DebtType? initialType,
+    int? initialAmount,
+    DateTime? initialDueDate,
+    String? initialNote,
+    String? initialAccountId,
+    String? initialCategoryId,
+  }) {}
   @override
   Future<void> save() async {}
 }


### PR DESCRIPTION
## 🎯 Description

- Support optional initial prefill parameters on creation form sheets (Budget, Goal, Debt, Category, Transaction).
- Update form notifiers to initialize form states with draft parameters when provided.
- Update unit and widget test suites to ensure prefill behavior works as expected.

## 🚀 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🛠️ Testing Instructions

1. Run `make check` -> Reports "No issues found!".
2. Run `make test:unit` -> All unit tests pass.
3. Run `make test:feature` -> All feature tests pass.
4. Verify calling `show()` on any creation sheet with initial values properly prefills the form inputs.

## ✅ Checklist

### Mandatory

- [x] `make fix` — dart fix + format applied
- [x] `make check` — reports **"No issues found!"**
- [x] `make generate` — codegen up to date (if annotated files changed)
- [x] `make test` — all tests pass
- [x] Every new `lib/` file has a matching `test/` file
- [x] My commit messages follow the Conventional Commits format (`feat:`)

### Code Quality

- [x] No Material widgets (`Scaffold`, `AppBar`, `ElevatedButton`, `Card`) — ForUI only
- [x] No shadows (`boxShadow`, `elevation > 0`, `PhysicalModel`)
- [x] No hardcoded colors (`Color(0xFF...)`, `Colors.white/black/grey`) outside `lib/theme/`
- [x] No inline typography (`TextStyle(fontSize: N)`, `fontWeight`) outside `lib/theme/`
- [x] No ForUI component styled inline — used `dart run forui style create <component>` instead
- [x] No `throw` inside a Repository or Notifier
- [x] No `print()` or `debugPrint()` — uses `talker`
- [x] No `dynamic` type anywhere
- [x] No sync logic, cloud integration, or multi-currency support
- [x] No Drift `*Data` class passed to or imported in a Widget/Screen — use Freezed domain models from `domain/` instead

---
<!-- pr-agent:describe -->