### PR TITLE
feat(reports): move excel export to reports header and simplify backup intervals

### DIFF
--- a/lib/features/reports/presentation/controllers/report_notifier.dart
+++ b/lib/features/reports/presentation/controllers/report_notifier.dart
@@ -1,8 +1,12 @@
+import 'dart:ui';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:poka_ce/app/providers/repository_providers.dart';
+import 'package:poka_ce/core/error/result.dart';
 import 'package:poka_ce/features/budgets/domain/budget_model.dart';
 import 'package:poka_ce/features/budgets/presentation/controllers/budget_list_notifier.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
+import 'package:poka_ce/features/transactions/data/excel_export_service.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -101,5 +105,21 @@ class ReportNotifier extends _$ReportNotifier {
     _customStart = start;
     _customEnd = end;
     ref.invalidateSelf();
+  }
+
+  /// Exports ledger transactions, accounts, and categories to an Excel spreadsheet
+  /// and opens the system share sheet.
+  ///
+  /// Returns `true` if the export and share succeeded, or `false` on failure.
+  Future<bool> exportExcel({Rect? sharePositionOrigin}) async {
+    final result = await ref
+        .read(excelExportServiceProvider)
+        .exportAndShare(
+          sharePositionOrigin: sharePositionOrigin,
+        );
+    return switch (result) {
+      Success() => true,
+      ErrorResult() => false,
+    };
   }
 }

--- a/lib/features/reports/presentation/screens/report_list_page.dart
+++ b/lib/features/reports/presentation/screens/report_list_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:forui/forui.dart';
 import 'package:forui_phosphor/forui_phosphor.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:poka_ce/core/error/result.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_budget_utilization.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_cashflow_chart.dart';
@@ -11,7 +10,6 @@ import 'package:poka_ce/features/reports/presentation/widgets/report_category_ch
 import 'package:poka_ce/features/reports/presentation/widgets/report_period_selector.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_spending_allocation.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_summary_card.dart';
-import 'package:poka_ce/features/transactions/data/excel_export_service.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/poka_header.dart';
 import 'package:poka_ce/shared/widgets/poka_section_label.dart';
@@ -37,20 +35,12 @@ class ReportListPage extends ConsumerWidget {
               final box = context.findRenderObject() as RenderBox?;
               final rect = box != null ? box.localToGlobal(Offset.zero) & box.size : null;
 
-              final result = await ref.read(excelExportServiceProvider).exportAndShare(sharePositionOrigin: rect);
+              final success = await ref.read(reportProvider.notifier).exportExcel(sharePositionOrigin: rect);
               if (context.mounted) {
-                switch (result) {
-                  case Success():
-                    showFToast(
-                      context: context,
-                      title: Text(t.exportExcelSuccess),
-                    );
-                  case ErrorResult():
-                    showFToast(
-                      context: context,
-                      title: Text(t.exportExcelError),
-                    );
-                }
+                showFToast(
+                  context: context,
+                  title: Text(success ? t.exportExcelSuccess : t.exportExcelError),
+                );
               }
             },
           ),

--- a/test/unit/features/reports/presentation/controllers/report_notifier_test.dart
+++ b/test/unit/features/reports/presentation/controllers/report_notifier_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -7,8 +9,11 @@ import 'package:poka_ce/core/error/result.dart';
 import 'package:poka_ce/features/budgets/domain/i_budget_repository.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
+import 'package:poka_ce/features/transactions/data/excel_export_service.dart';
 
 class MockBudgetRepository extends Mock implements IBudgetRepository {}
+
+class MockExcelExportService extends Mock implements ExcelExportService {}
 
 void main() {
   group('ReportState', () {
@@ -34,7 +39,7 @@ void main() {
   });
 
   group('ReportNotifier', () {
-    ProviderContainer makeContainer() {
+    ProviderContainer makeContainer({MockExcelExportService? mockExcelExport}) {
       final mockBudget = MockBudgetRepository();
       when(() => mockBudget.getBudgets()).thenAnswer((_) async => const Success([]));
       final container = ProviderContainer(
@@ -42,6 +47,7 @@ void main() {
           recentTransactionsStreamProvider.overrideWith((ref) => Stream.value([])),
           categoriesStreamProvider.overrideWith((ref) => Stream.value([])),
           budgetRepositoryProvider.overrideWithValue(mockBudget),
+          if (mockExcelExport != null) excelExportServiceProvider.overrideWithValue(mockExcelExport),
         ],
       );
       container.listen(reportProvider, (_, __) {});
@@ -86,6 +92,32 @@ void main() {
       expect(state.period, ReportPeriod.thisMonth);
       expect(state.customDateStart, isNull);
       expect(state.customDateEnd, isNull);
+    });
+
+    test('exportExcel returns true on success', () async {
+      final mockExport = MockExcelExportService();
+      when(() => mockExport.exportAndShare(sharePositionOrigin: any(named: 'sharePositionOrigin')))
+          .thenAnswer((_) async => Success(File('test.xlsx')));
+
+      final container = makeContainer(mockExcelExport: mockExport);
+      final notifier = container.read(reportProvider.notifier);
+
+      final success = await notifier.exportExcel();
+      expect(success, isTrue);
+      verify(() => mockExport.exportAndShare(sharePositionOrigin: any(named: 'sharePositionOrigin'))).called(1);
+    });
+
+    test('exportExcel returns false on error', () async {
+      final mockExport = MockExcelExportService();
+      when(() => mockExport.exportAndShare(sharePositionOrigin: any(named: 'sharePositionOrigin')))
+          .thenAnswer((_) async => const ErrorResult(UnexpectedFailure('error')));
+
+      final container = makeContainer(mockExcelExport: mockExport);
+      final notifier = container.read(reportProvider.notifier);
+
+      final success = await notifier.exportExcel();
+      expect(success, isFalse);
+      verify(() => mockExport.exportAndShare(sharePositionOrigin: any(named: 'sharePositionOrigin'))).called(1);
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR moves the **Export to Excel** feature to a more intuitive location in the Reports page header and simplifies the backup reminder interval labels:

1. **Relocate Export to Excel to Reports Header:**
   - Adds an Excel action button (`FHeaderAction` with `FPhosphorIcons.fileXls`) to `PokaHeader` in `ReportListPage`.
   - Triggers native multi-sheet Excel generation and sharing via `excelExportServiceProvider.exportAndShare`.
   - Displays toast feedback on success or failure.
   - Removes the redundant Excel export item from `DataManagementSection` under Settings.

2. **Simplify Backup Reminder Intervals:**
   - Cleans up redundant duration annotations in both Indonesian and English locales:
     - ID: `"Mingguan"` & `"Bulanan"` (removed `"(setiap 7 hari)"` & `"(setiap 30 hari)"`).
     - EN: `"Weekly"` & `"Monthly"` (removed `"(every 7 days)"` & `"(every 30 days)"`).
   - Regenerated translations with Slang.

3. **Testing & Coverage:**
   - Added full widget test suite for `ReportListPage` in `test/feature/features/reports/presentation/screens/report_list_page_test.dart` testing loading states, tab rendering, and export action button invocation/toasts.
   - Updated `backup_reminder_sheet_test.dart` to verify the simplified interval labels.

## Verification
- `make check`: flutter analyze reports "No issues found!".
- All unit & feature tests for `reports`, `backup`, and `settings` pass 100%.