### PR TITLE
fix(debts): restore close button and remove unconfirmed direct delete in edit sheet (#45)

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -778,7 +778,7 @@ On the **Reports Page (`ReportListPage`)**:
 7. [ ] Fix date formatting locale, `TransactionTypeSwitcher` tabs, and default category translations on the Transactions page (BUG-007 — [#42](https://github.com/getpoka/poka-ce/issues/42)).
 8. [ ] Enable swipe-to-edit and swipe-to-delete on repayment tiles in `DebtDetailPage` (BUG-008 — [#43](https://github.com/getpoka/poka-ce/issues/43)).
 9. [ ] Handle debt repayment semantic labeling and icon in `RecentTransactionTile` to eliminate "Uncategorized" (BUG-009 — [#44](https://github.com/getpoka/poka-ce/issues/44)).
-10. [ ] Restore standard 'X' close button on `DebtFormSheet` by removing the unconfirmed header trash action (BUG-010 — [#45](https://github.com/getpoka/poka-ce/issues/45)).
+10. [x] Restore standard 'X' close button on [`DebtFormSheet`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/widgets/debt_form_sheet.dart) by removing the unconfirmed header trash action (BUG-010 — [#45](https://github.com/getpoka/poka-ce/issues/45)).
 11. [ ] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).
 12. [ ] Implement `showPokaToast` with watchdog timer to eliminate stuck toasts across mobile touch events and route transitions (BUG-012 — [#46](https://github.com/getpoka/poka-ce/issues/46)).
 13. [ ] Implement privacy eye obfuscation (`isVisible`) across Dashboard Cashflow, Spending Activity, Categories, and Budgets (BUG-013 — [#47](https://github.com/getpoka/poka-ce/issues/47)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed missing allocation badge (Need, Want, Saving) on split item preview list in transaction creation sheet.
 - Resolved category resolution for split transaction child items when expanded, preventing them from falling back to "Uncategorized".
+- Restored standard close button on Debt edit sheet and eliminated unconfirmed direct delete action.
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/features/debts/presentation/widgets/debt_form_sheet.dart
+++ b/lib/features/debts/presentation/widgets/debt_form_sheet.dart
@@ -7,7 +7,6 @@ import 'package:poka_ce/features/categories/presentation/controllers/category_li
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/debts/domain/debt_model.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_form_notifier.dart';
-import 'package:poka_ce/features/debts/presentation/controllers/debt_list_notifier.dart';
 import 'package:poka_ce/features/debts/presentation/widgets/debt_date_picker.dart';
 import 'package:poka_ce/features/debts/presentation/widgets/debt_scope_tile.dart';
 import 'package:poka_ce/features/debts/presentation/widgets/debt_type_selector.dart';
@@ -161,22 +160,6 @@ class DebtFormSheet extends HookConsumerWidget {
 
     return PokaSheet(
       title: isEditing ? t.debts.editRecord : t.debts.newRecord,
-      trailing: isEditing
-          ? GestureDetector(
-              onTap: () async {
-                await ref.read(debtListProvider.notifier).deleteDebt(initialDebt!.id);
-                if (context.mounted) Navigator.of(context).pop();
-              },
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Icon(
-                  FPhosphorIcons.trash,
-                  size: 18,
-                  color: context.theme.colors.destructive,
-                ),
-              ),
-            )
-          : null,
       child: Form(
         key: formKey,
         child: Column(

--- a/test/feature/features/debts/presentation/widgets/debt_form_sheet_test.dart
+++ b/test/feature/features/debts/presentation/widgets/debt_form_sheet_test.dart
@@ -152,12 +152,13 @@ void main() {
       expect(find.text('Due Date'), findsOneWidget);
     });
 
-    testWidgets('renders edit mode with title Edit Record and delete icon', (tester) async {
+    testWidgets('renders edit mode with title Edit Record and close button', (tester) async {
       await tester.pumpWidget(buildWidget(initialDebt: sampleDebt()));
       await tester.pumpAndSettle();
       expect(find.text('Edit Record'), findsOneWidget);
       expect(find.text('Save Changes'), findsOneWidget);
-      expect(find.byIcon(FPhosphorIcons.trash), findsOneWidget);
+      expect(find.widgetWithIcon(FButton, FPhosphorIcons.x), findsOneWidget);
+      expect(find.byIcon(FPhosphorIcons.trash), findsNothing);
       // Transaction binding should be hidden in edit mode
       expect(find.text('Transaction Binding'), findsNothing);
     });
@@ -269,14 +270,12 @@ void main() {
       expect(container.read(debtFormProvider).isSaving, false);
     });
 
-    testWidgets('delete button in edit mode calls deleteDebt', (tester) async {
+    testWidgets('edit mode does not render direct delete button', (tester) async {
       final debt = sampleDebt();
       await tester.pumpWidget(buildWidget(initialDebt: debt));
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(FPhosphorIcons.trash));
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(milliseconds: 100));
-      verify(() => mockDebtRepo.deleteDebt('d1')).called(1);
+      expect(find.byIcon(FPhosphorIcons.trash), findsNothing);
+      verifyNever(() => mockDebtRepo.deleteDebt(any()));
     });
 
     testWidgets('init with initialDebt pre-fills fields', (tester) async {
@@ -381,6 +380,16 @@ void main() {
       await tester.tap(find.text('OpenDebtEdit'));
       await tester.pumpAndSettle();
       expect(find.text('Edit Record'), findsOneWidget);
+
+      // Verify close button ('X') is rendered and unconfirmed trash icon is NOT present
+      final closeButton = find.widgetWithIcon(FButton, FPhosphorIcons.x);
+      expect(closeButton, findsOneWidget);
+      expect(find.byIcon(FPhosphorIcons.trash), findsNothing);
+
+      // Verify tapping close button safely dismisses the sheet
+      await tester.tap(closeButton);
+      await tester.pumpAndSettle();
+      expect(find.text('Edit Record'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Closes #45

### Summary
- In `DebtFormSheet` (`lib/features/debts/presentation/widgets/debt_form_sheet.dart`), removed the unconfirmed direct delete action from the sheet header trailing slot in edit mode.
- Restored the standard 'X' close button via `PokaSheetHeader` so users can safely cancel out of editing. Deletion with full confirmation dialog remains safely accessible on `DebtDetailPage`.
- Updated widget tests in `test/feature/features/debts/presentation/widgets/debt_form_sheet_test.dart` to assert the close button is present and the direct trash icon is omitted.
- Updated `CHANGELOG.md` and `BUG.md` action items.

### Verification
- `flutter test test/feature/features/debts/` (all 32 passed)
- `rune fix` & `rune check` (No issues found!)