### PR TITLE
feat: unify and harmonize chart styles across dashboard and reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Reusable `PokaDonutChart` component unifying donut chart styling across Home and Reports with modern slim geometry and crisp section dividers.
+
+### Changed
+
+- Modernized dashboard spending bar chart with subtle background tracks, bottom-aligned fill, and unified 6px border radius.
+- Elevated reports cashflow bar chart with widened rods (13px), consistent top corner radius (6px), and softer gridlines.
+- Harmonized category breakdown chart and summary hero card in reports with unified donut styling.
+
 ## [v0.1.0-beta.5] - 2026-09-08
 
 Comprehensive bilingual localization (English & Indonesian), visual Net Worth sparkline trends, entity creation prefill support, and critical database integrity fixes for transaction reversals and recurring schedules.

--- a/lib/features/dashboard/presentation/widgets/cards/dashboard_spending_chart.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/dashboard_spending_chart.dart
@@ -187,24 +187,33 @@ class DashboardSpendingChart extends HookConsumerWidget {
 
   Widget _buildBar(BuildContext context, String day, double heightRatio, bool isActive) {
     final theme = context.theme;
-    final targetHeight = 12 + (48 * heightRatio);
+    final targetHeight = (8.0 + (52.0 * heightRatio)).clamp(8.0, 60.0);
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        TweenAnimationBuilder<double>(
-          tween: Tween<double>(begin: 0, end: targetHeight),
-          duration: const Duration(milliseconds: 700),
-          curve: Curves.easeOutCubic,
-          builder: (context, height, _) {
-            return Container(
-              width: 32,
-              height: height,
-              decoration: BoxDecoration(
-                color: isActive ? theme.colors.primary : theme.colors.primary.withValues(alpha: 0.2),
-                borderRadius: BorderRadius.circular(6),
-              ),
-            );
-          },
+        Container(
+          width: 28,
+          height: 60,
+          decoration: BoxDecoration(
+            color: theme.colors.muted.withValues(alpha: 0.4),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          alignment: Alignment.bottomCenter,
+          child: TweenAnimationBuilder<double>(
+            tween: Tween<double>(begin: 0, end: targetHeight),
+            duration: const Duration(milliseconds: 700),
+            curve: Curves.easeOutCubic,
+            builder: (context, height, _) {
+              return Container(
+                width: 28,
+                height: height,
+                decoration: BoxDecoration(
+                  color: isActive ? theme.colors.primary : theme.colors.primary.withValues(alpha: 0.35),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+              );
+            },
+          ),
         ),
         const SizedBox(height: 8),
         Text(

--- a/lib/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view.dart
@@ -5,6 +5,7 @@ import 'package:poka_ce/core/extensions/num_extension.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 class DashboardBudgetView extends ConsumerWidget {
@@ -23,19 +24,12 @@ class DashboardBudgetView extends ConsumerWidget {
 
     return Row(
       children: [
-        SizedBox(
-          width: 100,
-          height: 100,
-          child: CustomPaint(
-            painter: DonutChartPainter(
-              proportions: total == 1.0 && needAmt == 0 && wantAmt == 0 && saveAmt == 0
-                  ? [1.0]
-                  : [needAmt / total, wantAmt / total, saveAmt / total],
-              colors: total == 1.0 && needAmt == 0 && wantAmt == 0 && saveAmt == 0
-                  ? [theme.colors.border]
-                  : [theme.colors.primary, theme.colors.app.warning, theme.colors.border],
-            ),
-          ),
+        PokaDonutChart(
+          sections: [
+            if (needAmt > 0) PokaDonutSection(value: needAmt, color: theme.colors.primary),
+            if (wantAmt > 0) PokaDonutSection(value: wantAmt, color: theme.colors.app.warning),
+            if (saveAmt > 0) PokaDonutSection(value: saveAmt, color: theme.colors.border),
+          ],
         ),
         const SizedBox(width: 24),
         Expanded(

--- a/lib/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view.dart
@@ -5,6 +5,7 @@ import 'package:poka_ce/core/extensions/string_extension.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 class DashboardCategoriesView extends ConsumerWidget {
@@ -58,15 +59,8 @@ class DashboardCategoriesView extends ConsumerWidget {
 
     return Row(
       children: [
-        SizedBox(
-          width: 100,
-          height: 100,
-          child: CustomPaint(
-            painter: DonutChartPainter(
-              proportions: categoryData.isEmpty ? [1.0] : categoryData.map((e) => e.ratio).toList(),
-              colors: categoryData.isEmpty ? [theme.colors.border] : categoryData.map((e) => e.color).toList(),
-            ),
-          ),
+        PokaDonutChart(
+          sections: categoryData.map((e) => PokaDonutSection(value: e.ratio, color: e.color)).toList(),
         ),
         const SizedBox(width: 24),
         Expanded(

--- a/lib/features/reports/presentation/widgets/report_cashflow_chart.dart
+++ b/lib/features/reports/presentation/widgets/report_cashflow_chart.dart
@@ -163,7 +163,7 @@ class _CashflowBarChart extends StatelessWidget {
           drawVerticalLine: false,
           horizontalInterval: yMax / 4,
           getDrawingHorizontalLine: (_) => FlLine(
-            color: theme.colors.border.withValues(alpha: 0.4),
+            color: theme.colors.border.withValues(alpha: 0.25),
             strokeWidth: 1,
             dashArray: [4, 4],
           ),
@@ -178,17 +178,17 @@ class _CashflowBarChart extends StatelessWidget {
               BarChartRodData(
                 toY: point.income,
                 color: incomeColor.withValues(alpha: 0.85),
-                width: 9,
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
+                width: 13,
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(6)),
               ),
               BarChartRodData(
                 toY: point.expense,
                 color: expenseColor,
-                width: 9,
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
+                width: 13,
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(6)),
               ),
             ],
-            barsSpace: 3,
+            barsSpace: 4,
           );
         }),
       ),

--- a/lib/features/reports/presentation/widgets/report_category_chart.dart
+++ b/lib/features/reports/presentation/widgets/report_category_chart.dart
@@ -1,4 +1,3 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -7,6 +6,7 @@ import 'package:poka_ce/features/reports/domain/services/report_analytics_servic
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/category_item_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/shared/widgets/poka_icon.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -238,25 +238,16 @@ class _CategoryPieChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // The ranked list below already serves as the full legend (dot + name + amount + %).
-    // Removing the duplicate legend panel here lets the pie chart use the full width.
-    return SizedBox(
-      height: 160,
-      child: PieChart(
-        PieChartData(
-          sectionsSpace: 2,
-          centerSpaceRadius: 44,
-          startDegreeOffset: -90,
-          sections: items.map((item) {
-            return PieChartSectionData(
-              value: item.ratio,
-              color: _parseColor(context, item.color),
-              radius: 38,
-              showTitle: false,
-            );
-          }).toList(),
-        ),
-        duration: const Duration(milliseconds: 600),
-        curve: Curves.easeOutCubic,
+    return Center(
+      child: PokaDonutChart(
+        size: 156,
+        thickness: 18,
+        sections: items.map((item) {
+          return PokaDonutSection(
+            value: item.ratio,
+            color: _parseColor(context, item.color),
+          );
+        }).toList(),
       ),
     );
   }

--- a/lib/features/reports/presentation/widgets/report_summary_card.dart
+++ b/lib/features/reports/presentation/widgets/report_summary_card.dart
@@ -1,4 +1,3 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
@@ -7,6 +6,7 @@ import 'package:poka_ce/features/reports/presentation/controllers/report_notifie
 import 'package:poka_ce/features/reports/presentation/widgets/stat_row_tile.dart';
 import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 /// Cashflow summary hero card — donut chart + income/expense/net rows.
@@ -88,51 +88,27 @@ class ReportSummaryCard extends ConsumerWidget {
             Row(
               children: [
                 // Donut (fl_chart PieChart)
-                SizedBox(
-                  width: 100,
-                  height: 100,
-                  child: Stack(
-                    alignment: Alignment.center,
+                PokaDonutChart(
+                  sections: [
+                    PokaDonutSection(value: incomeVal, color: incomeColor),
+                    PokaDonutSection(value: expenseVal, color: expenseColor),
+                  ],
+                  center: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      PieChart(
-                        PieChartData(
-                          sectionsSpace: 2,
-                          centerSpaceRadius: 34,
-                          startDegreeOffset: -90,
-                          sections: [
-                            PieChartSectionData(
-                              value: incomeVal,
-                              color: incomeColor,
-                              radius: 16,
-                              showTitle: false,
-                            ),
-                            PieChartSectionData(
-                              value: expenseVal,
-                              color: expenseColor,
-                              radius: 16,
-                              showTitle: false,
-                            ),
-                          ],
+                      Text(
+                        '$savingsPct%',
+                        style: theme.typography.bodyPrimary.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: theme.colors.primary,
                         ),
                       ),
-                      Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            '$savingsPct%',
-                            style: theme.typography.bodyPrimary.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: theme.colors.primary,
-                            ),
-                          ),
-                          Text(
-                            t.savingsRate,
-                            style: theme.typography.labelBadge.copyWith(
-                              color: theme.colors.mutedForeground,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ],
+                      Text(
+                        t.savingsRate,
+                        style: theme.typography.labelBadge.copyWith(
+                          color: theme.colors.mutedForeground,
+                        ),
+                        textAlign: TextAlign.center,
                       ),
                     ],
                   ),

--- a/lib/shared/widgets/poka_donut_chart.dart
+++ b/lib/shared/widgets/poka_donut_chart.dart
@@ -1,0 +1,125 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+/// A single slice data representation for [PokaDonutChart].
+class PokaDonutSection {
+  /// Creates a donut chart section.
+  const PokaDonutSection({
+    required this.value,
+    required this.color,
+    this.title,
+  });
+
+  /// Numeric value of this segment. Must be >= 0.
+  final double value;
+
+  /// Color used to render this segment.
+  final Color color;
+
+  /// Optional title string displayed on the section (hidden by default).
+  final String? title;
+}
+
+/// A unified, sleek donut chart component with crisp section dividers.
+///
+/// Combines a slim, modern ring geometry with clean, distinct gaps between slices.
+/// Can optionally host a centered widget (e.g. key metric or icon).
+class PokaDonutChart extends StatelessWidget {
+  /// Creates a [PokaDonutChart].
+  const PokaDonutChart({
+    required this.sections,
+    super.key,
+    this.size = 100,
+    this.thickness = 14,
+    this.sectionsSpace = 2.5,
+    this.startDegreeOffset = -90,
+    this.center,
+    this.emptyColor,
+    this.animationDuration = const Duration(milliseconds: 600),
+  });
+
+  /// Slices to render in the donut.
+  final List<PokaDonutSection> sections;
+
+  /// Diameter (width and height) of the donut chart bounding box.
+  final double size;
+
+  /// Thickness of the outer ring in logical pixels.
+  final double thickness;
+
+  /// Spacing in pixels between adjacent slices, creating crisp divider lines.
+  final double sectionsSpace;
+
+  /// Angle offset in degrees for the first slice. Defaults to -90 (top center).
+  final double startDegreeOffset;
+
+  /// Optional widget rendered in the center hole of the donut.
+  final Widget? center;
+
+  /// Color of the fallback ring shown when there are no valid data sections.
+  final Color? emptyColor;
+
+  /// Duration of the easeOutCubic transition animation when data changes.
+  final Duration animationDuration;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    final validSections = sections.where((s) => s.value > 0).toList();
+    final hasData = validSections.isNotEmpty;
+
+    final fallbackColor = emptyColor ?? theme.colors.border;
+    final centerRadius = ((size / 2) - thickness).clamp(0.0, double.infinity);
+
+    final pieSections = hasData
+        ? validSections.map((s) {
+            return PieChartSectionData(
+              value: s.value,
+              color: s.color,
+              radius: thickness,
+              showTitle: s.title != null,
+              title: s.title,
+            );
+          }).toList()
+        : [
+            PieChartSectionData(
+              value: 1,
+              color: fallbackColor,
+              radius: thickness,
+              showTitle: false,
+            ),
+          ];
+
+    final chart = SizedBox(
+      width: size,
+      height: size,
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: validSections.length > 1 ? sectionsSpace : 0,
+          centerSpaceRadius: centerRadius,
+          startDegreeOffset: startDegreeOffset,
+          sections: pieSections,
+        ),
+        duration: animationDuration,
+        curve: Curves.easeOutCubic,
+      ),
+    );
+
+    if (center != null) {
+      return SizedBox(
+        width: size,
+        height: size,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            chart,
+            center!,
+          ],
+        ),
+      );
+    }
+
+    return chart;
+  }
+}

--- a/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view_test.dart
+++ b/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view.dart';
-import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
@@ -41,7 +41,7 @@ void main() {
       await tester.pumpWidget(createWidget(const DashboardState()));
       await tester.pump();
 
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
       expect(find.text('Needs (50%)'), findsOneWidget);
       expect(find.text('Wants (30%)'), findsOneWidget);
       expect(find.text('Savings (20%)'), findsOneWidget);
@@ -67,7 +67,7 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
       expect(find.text('Needs (50%)'), findsOneWidget);
       expect(find.text('Wants (30%)'), findsOneWidget);
       expect(find.text('Savings (20%)'), findsOneWidget);
@@ -95,7 +95,7 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
       expect(find.text('Needs (50%)'), findsOneWidget);
       // want and saving should be 0
       expect(find.text('0'), findsNWidgets(2));
@@ -114,7 +114,7 @@ void main() {
         ),
       );
       await tester.pump();
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
       expect(find.byType(LinearProgressIndicator), findsNWidgets(3));
     });
 
@@ -131,7 +131,7 @@ void main() {
         ),
       );
       await tester.pump();
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
     });
   });
 }

--- a/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view_test.dart
+++ b/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view_test.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
@@ -38,7 +39,7 @@ void main() {
       await tester.pump();
 
       expect(find.text('No data'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
     });
 
     testWidgets('shows categories with <=3 items no Other', (tester) async {
@@ -60,7 +61,7 @@ void main() {
       expect(find.text('Transport'), findsOneWidget);
       expect(find.text('Entertainment'), findsOneWidget);
       expect(find.text('Other'), findsNothing);
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
       expect(find.byType(LinearProgressIndicator), findsNWidgets(3));
     });
 
@@ -104,7 +105,7 @@ void main() {
 
       // When total is 0, code uses 1.0 as fallback, so should still render
       expect(find.text('Food'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
     });
 
     testWidgets('sorts expenses by amount descending', (tester) async {
@@ -157,7 +158,7 @@ void main() {
       await tester.pump();
 
       expect(find.text('BadColor'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is CustomPaint && w.painter is DonutChartPainter), findsOneWidget);
+      expect(find.byType(PokaDonutChart), findsOneWidget);
     });
   });
 }

--- a/test/feature/shared/widgets/poka_donut_chart_test.dart
+++ b/test/feature/shared/widgets/poka_donut_chart_test.dart
@@ -1,0 +1,108 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+Widget wrap(Widget child) => MaterialApp(
+  builder: (context, c) => FTheme(data: lightTheme, child: c!),
+  home: Scaffold(
+    body: Center(child: child),
+  ),
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PokaDonutChart', () {
+    testWidgets('renders fallback empty ring when sections is empty', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaDonutChart(sections: []),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PieChart), findsOneWidget);
+      final pieChart = tester.widget<PieChart>(find.byType(PieChart));
+      expect(pieChart.data.sections.length, 1);
+      expect(pieChart.data.sections.first.value, 1.0);
+    });
+
+    testWidgets('renders fallback empty ring when all section values are 0', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaDonutChart(
+            sections: [
+              PokaDonutSection(value: 0, color: Colors.blue),
+              PokaDonutSection(value: 0, color: Colors.red),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PieChart), findsOneWidget);
+      final pieChart = tester.widget<PieChart>(find.byType(PieChart));
+      expect(pieChart.data.sections.length, 1);
+    });
+
+    testWidgets('renders single section with sectionsSpace 0', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaDonutChart(
+            sections: [
+              PokaDonutSection(value: 100, color: Colors.green),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PieChart), findsOneWidget);
+      final pieChart = tester.widget<PieChart>(find.byType(PieChart));
+      expect(pieChart.data.sections.length, 1);
+      expect(pieChart.data.sectionsSpace, 0);
+    });
+
+    testWidgets('renders multiple sections with crisp divider spacing', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaDonutChart(
+            sections: [
+              PokaDonutSection(value: 50, color: Colors.blue),
+              PokaDonutSection(value: 30, color: Colors.orange),
+              PokaDonutSection(value: 20, color: Colors.green),
+            ],
+            sectionsSpace: 2.5,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PieChart), findsOneWidget);
+      final pieChart = tester.widget<PieChart>(find.byType(PieChart));
+      expect(pieChart.data.sections.length, 3);
+      expect(pieChart.data.sectionsSpace, 2.5);
+    });
+
+    testWidgets('renders center child widget when provided', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const PokaDonutChart(
+            sections: [
+              PokaDonutSection(value: 60, color: Colors.purple),
+              PokaDonutSection(value: 40, color: Colors.teal),
+            ],
+            center: Text('Center Content'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PieChart), findsOneWidget);
+      expect(find.text('Center Content'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Unifies and modernizes chart designs across Poka CE (Dashboard & Reports), establishing a consistent visual language aligned with ForUI tokens.

### Key Changes
- **Reusable `PokaDonutChart`**: Created a shared component in `lib/shared/widgets/poka_donut_chart.dart` combining modern slim ring geometry (14–18px) with crisp section divider gaps (2.5px).
- **Dashboard Views**: Refactored category and budget views to use `PokaDonutChart`.
- **Dashboard Spending Chart**: Added subtle background pill tracks (`width: 28`, `height: 60`) behind daily spending bars with bottom-aligned fill and 6px border radius.
- **Reports Cashflow Chart**: Widened bar rods from `9px` to `13px`, standardized top corner radius to `Radius.circular(6)`, and softened gridline opacity.
- **Reports Summary & Category Cards**: Replaced bulky pie charts with the unified donut styling.
- **Testing**: Added test suite for `PokaDonutChart` and updated existing test expectations.

### Verification
- `make fix`: Formatted with zero issues.
- `make check`: `flutter analyze` passed with "No issues found!".
- Widget and unit tests for all charts passed (45/45 tests).