### PR TITLE
fix(transactions): resolve categories for expanded split transaction sub-items (#38)

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -770,7 +770,7 @@ On the **Reports Page (`ReportListPage`)**:
 ## 📋 Recommended Action Items
 
 1. [x] Implement allocation badge display in [`lib/features/transactions/presentation/widgets/split/transaction_split_item_list.dart`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/transactions/presentation/widgets/split/transaction_split_item_list.dart) (BUG-001 — [#37](https://github.com/getpoka/poka-ce/issues/37)).
-2. [ ] Implement category auto-resolution and child tile passing in [`lib/features/transactions/presentation/widgets/tile/transaction_tile.dart`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart) (BUG-002 — [#38](https://github.com/getpoka/poka-ce/issues/38)).
+2. [x] Implement category auto-resolution and child tile passing in [`lib/features/transactions/presentation/widgets/tile/transaction_tile.dart`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart) (BUG-002 — [#38](https://github.com/getpoka/poka-ce/issues/38)).
 3. [x] ~~Add `recurring_period` column in Drift schema and snapshot period in `RecurringProcessorService`~~ (BUG-003 — **Marked Invalid / Working as Designed per `database-schema.md`**; candidate for future feature discussion).
 4. [ ] Make `SettingsNotifier` keep-alive (`@Riverpod(keepAlive: true)`), remove `_disposed` flag issue, and ensure base currency changes take effect immediately across all sessions (BUG-004 — [#39](https://github.com/getpoka/poka-ce/issues/39)).
 5. [ ] Add `restoreWarningDesc` localization key and fix copy in restore confirmation dialog (BUG-005 — [#40](https://github.com/getpoka/poka-ce/issues/40)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed missing allocation badge (Need, Want, Saving) on split item preview list in transaction creation sheet.
+- Resolved category resolution for split transaction child items when expanded, preventing them from falling back to "Uncategorized".
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
+++ b/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
@@ -157,7 +157,8 @@ class RecentTransactionTile extends HookConsumerWidget with FTileMixin {
 
     final firstItem = transaction.items.firstOrNull;
     final resolvedCategory =
-        category ?? (firstItem?.categoryId != null ? effectiveCategoriesById[firstItem!.categoryId] : null);
+        category ??
+        (!isSubItem && firstItem?.categoryId != null ? effectiveCategoriesById[firstItem!.categoryId] : null);
 
     // ── Category icon + color ──────────────────────────────────────────────
     var catColor = resolvedCategory?.color?.toColor() ?? theme.colors.primary;

--- a/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
+++ b/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
@@ -155,25 +155,29 @@ class RecentTransactionTile extends HookConsumerWidget with FTileMixin {
             ) ??
         <String, CategoryModel>{};
 
+    final firstItem = transaction.items.firstOrNull;
+    final resolvedCategory =
+        category ?? (firstItem?.categoryId != null ? effectiveCategoriesById[firstItem!.categoryId] : null);
+
     // ── Category icon + color ──────────────────────────────────────────────
-    var catColor = category?.color?.toColor() ?? theme.colors.primary;
-    var catIcon = IconUtil.getIcon(category?.icon);
+    var catColor = resolvedCategory?.color?.toColor() ?? theme.colors.primary;
+    var catIcon = IconUtil.getIcon(resolvedCategory?.icon);
 
     // ── Category label ─────────────────────────────────────────────────────
     var catLabel =
-        category?.name ??
+        resolvedCategory?.name ??
         (transaction.type == TransactionType.transfer ? t.transactions.transfer : t.common.uncategorized);
 
     IconData? subCatIcon;
     Color? subCatColor;
 
-    if (category?.parentId != null && effectiveCategoriesById.isNotEmpty) {
-      final parentCat = effectiveCategoriesById[category!.parentId!];
+    if (resolvedCategory?.parentId != null && effectiveCategoriesById.isNotEmpty) {
+      final parentCat = effectiveCategoriesById[resolvedCategory!.parentId!];
       if (parentCat != null) {
-        catLabel = '${parentCat.name} • ${category!.name}';
+        catLabel = '${parentCat.name} • ${resolvedCategory.name}';
         // Prefix gets the SUB category icon
-        catIcon = IconUtil.getIcon(category!.icon);
-        catColor = category!.color?.toColor() ?? theme.colors.primary;
+        catIcon = IconUtil.getIcon(resolvedCategory.icon);
+        catColor = resolvedCategory.color?.toColor() ?? theme.colors.primary;
         // Sub badge gets the PARENT category icon
         subCatIcon = IconUtil.getIcon(parentCat.icon);
         subCatColor = parentCat.color?.toColor() ?? theme.colors.primary;
@@ -324,7 +328,8 @@ class RecentTransactionTile extends HookConsumerWidget with FTileMixin {
                   child: RecentTransactionTile(
                     transaction: fakeTx,
                     isBalanceVisible: isBalanceVisible,
-                    categoriesById: categoriesById,
+                    categoriesById: effectiveCategoriesById,
+                    category: effectiveCategoriesById[item.categoryId],
                     account: account,
                     isSubItem: true,
                     onEdit: () => handleEditItem(entry.key),

--- a/lib/features/transactions/presentation/widgets/tile/transaction_tile_content.dart
+++ b/lib/features/transactions/presentation/widgets/tile/transaction_tile_content.dart
@@ -87,6 +87,7 @@ class TransactionTileContent extends StatelessWidget {
                       ),
                       child: Text(
                         '$itemCount',
+                        key: ValueKey('item_count_${itemCount}_$catColor'),
                         style: theme.typography.labelBadge.copyWith(
                           color: catColor,
                         ),

--- a/test/feature/features/transactions/presentation/widgets/tile/transaction_tile_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/tile/transaction_tile_test.dart
@@ -69,4 +69,95 @@ void main() {
 
     expect(find.byType(RecentTransactionTile), findsOneWidget);
   });
+
+  testWidgets('RecentTransactionTile resolves and displays child categories when expanded', (tester) async {
+    final foodCat = CategoryModel(
+      id: 'cat_food',
+      name: 'Food & Dining',
+      icon: 'forkKnife',
+      color: '#FF5722',
+      type: CategoryType.expense,
+      sort: 1,
+      isActive: true,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    final transportCat = CategoryModel(
+      id: 'cat_transport',
+      name: 'Transport',
+      icon: 'car',
+      color: '#2196F3',
+      type: CategoryType.expense,
+      sort: 2,
+      isActive: true,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+
+    final categoriesMap = {
+      foodCat.id: foodCat,
+      transportCat.id: transportCat,
+    };
+
+    final splitTransaction = TransactionModel(
+      id: 'tx_split',
+      accountId: 'acc_1',
+      type: TransactionType.expense,
+      amount: 150000,
+      transactionDate: DateTime.now(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      items: [
+        TransactionItemModel(
+          id: 'item_1',
+          transactionId: 'tx_split',
+          categoryId: 'cat_food',
+          amount: 100000,
+          allocation: TransactionAllocation.need,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+        TransactionItemModel(
+          id: 'item_2',
+          transactionId: 'tx_split',
+          categoryId: 'cat_transport',
+          amount: 50000,
+          allocation: TransactionAllocation.want,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        categoryListProvider.overrideWith(() => MockCategoryListNotifier()),
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildTestApp(
+        RecentTransactionTile(
+          transaction: splitTransaction,
+          isBalanceVisible: true,
+          categoriesById: categoriesMap,
+        ),
+        container,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tap to expand
+    await tester.tap(find.byType(RecentTransactionTile).first);
+    await tester.pumpAndSettle();
+
+    // After expanding:
+    // - Parent tile header auto-resolves to first item category ("Food & Dining")
+    // - Sub-item 1 resolves to its category ("Food & Dining")
+    // - Sub-item 2 resolves to its category ("Transport")
+    // - No item shows "Uncategorized"
+    expect(find.text('Food & Dining'), findsNWidgets(2));
+    expect(find.text('Transport'), findsOneWidget);
+    expect(find.text('Uncategorized'), findsNothing);
+  });
 }


### PR DESCRIPTION
Closes #38

### Summary
- In `RecentTransactionTile` (`lib/features/transactions/presentation/widgets/tile/transaction_tile.dart`), auto-resolve category from `effectiveCategoriesById` via `firstItem.categoryId` when `category` is omitted.
- In child sub-item mapping, pass `category: effectiveCategoriesById[item.categoryId]` and `categoriesById: effectiveCategoriesById` so child tiles render their respective category names and icons instead of falling back to "Uncategorized".
- Added widget test verifying expanded split sub-items resolve distinct categories without showing "Uncategorized" in `test/feature/features/transactions/presentation/widgets/tile/transaction_tile_test.dart`.
- Updated `CHANGELOG.md` and `BUG.md` action item status.

### Verification
- `flutter test test/feature/features/transactions/presentation/widgets/tile/transaction_tile_test.dart` (all passed)
- `rune fix` & `rune check` (No issues found!)