### PR TITLE
feat: add insufficient balance warning dialog on transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Insufficient balance confirmation warning dialog when creating or editing outgoing transactions (expense and transfer) that exceed available account balance, allowing users to proceed or review.
 - Reusable `PokaDonutChart` component unifying donut chart styling across Home and Reports with modern slim geometry and crisp section dividers.
 
 ### Changed

--- a/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
@@ -241,17 +241,17 @@ class TransactionFormSheet extends HookConsumerWidget {
             : (int.tryParse(state.amountExpression) ?? 0);
 
         if (amount > 0) {
-          final prevAmount =
-              (initialTransaction != null &&
-                  initialTransaction!.accountId == selectedAccount.id &&
-                  (initialTransaction!.type == TransactionType.expense ||
-                      initialTransaction!.type == TransactionType.transfer))
-              ? initialTransaction!.amount
-              : 0;
+          final isSameAccountOutgoing =
+              initialTransaction != null &&
+              initialTransaction!.accountId == selectedAccount.id &&
+              (initialTransaction!.type == TransactionType.expense ||
+                  initialTransaction!.type == TransactionType.transfer);
 
+          final prevAmount = isSameAccountOutgoing ? initialTransaction!.amount : 0;
           final availableBalance = selectedAccount.balance + prevAmount;
+          final isIncreasingOrNewExpense = !isSameAccountOutgoing || amount > prevAmount;
 
-          if (amount > availableBalance) {
+          if (isIncreasingOrNewExpense && amount > availableBalance) {
             final formattedAmount = amount.toCurrencyFormat(
               symbol: currencySymbol,
               precision: precision,

--- a/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/core/extensions/num_extension.dart';
 import 'package:poka_ce/features/accounts/presentation/widgets/pickers/account_selector_shelf.dart';
 import 'package:poka_ce/features/categories/domain/category_model.dart';
 import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
@@ -19,6 +22,7 @@ import 'package:poka_ce/features/transactions/presentation/widgets/forms/compone
 import 'package:poka_ce/features/transactions/presentation/widgets/split/transaction_split_sheet.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/split/transaction_split_summary_card.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -223,6 +227,59 @@ class TransactionFormSheet extends HookConsumerWidget {
       return true;
     }).toList();
 
+    final currencySymbol = settings?.baseCurrency?.symbol ?? '';
+    final precision = settings?.baseCurrency?.precision ?? 0;
+    final localeFormat = settings?.numberFormat ?? 'system';
+
+    Future<void> handleSave() async {
+      unawaited(HapticFeedback.mediumImpact());
+
+      final isOutgoing = state.type == TransactionType.expense || state.type == TransactionType.transfer;
+      if (isOutgoing && selectedAccount != null) {
+        final amount = isSplit
+            ? (state.splitItems?.fold<int>(0, (sum, i) => sum + i.amount) ?? 0)
+            : (int.tryParse(state.amountExpression) ?? 0);
+
+        if (amount > 0) {
+          final prevAmount =
+              (initialTransaction != null &&
+                  initialTransaction!.accountId == selectedAccount.id &&
+                  (initialTransaction!.type == TransactionType.expense ||
+                      initialTransaction!.type == TransactionType.transfer))
+              ? initialTransaction!.amount
+              : 0;
+
+          final availableBalance = selectedAccount.balance + prevAmount;
+
+          if (amount > availableBalance) {
+            final formattedAmount = amount.toCurrencyFormat(
+              symbol: currencySymbol,
+              precision: precision,
+              locale: localeFormat,
+            );
+            final formattedBalance = availableBalance.toCurrencyFormat(
+              symbol: currencySymbol,
+              precision: precision,
+              locale: localeFormat,
+            );
+
+            final proceed = await showPokaInsufficientBalanceDialog(
+              context,
+              accountName: selectedAccount.name,
+              formattedAmount: formattedAmount,
+              formattedBalance: formattedBalance,
+            );
+
+            if (proceed != true) {
+              return;
+            }
+          }
+        }
+      }
+
+      await notifier.save();
+    }
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -288,10 +345,7 @@ class TransactionFormSheet extends HookConsumerWidget {
                   )
                 else
                   FButton(
-                    onPress: () {
-                      HapticFeedback.mediumImpact();
-                      notifier.save();
-                    },
+                    onPress: handleSave,
                     child: Text(t.transactions.saveSplitTransaction),
                   ),
                 const SizedBox(height: 18),
@@ -318,8 +372,7 @@ class TransactionFormSheet extends HookConsumerWidget {
             onCategorySelected: (cat) => notifier.setCategory(cat?.id),
             onKeyPressed: (key) {
               if (key == 'OK') {
-                HapticFeedback.mediumImpact();
-                notifier.save();
+                handleSave();
               } else {
                 notifier.onKeyPressed(key);
               }

--- a/lib/i18n/en/transactions.i18n.json
+++ b/lib/i18n/en/transactions.i18n.json
@@ -59,5 +59,10 @@
   "debt": "Debt",
   "recurring": "Recurring",
   "transfer": "Transfer",
-  "weekNumber": "Week {{weekNum}} · {{date}}"
+  "weekNumber": "Week {{weekNum}} · {{date}}",
+  "insufficientBalance": "Insufficient Balance",
+  "insufficientBalanceWarning": "The amount ({{amount}}) exceeds the current balance in {{account}} ({{balance}}). Perhaps you forgot to record income first?",
+  "insufficientBalanceConsequence": "Your account balance will become negative if you proceed.",
+  "continueAnyway": "Continue Anyway",
+  "checkAgain": "Check Again"
 }

--- a/lib/i18n/id/transactions.i18n.json
+++ b/lib/i18n/id/transactions.i18n.json
@@ -59,5 +59,10 @@
   "debt": "Utang",
   "recurring": "Berulang",
   "transfer": "Transfer",
-  "weekNumber": "Minggu {{weekNum}} · {{date}}"
+  "weekNumber": "Minggu {{weekNum}} · {{date}}",
+  "insufficientBalance": "Saldo Tidak Cukup",
+  "insufficientBalanceWarning": "Jumlah transaksi ({{amount}}) melebihi saldo akun {{account}} ({{balance}}). Mungkin kamu belum mencatat pemasukan terlebih dahulu?",
+  "insufficientBalanceConsequence": "Saldo akun kamu akan menjadi minus jika tetap melanjutkan.",
+  "continueAnyway": "Tetap Simpan",
+  "checkAgain": "Periksa Kembali"
 }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1189 (594 per locale)
+/// Strings: 1199 (599 per locale)
 ///
-/// Built on 2026-09-07 at 16:22 UTC
+/// Built on 2026-09-07 at 17:47 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -1932,6 +1932,21 @@ class Translations$transactions$en {
 
 	/// en: 'Week {{weekNum}} · {{date}}'
 	String weekNumber({required Object weekNum, required Object date}) => 'Week ${weekNum} · ${date}';
+
+	/// en: 'Insufficient Balance'
+	String get insufficientBalance => 'Insufficient Balance';
+
+	/// en: 'The amount ({{amount}}) exceeds the current balance in {{account}} ({{balance}}). Perhaps you forgot to record income first?'
+	String insufficientBalanceWarning({required Object amount, required Object account, required Object balance}) => 'The amount (${amount}) exceeds the current balance in ${account} (${balance}). Perhaps you forgot to record income first?';
+
+	/// en: 'Your account balance will become negative if you proceed.'
+	String get insufficientBalanceConsequence => 'Your account balance will become negative if you proceed.';
+
+	/// en: 'Continue Anyway'
+	String get continueAnyway => 'Continue Anyway';
+
+	/// en: 'Check Again'
+	String get checkAgain => 'Check Again';
 }
 
 // Path: app.nav
@@ -2619,6 +2634,11 @@ extension on Translations {
 			'transactions.recurring' => 'Recurring',
 			'transactions.transfer' => 'Transfer',
 			'transactions.weekNumber' => ({required Object weekNum, required Object date}) => 'Week ${weekNum} · ${date}',
+			'transactions.insufficientBalance' => 'Insufficient Balance',
+			'transactions.insufficientBalanceWarning' => ({required Object amount, required Object account, required Object balance}) => 'The amount (${amount}) exceeds the current balance in ${account} (${balance}). Perhaps you forgot to record income first?',
+			'transactions.insufficientBalanceConsequence' => 'Your account balance will become negative if you proceed.',
+			'transactions.continueAnyway' => 'Continue Anyway',
+			'transactions.checkAgain' => 'Check Again',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_id.g.dart
+++ b/lib/i18n/strings_id.g.dart
@@ -782,6 +782,11 @@ class _Translations$transactions$id extends Translations$transactions$en {
 	@override String get recurring => 'Berulang';
 	@override String get transfer => 'Transfer';
 	@override String weekNumber({required Object weekNum, required Object date}) => 'Minggu ${weekNum} · ${date}';
+	@override String get insufficientBalance => 'Saldo Tidak Cukup';
+	@override String insufficientBalanceWarning({required Object amount, required Object account, required Object balance}) => 'Jumlah transaksi (${amount}) melebihi saldo akun ${account} (${balance}). Mungkin kamu belum mencatat pemasukan terlebih dahulu?';
+	@override String get insufficientBalanceConsequence => 'Saldo akun kamu akan menjadi minus jika tetap melanjutkan.';
+	@override String get continueAnyway => 'Tetap Simpan';
+	@override String get checkAgain => 'Periksa Kembali';
 }
 
 // Path: app.nav
@@ -1433,6 +1438,11 @@ extension on TranslationsId {
 			'transactions.recurring' => 'Berulang',
 			'transactions.transfer' => 'Transfer',
 			'transactions.weekNumber' => ({required Object weekNum, required Object date}) => 'Minggu ${weekNum} · ${date}',
+			'transactions.insufficientBalance' => 'Saldo Tidak Cukup',
+			'transactions.insufficientBalanceWarning' => ({required Object amount, required Object account, required Object balance}) => 'Jumlah transaksi (${amount}) melebihi saldo akun ${account} (${balance}). Mungkin kamu belum mencatat pemasukan terlebih dahulu?',
+			'transactions.insufficientBalanceConsequence' => 'Saldo akun kamu akan menjadi minus jika tetap melanjutkan.',
+			'transactions.continueAnyway' => 'Tetap Simpan',
+			'transactions.checkAgain' => 'Periksa Kembali',
 			_ => null,
 		};
 	}

--- a/lib/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart
+++ b/lib/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_icon.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+/// Shows a warning confirmation dialog when transaction amount exceeds account balance.
+///
+/// Returns `true` if the user confirms to proceed anyway, `false` (or `null`) if cancelled.
+///
+/// - [accountName]       : Name of the wallet/account being deducted.
+/// - [formattedAmount]   : Formatted transaction amount (e.g. "$50.00").
+/// - [formattedBalance]  : Formatted current account balance (e.g. "$10.00").
+/// - [confirmText]       : Optional override for confirm button label.
+/// - [cancelText]        : Optional override for cancel button label.
+Future<bool?> showPokaInsufficientBalanceDialog(
+  BuildContext context, {
+  required String accountName,
+  required String formattedAmount,
+  required String formattedBalance,
+  String? confirmText,
+  String? cancelText,
+}) {
+  return showFDialog<bool>(
+    context: context,
+    builder: (ctx, style, animation) => FDialog(
+      animation: animation,
+      builder: (dialogCtx, dialogStyle) {
+        final theme = ctx.theme;
+        final colors = theme.colors;
+        final typography = theme.typography;
+        final t = ctx.t.transactions;
+
+        return Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Warning icon
+              Center(
+                child: PokaIcon(
+                  icon: FPhosphorIcons.warning,
+                  shape: PokaIconShape.circle,
+                  color: colors.app.warning,
+                  size: PokaIconSize.hero,
+                ),
+              ),
+              const SizedBox(height: 20),
+
+              // Title
+              Text(
+                t.insufficientBalance,
+                style: typography.display.sm.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: colors.foreground,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+
+              // Body explanation
+              Text(
+                t.insufficientBalanceWarning(
+                  amount: formattedAmount,
+                  account: accountName,
+                  balance: formattedBalance,
+                ),
+                style: typography.body.md.copyWith(
+                  color: colors.mutedForeground,
+                  height: 1.5,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+
+              // Note about negative balance
+              Text(
+                t.insufficientBalanceConsequence,
+                style: typography.bodyPrimary.copyWith(
+                  color: colors.app.warning,
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+
+              // Actions
+              Row(
+                children: [
+                  Expanded(
+                    child: FButton(
+                      onPress: () => Navigator.of(ctx).pop(false),
+                      variant: FButtonVariant.outline,
+                      child: Text(cancelText ?? t.checkAgain),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: FButton(
+                      onPress: () => Navigator.of(ctx).pop(true),
+                      child: Text(confirmText ?? t.continueAnyway),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+}

--- a/test/e2e/features/transactions/transactions_e2e_test.dart
+++ b/test/e2e/features/transactions/transactions_e2e_test.dart
@@ -74,15 +74,15 @@ void main() {
     await tester.tap(okBtn);
     await settle();
 
+    // Confirm insufficient balance warning if dialog appears
+    final continueAnyway = find.text('Continue Anyway');
+    if (continueAnyway.evaluate().isNotEmpty) {
+      await tester.tap(continueAnyway);
+      await settle();
+    }
+
     // Wait for list to refresh
     await settle();
-
-    // Debug: print widgets
-    for (final widget in tester.allWidgets) {
-      if (widget is Text) {
-        print('Found text: "${widget.data}"');
-      }
-    }
 
     // Verify it appears in the list
     await tester.ensureVisible(find.text('E2E Transaction').last);
@@ -122,6 +122,12 @@ void main() {
     await tester.ensureVisible(okBtnEdit);
     await tester.tap(okBtnEdit);
     await settle();
+
+    final continueAnywayEdit = find.text('Continue Anyway');
+    if (continueAnywayEdit.evaluate().isNotEmpty) {
+      await tester.tap(continueAnywayEdit);
+      await settle();
+    }
 
     // Verify it is updated
     await tester.ensureVisible(find.text('E2E Transaction Edited').last);

--- a/test/feature/features/transactions/presentation/widgets/forms/transaction_form_sheet_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/forms/transaction_form_sheet_test.dart
@@ -546,6 +546,276 @@ void main() {
         ),
       ).called(1);
     });
+
+    testWidgets(
+      'Expense amount greater than account balance triggers warning dialog, cancel leaves sheet open without saving',
+      (tester) async {
+        when(
+          () => mockCreate.execute(
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            amount: any(named: 'amount'),
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+            transactionDate: any(named: 'transactionDate'),
+            debtId: any(named: 'debtId'),
+          ),
+        ).thenAnswer((_) async => Success(sampleTx()));
+
+        final lowBalanceAccounts = [
+          AccountModel(
+            id: 'a1',
+            name: 'Wallet',
+            type: AccountType.assets,
+            balance: 100,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#10B981',
+            icon: 'wallet',
+          ),
+        ];
+
+        await tester.pumpWidget(buildApp(accounts: lowBalanceAccounts));
+        await tester.pumpAndSettle();
+
+        // Enter amount 500 (> 100 balance)
+        await tester.tap(find.text('5'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(FPhosphorIcons.check));
+        await tester.pumpAndSettle();
+
+        // Warning dialog should appear
+        expect(find.byType(FDialog), findsOneWidget);
+        expect(find.text(t.transactions.insufficientBalance), findsOneWidget);
+        expect(find.text(t.transactions.checkAgain), findsOneWidget);
+
+        // Tap Check Again (cancel)
+        await tester.tap(find.text(t.transactions.checkAgain));
+        await tester.pumpAndSettle();
+
+        // Dialog dismissed
+        expect(find.byType(FDialog), findsNothing);
+        // Create was NOT called
+        verifyNever(
+          () => mockCreate.execute(
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            amount: any(named: 'amount'),
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+            transactionDate: any(named: 'transactionDate'),
+            debtId: any(named: 'debtId'),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'Expense amount greater than account balance allows proceeding when user confirms',
+      (tester) async {
+        when(
+          () => mockCreate.execute(
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            amount: any(named: 'amount'),
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+            transactionDate: any(named: 'transactionDate'),
+            debtId: any(named: 'debtId'),
+          ),
+        ).thenAnswer((_) async => Success(sampleTx()));
+
+        final lowBalanceAccounts = [
+          AccountModel(
+            id: 'a1',
+            name: 'Wallet',
+            type: AccountType.assets,
+            balance: 100,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#10B981',
+            icon: 'wallet',
+          ),
+        ];
+
+        await tester.pumpWidget(buildApp(accounts: lowBalanceAccounts));
+        await tester.pumpAndSettle();
+
+        // Enter amount 500 (> 100 balance)
+        await tester.tap(find.text('5'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(FPhosphorIcons.check));
+        await tester.pumpAndSettle();
+
+        // Warning dialog should appear
+        expect(find.byType(FDialog), findsOneWidget);
+
+        // Tap Continue Anyway
+        await tester.tap(find.text(t.transactions.continueAnyway));
+        await tester.pumpAndSettle();
+
+        // Dialog dismissed and create called
+        expect(find.byType(FDialog), findsNothing);
+        verify(
+          () => mockCreate.execute(
+            type: TransactionType.expense,
+            accountId: 'a1',
+            amount: 500,
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+            transactionDate: any(named: 'transactionDate'),
+            debtId: any(named: 'debtId'),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'Transfer amount greater than source balance shows warning and saves on confirm',
+      (tester) async {
+        when(
+          () => mockTransfer.execute(
+            amount: any(named: 'amount'),
+            sourceAccountId: any(named: 'sourceAccountId'),
+            destinationAccountId: any(named: 'destinationAccountId'),
+            note: any(named: 'note'),
+            transactionDate: any(named: 'transactionDate'),
+          ),
+        ).thenAnswer((_) async => Success(sampleTx().copyWith(type: TransactionType.transfer)));
+
+        final accounts = [
+          AccountModel(
+            id: 'a1',
+            name: 'Wallet',
+            type: AccountType.assets,
+            balance: 100,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#10B981',
+            icon: 'wallet',
+          ),
+          AccountModel(
+            id: 'a2',
+            name: 'Bank',
+            type: AccountType.assets,
+            balance: 5000,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#6366F1',
+            icon: 'bank',
+          ),
+        ];
+
+        await tester.pumpWidget(buildApp(initialType: TransactionType.transfer, accounts: accounts));
+        await tester.pumpAndSettle();
+
+        // Enter amount 200 (> 100 balance)
+        await tester.tap(find.text('2'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(FPhosphorIcons.check));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(FDialog), findsOneWidget);
+
+        await tester.tap(find.text(t.transactions.continueAnyway));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockTransfer.execute(
+            amount: 200,
+            sourceAccountId: 'a1',
+            destinationAccountId: 'a2',
+            note: any(named: 'note'),
+            transactionDate: any(named: 'transactionDate'),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'Income does not show insufficient balance warning even if amount is large',
+      (tester) async {
+        when(
+          () => mockCreate.execute(
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            amount: any(named: 'amount'),
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+            transactionDate: any(named: 'transactionDate'),
+            debtId: any(named: 'debtId'),
+          ),
+        ).thenAnswer((_) async => Success(sampleTx()));
+
+        final lowBalanceAccounts = [
+          AccountModel(
+            id: 'a1',
+            name: 'Wallet',
+            type: AccountType.assets,
+            balance: 50,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#10B981',
+            icon: 'wallet',
+          ),
+        ];
+
+        await tester.pumpWidget(buildApp(initialType: TransactionType.income, accounts: lowBalanceAccounts));
+        await tester.pumpAndSettle();
+
+        // Enter amount 500 (> 50 balance)
+        await tester.tap(find.text('5'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(FPhosphorIcons.check));
+        await tester.pumpAndSettle();
+
+        // No dialog shown
+        expect(find.byType(FDialog), findsNothing);
+        verify(
+          () => mockCreate.execute(
+            type: TransactionType.income,
+            accountId: 'a1',
+            amount: 500,
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+            transactionDate: any(named: 'transactionDate'),
+            debtId: any(named: 'debtId'),
+          ),
+        ).called(1);
+      },
+    );
   });
 }
 

--- a/test/feature/features/transactions/presentation/widgets/forms/transaction_form_sheet_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/forms/transaction_form_sheet_test.dart
@@ -18,6 +18,7 @@ import 'package:poka_ce/features/settings/presentation/controllers/settings_noti
 import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
 import 'package:poka_ce/features/transactions/domain/use_cases/create_transaction_use_case.dart';
 import 'package:poka_ce/features/transactions/domain/use_cases/transfer_funds_use_case.dart';
+import 'package:poka_ce/features/transactions/domain/use_cases/update_transaction_use_case.dart';
 import 'package:poka_ce/features/transactions/presentation/controllers/transaction_form_notifier.dart';
 import 'package:poka_ce/features/transactions/presentation/controllers/transaction_list_notifier.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/forms/components/transaction_transfer_selector.dart';
@@ -28,6 +29,8 @@ import 'package:poka_ce/theme/theme.dart';
 class MockCreateTransactionUseCase extends Mock implements CreateTransactionUseCase {}
 
 class MockTransferFundsUseCase extends Mock implements TransferFundsUseCase {}
+
+class MockUpdateTransactionUseCase extends Mock implements UpdateTransactionUseCase {}
 
 class FakeTransactionModel extends Fake implements TransactionModel {}
 
@@ -42,10 +45,12 @@ void main() {
 
   late MockCreateTransactionUseCase mockCreate;
   late MockTransferFundsUseCase mockTransfer;
+  late MockUpdateTransactionUseCase mockUpdate;
 
   setUp(() {
     mockCreate = MockCreateTransactionUseCase();
     mockTransfer = MockTransferFundsUseCase();
+    mockUpdate = MockUpdateTransactionUseCase();
   });
 
   List<AccountModel> sampleAccounts() => [
@@ -101,6 +106,7 @@ void main() {
 
   ProviderScope buildApp({
     TransactionType? initialType,
+    TransactionModel? initialTransaction,
     List<AccountModel>? accounts,
     List<CategoryModel>? categories,
     SettingsState? settingsState,
@@ -113,6 +119,7 @@ void main() {
     return ProviderScope(
       overrides: [
         createTransactionUseCaseProvider.overrideWithValue(mockCreate),
+        updateTransactionUseCaseProvider.overrideWithValue(mockUpdate),
         transferFundsUseCaseProvider.overrideWithValue(mockTransfer),
         dashboardProvider.overrideWith(
           () => _FakeDashboardNotifier(DashboardState(accounts: accs, isLoading: false)),
@@ -131,7 +138,12 @@ void main() {
             child: FToaster(child: child!),
           ),
           home: Scaffold(
-            body: SingleChildScrollView(child: TransactionFormSheet(initialType: initialType)),
+            body: SingleChildScrollView(
+              child: TransactionFormSheet(
+                initialType: initialType,
+                initialTransaction: initialTransaction,
+              ),
+            ),
           ),
         ),
       ),
@@ -812,6 +824,146 @@ void main() {
             splitItems: any(named: 'splitItems'),
             transactionDate: any(named: 'transactionDate'),
             debtId: any(named: 'debtId'),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'Editing existing transaction on same account with same amount does not show warning',
+      (tester) async {
+        final existingTx = sampleTx().copyWith(amount: 500);
+        when(
+          () => mockUpdate.execute(
+            any(),
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            destinationAccountId: any(named: 'destinationAccountId'),
+            amount: any(named: 'amount'),
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            transactionDate: any(named: 'transactionDate'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+          ),
+        ).thenAnswer((_) async => Success(existingTx));
+
+        final accounts = [
+          AccountModel(
+            id: 'a1',
+            name: 'Wallet',
+            type: AccountType.assets,
+            balance: 0,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#10B981',
+            icon: 'wallet',
+          ),
+        ];
+
+        await tester.pumpWidget(
+          buildApp(
+            initialTransaction: existingTx,
+            accounts: accounts,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(FPhosphorIcons.check));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(FDialog), findsNothing);
+        verify(
+          () => mockUpdate.execute(
+            any(),
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            destinationAccountId: any(named: 'destinationAccountId'),
+            amount: 500,
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            transactionDate: any(named: 'transactionDate'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'Editing existing transaction on same account with increased amount exceeding available balance shows warning',
+      (tester) async {
+        final existingTx = sampleTx().copyWith(amount: 100);
+        when(
+          () => mockUpdate.execute(
+            any(),
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            destinationAccountId: any(named: 'destinationAccountId'),
+            amount: any(named: 'amount'),
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            transactionDate: any(named: 'transactionDate'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
+          ),
+        ).thenAnswer((_) async => Success(existingTx));
+
+        final accounts = [
+          AccountModel(
+            id: 'a1',
+            name: 'Wallet',
+            type: AccountType.assets,
+            balance: 0,
+            createdAt: DateTime.utc(2024, 1, 1),
+            updatedAt: DateTime.utc(2024, 1, 1),
+            color: '#10B981',
+            icon: 'wallet',
+          ),
+        ];
+
+        await tester.pumpWidget(
+          buildApp(
+            initialTransaction: existingTx,
+            accounts: accounts,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Clear and enter 500 via numpad (> 100 available)
+        await tester.tap(find.byIcon(FPhosphorIcons.backspace));
+        await tester.pump();
+        await tester.tap(find.byIcon(FPhosphorIcons.backspace));
+        await tester.pump();
+        await tester.tap(find.byIcon(FPhosphorIcons.backspace));
+        await tester.pump();
+        await tester.tap(find.text('5'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+        await tester.tap(find.text('0'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(FPhosphorIcons.check));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(FDialog), findsOneWidget);
+
+        await tester.tap(find.text(t.transactions.continueAnyway));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockUpdate.execute(
+            any(),
+            type: any(named: 'type'),
+            accountId: any(named: 'accountId'),
+            destinationAccountId: any(named: 'destinationAccountId'),
+            amount: 500,
+            categoryId: any(named: 'categoryId'),
+            note: any(named: 'note'),
+            transactionDate: any(named: 'transactionDate'),
+            allocation: any(named: 'allocation'),
+            splitItems: any(named: 'splitItems'),
           ),
         ).called(1);
       },

--- a/test/feature/shared/widgets/dialogs/poka_insufficient_balance_dialog_test.dart
+++ b/test/feature/shared/widgets/dialogs/poka_insufficient_balance_dialog_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+Widget wrapHost({
+  required void Function(bool?) onResult,
+  String? confirmText,
+  String? cancelText,
+}) {
+  return TranslationProvider(
+    child: MaterialApp(
+      builder: (context, c) => FTheme(data: lightTheme, child: c!),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () async {
+                final r = await showPokaInsufficientBalanceDialog(
+                  context,
+                  accountName: 'Main Wallet',
+                  formattedAmount: 'Rp 50.000',
+                  formattedBalance: 'Rp 10.000',
+                  confirmText: confirmText,
+                  cancelText: cancelText,
+                );
+                onResult(r);
+              },
+              child: const Text('Open Dialog'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => LocaleSettings.setLocaleSync(AppLocale.en));
+
+  group('showPokaInsufficientBalanceDialog', () {
+    testWidgets('shows headline, details and negative balance warning', (tester) async {
+      await tester.pumpWidget(wrapHost(onResult: (_) {}));
+      await tester.tap(find.text('Open Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Insufficient Balance'), findsOneWidget);
+      expect(
+        find.textContaining('Main Wallet'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Rp 50.000'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Rp 10.000'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Your account balance will become negative if you proceed.'),
+        findsOneWidget,
+      );
+      expect(find.text('Check Again'), findsOneWidget);
+      expect(find.text('Continue Anyway'), findsOneWidget);
+    });
+
+    testWidgets('clicking Continue Anyway pops with true', (tester) async {
+      bool? result;
+      await tester.pumpWidget(wrapHost(onResult: (v) => result = v));
+      await tester.tap(find.text('Open Dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Continue Anyway'));
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('clicking Check Again pops with false', (tester) async {
+      bool? result;
+      await tester.pumpWidget(wrapHost(onResult: (v) => result = v));
+      await tester.tap(find.text('Open Dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Check Again'));
+      await tester.pumpAndSettle();
+
+      expect(result, isFalse);
+    });
+
+    testWidgets('custom confirmText and cancelText override default labels', (tester) async {
+      await tester.pumpWidget(
+        wrapHost(
+          onResult: (_) {},
+          confirmText: 'Yes, proceed',
+          cancelText: 'Go back',
+        ),
+      );
+      await tester.tap(find.text('Open Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Yes, proceed'), findsOneWidget);
+      expect(find.text('Go back'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
When recording or editing an outgoing transaction (expense or transfer), if the transaction amount exceeds the current available balance of the source account, a warning confirmation dialog is displayed. This helps users notice if they accidentally spent more than their recorded balance (e.g. forgot to record income first), while still giving them the flexibility to proceed and record a negative balance if desired.

## Changes
- **Dialog (`showPokaInsufficientBalanceDialog`)**: Created shared modal dialog using ForUI `FDialog`, `PokaIcon` warning symbol, formatted amount/balance display, and clear options: "Check Again" (cancel) and "Continue Anyway" (proceed).
- **Form Sheet (`TransactionFormSheet`)**: Intercepted outgoing transaction saves (simple and split) to verify `amount > availableBalance`. When editing an existing transaction, the previous amount for that account is considered in available balance calculation.
- **Localization**: Added English and Indonesian translations for insufficient balance dialog title, message, consequence, and button labels.
- **Tests**: Added unit & widget tests covering dialog confirmation/cancellation and `TransactionFormSheet` interceptor flow.
- **Changelog**: Documented in `CHANGELOG.md` under `[Unreleased]`.