### PR TITLE
fix: resolve database integrity, balance reversals, and recurring date drifts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ uninstall:
 generate:
 	rm -f lib/i18n/*.g.dart
 	dart run build_runner build
+	dart run slang
 	dart format .
 
 assets:

--- a/lib/database/daos/debts_dao.dart
+++ b/lib/database/daos/debts_dao.dart
@@ -1,12 +1,13 @@
 import 'package:drift/drift.dart';
 import 'package:poka_ce/database/database.dart';
 import 'package:poka_ce/database/tables/accounts_table.dart';
+import 'package:poka_ce/database/tables/budgets_table.dart';
 import 'package:poka_ce/database/tables/debts_table.dart';
 import 'package:poka_ce/database/tables/transactions_table.dart';
 
 part 'debts_dao.g.dart';
 
-@DriftAccessor(tables: [Debts, Transactions, TransactionItems, Accounts])
+@DriftAccessor(tables: [Debts, Transactions, TransactionItems, Accounts, Budgets, BudgetRecords])
 class DebtsDao extends DatabaseAccessor<AppDatabase> with _$DebtsDaoMixin {
   DebtsDao(super.attachedDatabase);
 
@@ -38,15 +39,17 @@ class DebtsDao extends DatabaseAccessor<AppDatabase> with _$DebtsDaoMixin {
       final amount = transactionHeader.amount.value;
       final typeStr = transactionHeader.type.value.toString().split('.').last;
 
-      final account = await (select(accounts)..where((a) => a.id.equals(accountId))).getSingle();
-      if (typeStr == 'income') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
-      } else if (typeStr == 'expense') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
+      final account = await (select(accounts)..where((a) => a.id.equals(accountId))).getSingleOrNull();
+      if (account != null) {
+        if (typeStr == 'income') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
+        } else if (typeStr == 'expense') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
+        }
       }
     });
   }
@@ -59,16 +62,48 @@ class DebtsDao extends DatabaseAccessor<AppDatabase> with _$DebtsDaoMixin {
       final relatedTransactions = await (select(transactions)..where((t) => t.debtId.equals(id))).get();
 
       for (final tx in relatedTransactions) {
-        final account = await (select(accounts)..where((a) => a.id.equals(tx.accountId))).getSingle();
+        final account = await (select(accounts)..where((a) => a.id.equals(tx.accountId))).getSingleOrNull();
         final typeStr = tx.type.toString().split('.').last;
-        if (typeStr == 'income') {
-          await (update(accounts)..where((a) => a.id.equals(tx.accountId))).write(
-            AccountsCompanion(balance: Value(account.balance - tx.amount)),
-          );
-        } else if (typeStr == 'expense') {
-          await (update(accounts)..where((a) => a.id.equals(tx.accountId))).write(
-            AccountsCompanion(balance: Value(account.balance + tx.amount)),
-          );
+        if (account != null) {
+          if (typeStr == 'income') {
+            await (update(accounts)..where((a) => a.id.equals(tx.accountId))).write(
+              AccountsCompanion(balance: Value(account.balance - tx.amount)),
+            );
+          } else if (typeStr == 'expense') {
+            await (update(accounts)..where((a) => a.id.equals(tx.accountId))).write(
+              AccountsCompanion(balance: Value(account.balance + tx.amount)),
+            );
+          }
+        }
+
+        if (typeStr == 'expense') {
+          final date = tx.transactionDate;
+          final items = await (select(transactionItems)..where((ti) => ti.transactionId.equals(tx.id))).get();
+
+          for (final item in items) {
+            final itemAmount = item.amount;
+            final catId = item.categoryId;
+
+            final matchingRecords =
+                await (select(budgetRecords).join([
+                        innerJoin(budgets, budgets.id.equalsExp(budgetRecords.budgetId)),
+                      ])
+                      ..where(budgets.accountId.isNull() | budgets.accountId.equals(tx.accountId))
+                      ..where(
+                        budgets.categoryId.isNull() |
+                            (catId == null ? budgets.categoryId.isNull() : budgets.categoryId.equals(catId)),
+                      )
+                      ..where(budgetRecords.periodStart.isSmallerOrEqualValue(date))
+                      ..where(budgetRecords.periodEnd.isBiggerOrEqualValue(date)))
+                    .get();
+
+            for (final recordRow in matchingRecords) {
+              final record = recordRow.readTable(budgetRecords);
+              await (update(budgetRecords)..where((r) => r.id.equals(record.id))).write(
+                BudgetRecordsCompanion(spentAmount: Value(record.spentAmount - itemAmount)),
+              );
+            }
+          }
         }
       }
 

--- a/lib/database/daos/debts_dao.dart
+++ b/lib/database/daos/debts_dao.dart
@@ -51,6 +51,32 @@ class DebtsDao extends DatabaseAccessor<AppDatabase> with _$DebtsDaoMixin {
           )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
         }
       }
+
+      if (typeStr == 'expense') {
+        final date = transactionHeader.transactionDate.value;
+        final itemAmount = transactionItem.amount.value;
+        final catId = transactionItem.categoryId.present ? transactionItem.categoryId.value : null;
+
+        final matchingRecords =
+            await (select(budgetRecords).join([
+                    innerJoin(budgets, budgets.id.equalsExp(budgetRecords.budgetId)),
+                  ])
+                  ..where(budgets.accountId.isNull() | budgets.accountId.equals(accountId))
+                  ..where(
+                    budgets.categoryId.isNull() |
+                        (catId == null ? budgets.categoryId.isNull() : budgets.categoryId.equals(catId)),
+                  )
+                  ..where(budgetRecords.periodStart.isSmallerOrEqualValue(date))
+                  ..where(budgetRecords.periodEnd.isBiggerOrEqualValue(date)))
+                .get();
+
+        for (final recordRow in matchingRecords) {
+          final record = recordRow.readTable(budgetRecords);
+          await (update(budgetRecords)..where((r) => r.id.equals(record.id))).write(
+            BudgetRecordsCompanion(spentAmount: Value(record.spentAmount + itemAmount)),
+          );
+        }
+      }
     });
   }
 

--- a/lib/database/daos/debts_dao.g.dart
+++ b/lib/database/daos/debts_dao.g.dart
@@ -10,6 +10,8 @@ mixin _$DebtsDaoMixin on DatabaseAccessor<AppDatabase> {
   $RecurringTransactionsTable get recurringTransactions => attachedDatabase.recurringTransactions;
   $TransactionsTable get transactions => attachedDatabase.transactions;
   $TransactionItemsTable get transactionItems => attachedDatabase.transactionItems;
+  $BudgetsTable get budgets => attachedDatabase.budgets;
+  $BudgetRecordsTable get budgetRecords => attachedDatabase.budgetRecords;
   DebtsDaoManager get managers => DebtsDaoManager(this);
 }
 
@@ -29,4 +31,7 @@ class DebtsDaoManager {
     _db.attachedDatabase,
     _db.transactionItems,
   );
+  $$BudgetsTableTableManager get budgets => $$BudgetsTableTableManager(_db.attachedDatabase, _db.budgets);
+  $$BudgetRecordsTableTableManager get budgetRecords =>
+      $$BudgetRecordsTableTableManager(_db.attachedDatabase, _db.budgetRecords);
 }

--- a/lib/database/daos/transactions_dao.dart
+++ b/lib/database/daos/transactions_dao.dart
@@ -156,22 +156,30 @@ class TransactionsDao extends DatabaseAccessor<AppDatabase> with _$TransactionsD
       }
 
       final accountId = transactionHeader.accountId.value;
-      final account = await (select(accounts)..where((a) => a.id.equals(accountId))).getSingle();
+      final account = await (select(accounts)..where((a) => a.id.equals(accountId))).getSingleOrNull();
 
       // Accessing string value directly since it was mapped by EnumNameConverter
       // We will assume the type string equals to lowercase enum name
       final typeStr = transactionHeader.type.value.toString().split('.').last;
       final amount = transactionHeader.amount.value;
 
-      if (typeStr == 'income') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
-      } else if (typeStr == 'expense') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
+      if (account != null) {
+        if (typeStr == 'income') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
+        } else if (typeStr == 'expense') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
+        } else if (typeStr == 'transfer') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
+        }
+      }
 
+      if (typeStr == 'expense') {
         // Accurate Deduction for budgets
         final date = transactionHeader.transactionDate.value;
         for (final item in items) {
@@ -199,29 +207,31 @@ class TransactionsDao extends DatabaseAccessor<AppDatabase> with _$TransactionsD
           }
         }
       } else if (typeStr == 'transfer') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
-
         if (transactionHeader.destinationAccountId.present && transactionHeader.destinationAccountId.value != null) {
           final destId = transactionHeader.destinationAccountId.value!;
-          final destAccount = await (select(accounts)..where((a) => a.id.equals(destId))).getSingle();
-          await (update(
-            accounts,
-          )..where((a) => a.id.equals(destId))).write(AccountsCompanion(balance: Value(destAccount.balance + amount)));
+          final destAccount = await (select(accounts)..where((a) => a.id.equals(destId))).getSingleOrNull();
+          if (destAccount != null) {
+            await (update(
+              accounts,
+            )..where((a) => a.id.equals(destId))).write(
+              AccountsCompanion(balance: Value(destAccount.balance + amount)),
+            );
+          }
         }
       }
 
       // Debt repayment tracking
       if (transactionHeader.debtId.present && transactionHeader.debtId.value != null) {
         final debtId = transactionHeader.debtId.value!;
-        final debtRow = await (select(debts)..where((d) => d.id.equals(debtId))).getSingle();
-        // Since repayment reduces the remaining amount:
-        final newRemaining = (debtRow.remainingAmount - amount).clamp(0, debtRow.amount);
-        final newStatus = newRemaining == 0 ? DebtStatus.paid : DebtStatus.active;
-        await (update(debts)..where((d) => d.id.equals(debtId))).write(
-          DebtsCompanion(remainingAmount: Value(newRemaining), status: Value(newStatus)),
-        );
+        final debtRow = await (select(debts)..where((d) => d.id.equals(debtId))).getSingleOrNull();
+        if (debtRow != null) {
+          // Since repayment reduces the remaining amount:
+          final newRemaining = (debtRow.remainingAmount - amount).clamp(0, debtRow.amount);
+          final newStatus = newRemaining == 0 ? DebtStatus.paid : DebtStatus.active;
+          await (update(debts)..where((d) => d.id.equals(debtId))).write(
+            DebtsCompanion(remainingAmount: Value(newRemaining), status: Value(newStatus)),
+          );
+        }
       }
     });
   }
@@ -232,20 +242,28 @@ class TransactionsDao extends DatabaseAccessor<AppDatabase> with _$TransactionsD
       if (tx == null) return;
 
       final accountId = tx.accountId;
-      final account = await (select(accounts)..where((a) => a.id.equals(accountId))).getSingle();
+      final account = await (select(accounts)..where((a) => a.id.equals(accountId))).getSingleOrNull();
 
       final typeStr = tx.type.toString().split('.').last;
       final amount = tx.amount;
 
-      if (typeStr == 'income') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
-      } else if (typeStr == 'expense') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
+      if (account != null) {
+        if (typeStr == 'income') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance - amount)));
+        } else if (typeStr == 'expense') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
+        } else if (typeStr == 'transfer') {
+          await (update(
+            accounts,
+          )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
+        }
+      }
 
+      if (typeStr == 'expense') {
         // Revert budget deductions
         final date = tx.transactionDate;
         final items = await getTransactionItems(id);
@@ -275,29 +293,31 @@ class TransactionsDao extends DatabaseAccessor<AppDatabase> with _$TransactionsD
           }
         }
       } else if (typeStr == 'transfer') {
-        await (update(
-          accounts,
-        )..where((a) => a.id.equals(accountId))).write(AccountsCompanion(balance: Value(account.balance + amount)));
-
         if (tx.destinationAccountId != null) {
           final destId = tx.destinationAccountId!;
-          final destAccount = await (select(accounts)..where((a) => a.id.equals(destId))).getSingle();
-          await (update(
-            accounts,
-          )..where((a) => a.id.equals(destId))).write(AccountsCompanion(balance: Value(destAccount.balance - amount)));
+          final destAccount = await (select(accounts)..where((a) => a.id.equals(destId))).getSingleOrNull();
+          if (destAccount != null) {
+            await (update(
+              accounts,
+            )..where((a) => a.id.equals(destId))).write(
+              AccountsCompanion(balance: Value(destAccount.balance - amount)),
+            );
+          }
         }
       }
 
       // Revert debt repayment
       if (tx.debtId != null) {
         final debtId = tx.debtId!;
-        final debtRow = await (select(debts)..where((d) => d.id.equals(debtId))).getSingle();
-        // Since repayment was deleted, we increase the remaining amount
-        final newRemaining = (debtRow.remainingAmount + amount).clamp(0, debtRow.amount);
-        final newStatus = newRemaining == 0 ? DebtStatus.paid : DebtStatus.active;
-        await (update(debts)..where((d) => d.id.equals(debtId))).write(
-          DebtsCompanion(remainingAmount: Value(newRemaining), status: Value(newStatus)),
-        );
+        final debtRow = await (select(debts)..where((d) => d.id.equals(debtId))).getSingleOrNull();
+        if (debtRow != null) {
+          // Since repayment was deleted, we increase the remaining amount
+          final newRemaining = (debtRow.remainingAmount + amount).clamp(0, debtRow.amount);
+          final newStatus = newRemaining == 0 ? DebtStatus.paid : DebtStatus.active;
+          await (update(debts)..where((d) => d.id.equals(debtId))).write(
+            DebtsCompanion(remainingAmount: Value(newRemaining), status: Value(newStatus)),
+          );
+        }
       }
 
       await (delete(transactions)..where((t) => t.id.equals(id))).go();

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -2362,7 +2362,7 @@ class $BudgetsTable extends Budgets with TableInfo<$BudgetsTable, Budget> {
     type: DriftSqlType.string,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES accounts (id)',
+      'REFERENCES accounts (id) ON DELETE SET NULL',
     ),
   );
   @override
@@ -3497,7 +3497,7 @@ class $RecurringTransactionsTable extends RecurringTransactions
     type: DriftSqlType.string,
     requiredDuringInsert: true,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES accounts (id)',
+      'REFERENCES accounts (id) ON DELETE CASCADE',
     ),
   );
   static const VerificationMeta _destinationAccountIdMeta = const VerificationMeta('destinationAccountId');
@@ -3509,7 +3509,7 @@ class $RecurringTransactionsTable extends RecurringTransactions
     type: DriftSqlType.string,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES accounts (id)',
+      'REFERENCES accounts (id) ON DELETE SET NULL',
     ),
   );
   static const VerificationMeta _categoryIdMeta = const VerificationMeta(
@@ -3523,7 +3523,7 @@ class $RecurringTransactionsTable extends RecurringTransactions
     type: DriftSqlType.string,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES categories (id)',
+      'REFERENCES categories (id) ON DELETE SET NULL',
     ),
   );
   @override
@@ -4941,7 +4941,7 @@ class $TransactionsTable extends Transactions with TableInfo<$TransactionsTable,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES recurring_transactions (id)',
+      'REFERENCES recurring_transactions (id) ON DELETE SET NULL',
     ),
   );
   static const VerificationMeta _debtIdMeta = const VerificationMeta('debtId');
@@ -4953,7 +4953,7 @@ class $TransactionsTable extends Transactions with TableInfo<$TransactionsTable,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES debts (id)',
+      'REFERENCES debts (id) ON DELETE SET NULL',
     ),
   );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
@@ -6726,6 +6726,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     ),
     WritePropagation(
       on: TableUpdateQuery.onTableName(
+        'accounts',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('budgets', kind: UpdateKind.update)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
         'budgets',
         limitUpdateKind: UpdateKind.delete,
       ),
@@ -6736,6 +6743,27 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         'accounts',
         limitUpdateKind: UpdateKind.delete,
       ),
+      result: [TableUpdate('recurring_transactions', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'accounts',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('recurring_transactions', kind: UpdateKind.update)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'categories',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('recurring_transactions', kind: UpdateKind.update)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'accounts',
+        limitUpdateKind: UpdateKind.delete,
+      ),
       result: [TableUpdate('transactions', kind: UpdateKind.delete)],
     ),
     WritePropagation(
@@ -6744,6 +6772,20 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('transactions', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'recurring_transactions',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('transactions', kind: UpdateKind.update)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'debts',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('transactions', kind: UpdateKind.update)],
     ),
     WritePropagation(
       on: TableUpdateQuery.onTableName(

--- a/lib/database/tables/budgets_table.dart
+++ b/lib/database/tables/budgets_table.dart
@@ -10,7 +10,7 @@ class Budgets extends Table {
   TextColumn get name => text()();
   IntColumn get amount => integer()();
   TextColumn get categoryId => text().nullable().references(Categories, #id, onDelete: KeyAction.setNull)();
-  TextColumn get accountId => text().nullable().references(Accounts, #id)();
+  TextColumn get accountId => text().nullable().references(Accounts, #id, onDelete: KeyAction.setNull)();
   TextColumn get period => text().map(const EnumNameConverter(BudgetPeriod.values))();
   IntColumn get resetDay => integer().nullable()();
   IntColumn get alertThreshold => integer().nullable()();

--- a/lib/database/tables/recurring_table.dart
+++ b/lib/database/tables/recurring_table.dart
@@ -8,11 +8,11 @@ import 'package:uuid/uuid.dart';
 class RecurringTransactions extends Table {
   TextColumn get id => text().clientDefault(() => const Uuid().v7())();
   @ReferenceName('recurringSource')
-  TextColumn get accountId => text().references(Accounts, #id)();
+  TextColumn get accountId => text().references(Accounts, #id, onDelete: KeyAction.cascade)();
 
   @ReferenceName('recurringDestination')
-  TextColumn get destinationAccountId => text().nullable().references(Accounts, #id)();
-  TextColumn get categoryId => text().nullable().references(Categories, #id)();
+  TextColumn get destinationAccountId => text().nullable().references(Accounts, #id, onDelete: KeyAction.setNull)();
+  TextColumn get categoryId => text().nullable().references(Categories, #id, onDelete: KeyAction.setNull)();
   TextColumn get allocation => text().map(const EnumNameConverter(TransactionAllocation.values)).nullable()();
   TextColumn get type => text().map(const EnumNameConverter(TransactionType.values))();
   IntColumn get amount => integer()();

--- a/lib/database/tables/transactions_table.dart
+++ b/lib/database/tables/transactions_table.dart
@@ -18,8 +18,9 @@ class Transactions extends Table {
   IntColumn get amount => integer()();
   DateTimeColumn get transactionDate => dateTime()();
   TextColumn get note => text().nullable()();
-  TextColumn get recurringTransactionId => text().nullable().references(RecurringTransactions, #id)();
-  TextColumn get debtId => text().nullable().references(Debts, #id)();
+  TextColumn get recurringTransactionId =>
+      text().nullable().references(RecurringTransactions, #id, onDelete: KeyAction.setNull)();
+  TextColumn get debtId => text().nullable().references(Debts, #id, onDelete: KeyAction.setNull)();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 

--- a/lib/features/accounts/data/account_repository_impl.dart
+++ b/lib/features/accounts/data/account_repository_impl.dart
@@ -65,6 +65,7 @@ class AccountRepositoryImpl implements IAccountRepository {
           name: model.name,
           type: model.type,
           balance: Value(model.balance),
+          initialBalance: Value(model.initialBalance),
           icon: Value(model.icon),
           color: Value(model.color),
           parentId: Value(model.parentId),
@@ -94,6 +95,7 @@ class AccountRepositoryImpl implements IAccountRepository {
           name: Value(model.name),
           type: Value(model.type),
           balance: Value(model.balance),
+          initialBalance: Value(model.initialBalance),
           icon: Value(model.icon),
           color: Value(model.color),
           parentId: Value(model.parentId),
@@ -103,9 +105,7 @@ class AccountRepositoryImpl implements IAccountRepository {
         ),
       );
 
-      if (model.restrictedCategoryIds.isNotEmpty) {
-        await _dao.setAccountCategories(model.id, model.restrictedCategoryIds);
-      }
+      await _dao.setAccountCategories(model.id, model.restrictedCategoryIds);
       return const Success(null);
     } on Exception catch (e, st) {
       talker.handle(e, st, 'AccountRepositoryImpl.updateAccount');

--- a/lib/features/budgets/presentation/controllers/budget_form_notifier.g.dart
+++ b/lib/features/budgets/presentation/controllers/budget_form_notifier.g.dart
@@ -40,7 +40,7 @@ final class BudgetFormNotifierProvider extends $NotifierProvider<BudgetFormNotif
   }
 }
 
-String _$budgetFormNotifierHash() => r'685138d2aef7b65fa31c04ed68b0b63f65be75b9';
+String _$budgetFormNotifierHash() => r'8cf79a6898a5405a41c356252bd0f92527dc00b6';
 
 abstract class _$BudgetFormNotifier extends $Notifier<BudgetFormState> {
   BudgetFormState build();

--- a/lib/features/budgets/presentation/controllers/budget_list_notifier.g.dart
+++ b/lib/features/budgets/presentation/controllers/budget_list_notifier.g.dart
@@ -32,7 +32,7 @@ final class BudgetListNotifierProvider extends $AsyncNotifierProvider<BudgetList
   BudgetListNotifier create() => BudgetListNotifier();
 }
 
-String _$budgetListNotifierHash() => r'94eb9ac9c385600806669935a85cb38459ca3435';
+String _$budgetListNotifierHash() => r'b367f8af97e0d2c614793f16369585253e7ffbda';
 
 abstract class _$BudgetListNotifier extends $AsyncNotifier<List<BudgetModel>> {
   FutureOr<List<BudgetModel>> build();

--- a/lib/features/categories/presentation/controllers/category_form_notifier.g.dart
+++ b/lib/features/categories/presentation/controllers/category_form_notifier.g.dart
@@ -46,7 +46,7 @@ final class CategoryFormNotifierProvider extends $NotifierProvider<CategoryFormN
   }
 }
 
-String _$categoryFormNotifierHash() => r'6ea130ea5f22e3b1cde40110083ecf4ffb0a2ada';
+String _$categoryFormNotifierHash() => r'ae20726264e8047db540260b8791cc45ddbba8f8';
 
 /// Notifier for the category creation and editing form.
 /// Manages form state, validation (e.g., empty name), and orchestrates save operations.

--- a/lib/features/categories/presentation/controllers/category_list_notifier.g.dart
+++ b/lib/features/categories/presentation/controllers/category_list_notifier.g.dart
@@ -38,7 +38,7 @@ final class CategoryListNotifierProvider extends $AsyncNotifierProvider<Category
   CategoryListNotifier create() => CategoryListNotifier();
 }
 
-String _$categoryListNotifierHash() => r'9808309d774dc75ab01b61f68bcd9d62ed973d29';
+String _$categoryListNotifierHash() => r'05f7e3f47590be9540d79e0f0623a3148e1e0859';
 
 /// StateNotifier for managing the list of categories.
 /// Handles fetching, refreshing, toggling active status, deleting, and reordering.

--- a/lib/features/dashboard/presentation/controllers/dashboard_notifier.g.dart
+++ b/lib/features/dashboard/presentation/controllers/dashboard_notifier.g.dart
@@ -40,7 +40,7 @@ final class DashboardNotifierProvider extends $NotifierProvider<DashboardNotifie
   }
 }
 
-String _$dashboardNotifierHash() => r'9f54a5fbe59b2fd63aef72f0f560886b821f6b42';
+String _$dashboardNotifierHash() => r'a6f2d2e4de7242c5b05e95e8acfda78486de5154';
 
 abstract class _$DashboardNotifier extends $Notifier<DashboardState> {
   DashboardState build();

--- a/lib/features/debts/presentation/controllers/debt_detail_notifier.g.dart
+++ b/lib/features/debts/presentation/controllers/debt_detail_notifier.g.dart
@@ -60,7 +60,7 @@ final class DebtTransactionsProvider
   }
 }
 
-String _$debtTransactionsHash() => r'3773a86994d979998ccbcb2432ade641b432f21f';
+String _$debtTransactionsHash() => r'c7a343ff8ab18e30fdda8263ba69aff33d656dff';
 
 final class DebtTransactionsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<TransactionModel>>, DebtModel> {

--- a/lib/features/debts/presentation/controllers/debt_form_notifier.g.dart
+++ b/lib/features/debts/presentation/controllers/debt_form_notifier.g.dart
@@ -40,7 +40,7 @@ final class DebtFormProvider extends $NotifierProvider<DebtForm, DebtFormState> 
   }
 }
 
-String _$debtFormHash() => r'e6608128d2a9bc26f2441a6248789ca2e8faab62';
+String _$debtFormHash() => r'50f53bc3bc36ff211f921094968bd3eb3257e13d';
 
 abstract class _$DebtForm extends $Notifier<DebtFormState> {
   DebtFormState build();

--- a/lib/features/goals/presentation/controllers/goal_detail_notifier.g.dart
+++ b/lib/features/goals/presentation/controllers/goal_detail_notifier.g.dart
@@ -60,7 +60,7 @@ final class GoalTransactionsProvider
   }
 }
 
-String _$goalTransactionsHash() => r'eab7d2207015a5435fcda57c96943a84b88908e2';
+String _$goalTransactionsHash() => r'c38f6d823473ece186f45bed0e924b0ccae31816';
 
 final class GoalTransactionsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<TransactionModel>>, GoalModel> {

--- a/lib/features/goals/presentation/controllers/goal_form_notifier.g.dart
+++ b/lib/features/goals/presentation/controllers/goal_form_notifier.g.dart
@@ -40,7 +40,7 @@ final class GoalFormNotifierProvider extends $NotifierProvider<GoalFormNotifier,
   }
 }
 
-String _$goalFormNotifierHash() => r'87104741e54a8bae629b3021d41b7941ef212fdd';
+String _$goalFormNotifierHash() => r'bc200a4ba361abfeda2c5c46e210747cbdd06a34';
 
 abstract class _$GoalFormNotifier extends $Notifier<GoalFormState> {
   GoalFormState build();

--- a/lib/features/recurring/domain/recurring_processor_service.dart
+++ b/lib/features/recurring/domain/recurring_processor_service.dart
@@ -114,22 +114,37 @@ class RecurringProcessorService {
     return switch (period) {
       RecurringPeriod.daily => current.add(const Duration(days: 1)),
       RecurringPeriod.weekly => current.add(const Duration(days: 7)),
-      RecurringPeriod.monthly => DateTime.utc(
-        current.year,
-        current.month + 1,
-        current.day,
-        current.hour,
-        current.minute,
-        current.second,
-      ),
-      RecurringPeriod.yearly => DateTime.utc(
-        current.year + 1,
-        current.month,
-        current.day,
-        current.hour,
-        current.minute,
-        current.second,
-      ),
+      RecurringPeriod.monthly => () {
+        var nextYear = current.year;
+        var nextMonth = current.month + 1;
+        if (nextMonth > 12) {
+          nextMonth = 1;
+          nextYear++;
+        }
+        final daysInNextMonth = DateTime.utc(nextYear, nextMonth + 1, 0).day;
+        final nextDay = current.day > daysInNextMonth ? daysInNextMonth : current.day;
+        return DateTime.utc(
+          nextYear,
+          nextMonth,
+          nextDay,
+          current.hour,
+          current.minute,
+          current.second,
+        );
+      }(),
+      RecurringPeriod.yearly => () {
+        final nextYear = current.year + 1;
+        final daysInTargetMonth = DateTime.utc(nextYear, current.month + 1, 0).day;
+        final nextDay = current.day > daysInTargetMonth ? daysInTargetMonth : current.day;
+        return DateTime.utc(
+          nextYear,
+          current.month,
+          nextDay,
+          current.hour,
+          current.minute,
+          current.second,
+        );
+      }(),
     };
   }
 }

--- a/lib/features/recurring/presentation/controllers/recurring_detail_notifier.g.dart
+++ b/lib/features/recurring/presentation/controllers/recurring_detail_notifier.g.dart
@@ -60,7 +60,7 @@ final class RecurringTransactionsProvider
   }
 }
 
-String _$recurringTransactionsHash() => r'26a9c0db7a7ea9cc1baa6c895e61c60f15d3ec5d';
+String _$recurringTransactionsHash() => r'678daf4133a51e195353df7c7b3bea5af1012f24';
 
 final class RecurringTransactionsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<TransactionModel>>, RecurringTransactionModel> {

--- a/lib/features/transactions/presentation/controllers/transaction_form_notifier.dart
+++ b/lib/features/transactions/presentation/controllers/transaction_form_notifier.dart
@@ -282,6 +282,7 @@ class TransactionFormNotifier extends _$TransactionFormNotifier {
                 sourceAccountId: state.accountId!,
                 destinationAccountId: catId!, // Reusing categoryId as destination for transfer
                 note: state.note.isNotEmpty ? state.note : null,
+                transactionDate: state.date,
               );
         }
       } else {
@@ -352,6 +353,7 @@ class TransactionFormNotifier extends _$TransactionFormNotifier {
               type: state.type,
               accountId: state.accountId!,
               transactionDate: state.date,
+              note: state.note.isNotEmpty ? state.note : null,
               splitItems: splitData,
             );
       } else {
@@ -362,6 +364,7 @@ class TransactionFormNotifier extends _$TransactionFormNotifier {
               type: state.type,
               accountId: state.accountId!,
               transactionDate: state.date,
+              note: state.note.isNotEmpty ? state.note : null,
               splitItems: splitData,
             );
       }

--- a/lib/features/transactions/presentation/controllers/transaction_form_notifier.g.dart
+++ b/lib/features/transactions/presentation/controllers/transaction_form_notifier.g.dart
@@ -57,7 +57,7 @@ final class TransactionFormNotifierProvider extends $NotifierProvider<Transactio
   }
 }
 
-String _$transactionFormNotifierHash() => r'4713c39d5436609e2f5336f0763452d1abc491d5';
+String _$transactionFormNotifierHash() => r'b23c76ff47eaae665bf1827f070bc66f0406e9a6';
 
 final class TransactionFormNotifierFamily extends $Family
     with

--- a/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
@@ -209,6 +209,20 @@ class TransactionFormSheet extends HookConsumerWidget {
       );
     }
 
+    final selectedAccount = accounts.where((a) => a.id == state.accountId).firstOrNull;
+    final parentAccount = selectedAccount?.parentId != null
+        ? accounts.where((a) => a.id == selectedAccount!.parentId).firstOrNull
+        : null;
+    final allowedCategoryIds = selectedAccount?.effectiveRestrictedCategoryIds(parentAccount) ?? const <String>[];
+
+    final filteredCategories = categories.where((c) {
+      if (!c.isActive) return false;
+      if (state.type == TransactionType.income && c.type != CategoryType.income) return false;
+      if (state.type == TransactionType.expense && c.type != CategoryType.expense) return false;
+      if (allowedCategoryIds.isNotEmpty && !allowedCategoryIds.contains(c.id)) return false;
+      return true;
+    }).toList();
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -293,12 +307,7 @@ class TransactionFormSheet extends HookConsumerWidget {
             typeColor: typeColor,
             allocation: state.allocation,
             currencyCode: currencyCode,
-            categories: categories.where((c) {
-              if (!c.isActive) return false;
-              if (state.type == TransactionType.income) return c.type == CategoryType.income;
-              if (state.type == TransactionType.expense) return c.type == CategoryType.expense;
-              return false;
-            }).toList(),
+            categories: filteredCategories,
             selectedCategoryId: state.categoryId,
             isLoading: state.isLoading,
             showSplitButton: state.type == TransactionType.expense,

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 2
 /// Strings: 950 (475 per locale)
 ///
-/// Built on 2026-09-02 at 06:13 UTC
+/// Built on 2026-09-07 at 14:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/test/e2e/features/recurring/recurring_e2e_test.dart
+++ b/test/e2e/features/recurring/recurring_e2e_test.dart
@@ -8,7 +8,7 @@ import '../../test_setup.dart';
 
 void main() {
   testWidgets('Recurring CRUD operations', (tester) async {
-    await pumpAppForTesting(tester);
+    final db = await pumpAppForTesting(tester);
     Future<void> settle() => tester.pumpAndSettle(const Duration(milliseconds: 200));
     await settle();
 
@@ -131,5 +131,7 @@ void main() {
 
     // Verify it is deleted
     expect(find.text('Updated Subscription'), findsNothing);
+
+    await tearDownAppForTesting(tester, db);
   });
 }

--- a/test/feature/features/transactions/presentation/widgets/forms/transaction_form_sheet_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/forms/transaction_form_sheet_test.dart
@@ -260,6 +260,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       );
     });
@@ -316,6 +317,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       ).thenAnswer((_) async => Success(sampleTx().copyWith(type: TransactionType.transfer)));
 
@@ -339,6 +341,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       ).called(1);
     });
@@ -468,6 +471,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       );
     });
@@ -479,6 +483,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       ).thenAnswer((_) async => const ErrorResult<TransactionModel, Failure>(DatabaseFailure('db error')));
 
@@ -499,6 +504,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       ).called(1);
     });

--- a/test/unit/database/daos/debts_dao_test.dart
+++ b/test/unit/database/daos/debts_dao_test.dart
@@ -262,5 +262,84 @@ void main() {
       acc = await (db.select(db.accounts)..where((a) => a.id.equals('acc1'))).getSingle();
       expect(acc.balance, 100000);
     });
+
+    test('insertDebtWithTransaction and deleteDebtWithTransactionReversal update budget records', () async {
+      await db
+          .into(db.accounts)
+          .insert(
+            AccountsCompanion.insert(
+              id: const Value('acc1'),
+              name: 'Wallet',
+              type: AccountType.assets,
+              balance: const Value(100000),
+            ),
+          );
+
+      // Create a monthly budget covering this period
+      final now = DateTime.now().toUtc();
+      final start = DateTime.utc(now.year, now.month, 1);
+      final end = DateTime.utc(now.year, now.month + 1, 0, 23, 59, 59);
+      await db
+          .into(db.budgets)
+          .insert(
+            BudgetsCompanion.insert(
+              id: const Value('b1'),
+              name: 'General Spending',
+              amount: 500000,
+              period: BudgetPeriod.monthly,
+              resetDay: const Value(1),
+              alertThreshold: const Value(80),
+              startDate: start,
+              endDate: Value(end),
+            ),
+          );
+      await db
+          .into(db.budgetRecords)
+          .insert(
+            BudgetRecordsCompanion.insert(
+              id: const Value('br1'),
+              budgetId: 'b1',
+              periodStart: start,
+              periodEnd: end,
+              spentAmount: const Value(0),
+            ),
+          );
+
+      // Loan -> expense of 30,000 -> balance becomes 70,000, budget spent becomes 30,000
+      final debt = DebtsCompanion.insert(
+        id: const Value('d1'),
+        personName: 'Dave',
+        type: DebtType.loan,
+        amount: 30000,
+        remainingAmount: 30000,
+        status: DebtStatus.active,
+      );
+
+      final tx = TransactionsCompanion.insert(
+        id: const Value('tx1'),
+        accountId: 'acc1',
+        type: TransactionType.expense,
+        amount: 30000,
+        debtId: const Value('d1'),
+        transactionDate: now,
+      );
+
+      final item = TransactionItemsCompanion.insert(
+        id: const Value('item1'),
+        transactionId: 'tx1',
+        amount: 30000,
+      );
+
+      await db.debtsDao.insertDebtWithTransaction(debt, tx, item);
+
+      var br = await (db.select(db.budgetRecords)..where((r) => r.id.equals('br1'))).getSingle();
+      expect(br.spentAmount, 30000);
+
+      // Reversal should subtract the 30,000 back to 0
+      await db.debtsDao.deleteDebtWithTransactionReversal('d1');
+
+      br = await (db.select(db.budgetRecords)..where((r) => r.id.equals('br1'))).getSingle();
+      expect(br.spentAmount, 0);
+    });
   });
 }

--- a/test/unit/database/daos/debts_dao_test.dart
+++ b/test/unit/database/daos/debts_dao_test.dart
@@ -160,5 +160,107 @@ void main() {
       expect(d!.dueDate!.toUtc(), due.toUtc());
       expect(d.note, 'urgent');
     });
+
+    test('insertDebtWithTransaction for debt creates income and increases balance', () async {
+      await db
+          .into(db.accounts)
+          .insert(
+            AccountsCompanion.insert(
+              id: const Value('acc1'),
+              name: 'Wallet',
+              type: AccountType.assets,
+              balance: const Value(50000),
+            ),
+          );
+
+      final debt = DebtsCompanion.insert(
+        id: const Value('d1'),
+        personName: 'Charlie',
+        type: DebtType.debt,
+        amount: 20000,
+        remainingAmount: 20000,
+        status: DebtStatus.active,
+      );
+
+      final tx = TransactionsCompanion.insert(
+        id: const Value('tx1'),
+        accountId: 'acc1',
+        type: TransactionType.income,
+        amount: 20000,
+        debtId: const Value('d1'),
+        transactionDate: DateTime.now().toUtc(),
+      );
+
+      final item = TransactionItemsCompanion.insert(
+        id: const Value('item1'),
+        transactionId: 'tx1',
+        amount: 20000,
+      );
+
+      await db.debtsDao.insertDebtWithTransaction(debt, tx, item);
+
+      final savedDebt = await db.debtsDao.getDebt('d1');
+      expect(savedDebt, isNotNull);
+      expect(savedDebt!.amount, 20000);
+
+      final savedTx = await db.transactionsDao.getTransaction('tx1');
+      expect(savedTx, isNotNull);
+      expect(savedTx!.amount, 20000);
+
+      final acc = await (db.select(db.accounts)..where((a) => a.id.equals('acc1'))).getSingle();
+      expect(acc.balance, 70000);
+    });
+
+    test('deleteDebtWithTransactionReversal reverts account balance and deletes transactions', () async {
+      await db
+          .into(db.accounts)
+          .insert(
+            AccountsCompanion.insert(
+              id: const Value('acc1'),
+              name: 'Wallet',
+              type: AccountType.assets,
+              balance: const Value(100000),
+            ),
+          );
+
+      // Loan -> expense of 30,000 -> balance becomes 70,000
+      final debt = DebtsCompanion.insert(
+        id: const Value('d1'),
+        personName: 'Dave',
+        type: DebtType.loan,
+        amount: 30000,
+        remainingAmount: 30000,
+        status: DebtStatus.active,
+      );
+
+      final tx = TransactionsCompanion.insert(
+        id: const Value('tx1'),
+        accountId: 'acc1',
+        type: TransactionType.expense,
+        amount: 30000,
+        debtId: const Value('d1'),
+        transactionDate: DateTime.now().toUtc(),
+      );
+
+      final item = TransactionItemsCompanion.insert(
+        id: const Value('item1'),
+        transactionId: 'tx1',
+        amount: 30000,
+      );
+
+      await db.debtsDao.insertDebtWithTransaction(debt, tx, item);
+      var acc = await (db.select(db.accounts)..where((a) => a.id.equals('acc1'))).getSingle();
+      expect(acc.balance, 70000);
+
+      // Delete debt with reversal
+      await db.debtsDao.deleteDebtWithTransactionReversal('d1');
+
+      expect(await db.debtsDao.getDebt('d1'), isNull);
+      expect(await db.transactionsDao.getTransaction('tx1'), isNull);
+
+      // Balance should be reverted back to 100,000
+      acc = await (db.select(db.accounts)..where((a) => a.id.equals('acc1'))).getSingle();
+      expect(acc.balance, 100000);
+    });
   });
 }

--- a/test/unit/database/daos/transactions_dao_delete_test.dart
+++ b/test/unit/database/daos/transactions_dao_delete_test.dart
@@ -163,5 +163,64 @@ void main() {
       expect(list.length, 1);
       expect(list.first.items.length, 2);
     });
+
+    test('deleteTransaction when account is already deleted does not throw', () async {
+      await addAccount('acc1', 10000);
+      await db.transactionsDao.insertTransactionWithItems(
+        TransactionsCompanion.insert(
+          id: const Value('txn1'),
+          accountId: 'acc1',
+          type: TransactionType.income,
+          amount: 5000,
+          transactionDate: DateTime.now().toUtc(),
+        ),
+        [],
+      );
+      // Hard delete the account row directly
+      await (db.delete(db.accounts)..where((a) => a.id.equals('acc1'))).go();
+
+      // Deleting transaction should handle missing account safely without StateError
+      await expectLater(
+        db.transactionsDao.deleteTransaction('txn1'),
+        completes,
+      );
+      expect(await db.transactionsDao.getTransaction('txn1'), isNull);
+    });
+
+    test('deleteTransaction with debtId when debt is already deleted does not throw', () async {
+      await addAccount('acc1', 10000);
+      await db
+          .into(db.debts)
+          .insert(
+            DebtsCompanion.insert(
+              id: const Value('debt1'),
+              personName: 'Bob',
+              type: DebtType.debt,
+              amount: 5000,
+              remainingAmount: 5000,
+              status: DebtStatus.active,
+            ),
+          );
+      await db.transactionsDao.insertTransactionWithItems(
+        TransactionsCompanion.insert(
+          id: const Value('txn1'),
+          accountId: 'acc1',
+          type: TransactionType.income,
+          amount: 5000,
+          debtId: const Value('debt1'),
+          transactionDate: DateTime.now().toUtc(),
+        ),
+        [],
+      );
+      // Delete the debt row first
+      await (db.delete(db.debts)..where((d) => d.id.equals('debt1'))).go();
+
+      // Deleting transaction should handle missing debt safely
+      await expectLater(
+        db.transactionsDao.deleteTransaction('txn1'),
+        completes,
+      );
+      expect(await db.transactionsDao.getTransaction('txn1'), isNull);
+    });
   });
 }

--- a/test/unit/features/accounts/data/account_repository_impl_test.dart
+++ b/test/unit/features/accounts/data/account_repository_impl_test.dart
@@ -67,4 +67,111 @@ void main() {
       (error) => fail('Should not be error'),
     );
   });
+
+  test('createAccount persists initialBalance and category restrictions', () async {
+    // Insert dummy category
+    await db
+        .into(db.categories)
+        .insert(
+          CategoriesCompanion.insert(
+            id: const Value('cat1'),
+            name: 'Food',
+            icon: const Value('fork'),
+            color: const Value('0xFF123456'),
+            type: CategoryType.expense,
+          ),
+        );
+
+    final model = AccountModel(
+      id: 'acc3',
+      name: 'Wallet with Limits',
+      type: AccountType.assets,
+      balance: 150000,
+      initialBalance: 150000,
+      restrictedCategoryIds: ['cat1'],
+      createdAt: DateTimeUtils.nowUtc(),
+      updatedAt: DateTimeUtils.nowUtc(),
+    );
+
+    final result = await repository.createAccount(model);
+    expect(result, isA<Success<void, Failure>>());
+
+    final saved = await (db.select(db.accounts)..where((a) => a.id.equals('acc3'))).getSingle();
+    expect(saved.initialBalance, 150000);
+
+    final fetchedResult = await repository.getAccountById('acc3');
+    expect(fetchedResult, isA<Success<AccountModel, Failure>>());
+    fetchedResult.fold(
+      (value) {
+        expect(value.initialBalance, 150000);
+        expect(value.restrictedCategoryIds, ['cat1']);
+      },
+      (error) => fail('Failed to fetch account'),
+    );
+  });
+
+  test('updateAccount updates initialBalance and clears category restrictions', () async {
+    // Insert dummy categories
+    await db
+        .into(db.categories)
+        .insert(
+          CategoriesCompanion.insert(
+            id: const Value('cat1'),
+            name: 'Food',
+            icon: const Value('fork'),
+            color: const Value('0xFF123456'),
+            type: CategoryType.expense,
+          ),
+        );
+
+    final model = AccountModel(
+      id: 'acc4',
+      name: 'Initial Wallet',
+      type: AccountType.assets,
+      balance: 100000,
+      initialBalance: 100000,
+      restrictedCategoryIds: ['cat1'],
+      createdAt: DateTimeUtils.nowUtc(),
+      updatedAt: DateTimeUtils.nowUtc(),
+    );
+    await repository.createAccount(model);
+
+    // Update with empty restricted categories and new initial balance
+    final updatedModel = model.copyWith(
+      name: 'Updated Wallet',
+      initialBalance: 200000,
+      restrictedCategoryIds: [],
+    );
+    final updateResult = await repository.updateAccount(updatedModel);
+    expect(updateResult, isA<Success<void, Failure>>());
+
+    final fetchedResult = await repository.getAccountById('acc4');
+    expect(fetchedResult, isA<Success<AccountModel, Failure>>());
+    fetchedResult.fold(
+      (value) {
+        expect(value.name, 'Updated Wallet');
+        expect(value.initialBalance, 200000);
+        expect(value.restrictedCategoryIds, isEmpty);
+      },
+      (error) => fail('Failed to fetch account'),
+    );
+  });
+
+  test('deactivateAccount sets isActive to false', () async {
+    final model = AccountModel(
+      id: 'acc5',
+      name: 'Deactivatable',
+      type: AccountType.assets,
+      balance: 50000,
+      createdAt: DateTimeUtils.nowUtc(),
+      updatedAt: DateTimeUtils.nowUtc(),
+    );
+    await repository.createAccount(model);
+
+    final result = await repository.deactivateAccount('acc5');
+    expect(result, isA<Success<void, Failure>>());
+
+    final saved = await (db.select(db.accounts)..where((a) => a.id.equals('acc5'))).getSingle();
+    expect(saved.isActive, isFalse);
+  });
 }

--- a/test/unit/features/recurring/domain/recurring_processor_service_test.dart
+++ b/test/unit/features/recurring/domain/recurring_processor_service_test.dart
@@ -152,6 +152,39 @@ void main() {
         final captured = verify(() => recurringRepo.updateRecurring(captureAny())).captured;
         expect((captured.first as RecurringTransactionModel).nextDate, DateTime.utc(2024, 10, 10));
       });
+
+      test('Monthly advancement clamps days when target month has fewer days', () async {
+        final jan31 = DateTime.utc(2023, 1, 31);
+        final recurring = testRecurring.copyWith(
+          period: RecurringPeriod.monthly,
+          nextDate: jan31,
+        );
+        when(() => recurringRepo.getDueRecurringTransactions(any())).thenAnswer((_) async => Success([recurring]));
+        when(() => transactionRepo.createTransaction(any())).thenAnswer((_) async => const Success(null));
+        when(() => recurringRepo.updateRecurring(any())).thenAnswer((_) async => const Success(null));
+
+        await service.run(jan31);
+
+        final captured = verify(() => recurringRepo.updateRecurring(captureAny())).captured;
+        // 2023 is non-leap year, February has 28 days -> must be Feb 28, not March
+        expect((captured.first as RecurringTransactionModel).nextDate, DateTime.utc(2023, 2, 28));
+      });
+
+      test('Yearly advancement clamps leap day (Feb 29) to Feb 28 in non-leap year', () async {
+        final leapDay = DateTime.utc(2024, 2, 29);
+        final recurring = testRecurring.copyWith(
+          period: RecurringPeriod.yearly,
+          nextDate: leapDay,
+        );
+        when(() => recurringRepo.getDueRecurringTransactions(any())).thenAnswer((_) async => Success([recurring]));
+        when(() => transactionRepo.createTransaction(any())).thenAnswer((_) async => const Success(null));
+        when(() => recurringRepo.updateRecurring(any())).thenAnswer((_) async => const Success(null));
+
+        await service.run(leapDay);
+
+        final captured = verify(() => recurringRepo.updateRecurring(captureAny())).captured;
+        expect((captured.first as RecurringTransactionModel).nextDate, DateTime.utc(2025, 2, 28));
+      });
     });
   });
 }

--- a/test/unit/features/transactions/presentation/controllers/transaction_form_notifier_test.dart
+++ b/test/unit/features/transactions/presentation/controllers/transaction_form_notifier_test.dart
@@ -173,6 +173,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       ).thenAnswer((_) async => Success(sampleTx().copyWith(type: TransactionType.transfer)));
       final container = createContainer();
@@ -195,6 +196,7 @@ void main() {
           sourceAccountId: any(named: 'sourceAccountId'),
           destinationAccountId: any(named: 'destinationAccountId'),
           note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
         ),
       ).thenAnswer((_) async => const ErrorResult<TransactionModel, Failure>(DatabaseFailure('db')));
       final container = createContainer();
@@ -583,6 +585,7 @@ void main() {
           accountId: any(named: 'accountId'),
           transactionDate: any(named: 'transactionDate'),
           splitItems: any(named: 'splitItems'),
+          note: any(named: 'note'),
         ),
       ).thenAnswer((_) async => Success(splitTx()));
 


### PR DESCRIPTION
## Summary
Comprehensive resolution for data integrity, transaction balance mutations, category restrictions, and date calculation bugs across SQLite, DAOs, and repository layers.

Closes #24
Closes #25
Closes #26
Closes #27

---

## Changes

### 1. Database Schema & Foreign Key Constraints (#24)
- **`BudgetsTable`**: Added `onDelete: KeyAction.setNull` to `accountId`. Deleting a parent account preserves the budget without triggering SQLite error 787.
- **`RecurringTransactionsTable`**:
  - Added `onDelete: KeyAction.cascade` to `accountId`.
  - Added `onDelete: KeyAction.setNull` to `destinationAccountId` and `categoryId`.
- **`TransactionsTable`**: Added `onDelete: KeyAction.setNull` to `recurringTransactionId` and `debtId` so physical transaction records remain intact when blueprint/debt records are removed.

### 2. Account Persistence & Category Restrictions (#25)
- **`AccountRepositoryImpl`**:
  - Explicitly persisted `initialBalance` in `AccountsCompanion` on both `createAccount` and `updateAccount`.
  - Consistently invoked `_dao.setAccountCategories` even when an empty list is passed, enabling users to clear previously active category restrictions.
- **`TransactionFormSheet`**:
  - Filtered category list with `selectedAccount.effectiveRestrictedCategoryIds(parentAccount)` so wallets and pockets only expose permitted categories.
- **`TransactionFormNotifier`**:
  - Preserved `transactionDate: state.date` during transfer execution to prevent falling back to `DateTime.now()`.
  - Maintained `note` during split transaction updates.

### 3. StateError Prevention & Debt Budget Reversals (#26)
- **`TransactionsDao`**:
  - Switched from `getSingle()` to `getSingleOrNull()` with null-safety checks when querying accounts and debts during transaction deletion/creation.
- **`DebtsDao`**:
  - Added `Budgets` and `BudgetRecords` access.
  - In `deleteDebtWithTransactionReversal`, safely reversed account balance and reverted corresponding `budget_records` allocations for loan disbursement expenses.

### 4. Recurring Month-End Date Clamping (#27)
- **`RecurringProcessorService`**:
  - Added day-clamping logic for `RecurringPeriod.monthly` and `yearly` to prevent overflow roll-overs (e.g. Jan 31 -> Feb 28/29 instead of March 3; Feb 29 leap year -> Feb 28 non-leap year).

---

## Verification
- `make check` (`flutter analyze`): **No issues found!**
- `make fix` (`dart format .` & `dart fix`): **Clean**
- `flutter test`: **All 87 targeted unit, feature, and E2E tests passed cleanly.**