### PR TITLE
fix(debts): enable edit and delete swipe interactions on repayment tiles (#43)

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -776,7 +776,7 @@ On the **Reports Page (`ReportListPage`)**:
 5. [ ] Add `restoreWarningDesc` localization key and fix copy in restore confirmation dialog (BUG-005 — [#40](https://github.com/getpoka/poka-ce/issues/40)).
 6. [ ] Properly close database connection, clean WAL/SHM files, and reload all providers reactively on restore without requiring app restart (BUG-006 — [#41](https://github.com/getpoka/poka-ce/issues/41)).
 7. [ ] Fix date formatting locale, `TransactionTypeSwitcher` tabs, and default category translations on the Transactions page (BUG-007 — [#42](https://github.com/getpoka/poka-ce/issues/42)).
-8. [ ] Enable swipe-to-edit and swipe-to-delete on repayment tiles in `DebtDetailPage` (BUG-008 — [#43](https://github.com/getpoka/poka-ce/issues/43)).
+8. [x] Enable swipe-to-edit and swipe-to-delete on repayment tiles in [`DebtDetailPage`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/screens/debt_detail_page.dart) (BUG-008 — [#43](https://github.com/getpoka/poka-ce/issues/43)).
 9. [ ] Handle debt repayment semantic labeling and icon in `RecentTransactionTile` to eliminate "Uncategorized" (BUG-009 — [#44](https://github.com/getpoka/poka-ce/issues/44)).
 10. [x] Restore standard 'X' close button on [`DebtFormSheet`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/widgets/debt_form_sheet.dart) by removing the unconfirmed header trash action (BUG-010 — [#45](https://github.com/getpoka/poka-ce/issues/45)).
 11. [ ] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing allocation badge (Need, Want, Saving) on split item preview list in transaction creation sheet.
 - Resolved category resolution for split transaction child items when expanded, preventing them from falling back to "Uncategorized".
 - Restored standard close button on Debt edit sheet and eliminated unconfirmed direct delete action.
+- Added swipe-to-edit and swipe-to-delete interactions to repayment history items in Debt detail page.
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/features/debts/presentation/controllers/debt_detail_notifier.dart
+++ b/lib/features/debts/presentation/controllers/debt_detail_notifier.dart
@@ -1,10 +1,14 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/core/error/failure.dart';
 import 'package:poka_ce/core/error/result.dart';
+import 'package:poka_ce/features/accounts/presentation/controllers/account_list_notifier.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/debts/domain/debt_model.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_list_notifier.dart';
 import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
+import 'package:poka_ce/features/transactions/presentation/controllers/transaction_list_notifier.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -73,5 +77,18 @@ class DebtDetailNotifier extends _$DebtDetailNotifier {
       return true;
     }
     return false;
+  }
+
+  /// Deletes a repayment transaction by its [transactionId] linked to this debt, reversing the balance mutation.
+  Future<Result<void, Failure>> deleteRepayment(String transactionId) async {
+    final result = await ref.read(transactionRepositoryProvider).deleteTransaction(transactionId);
+    if (result case Success()) {
+      ref
+        ..invalidate(debtListProvider)
+        ..invalidate(dashboardProvider)
+        ..invalidate(accountListProvider)
+        ..invalidate(transactionListNotifierProvider);
+    }
+    return result;
   }
 }

--- a/lib/features/debts/presentation/screens/debt_detail_page.dart
+++ b/lib/features/debts/presentation/screens/debt_detail_page.dart
@@ -1,19 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/core/enums.dart';
 import 'package:poka_ce/features/accounts/domain/account_model.dart';
 import 'package:poka_ce/features/accounts/presentation/controllers/account_list_notifier.dart';
 import 'package:poka_ce/features/categories/domain/category_model.dart';
 import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/debts/domain/debt_model.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_detail_notifier.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_list_notifier.dart';
 import 'package:poka_ce/features/debts/presentation/widgets/debt_card.dart';
 import 'package:poka_ce/features/debts/presentation/widgets/debt_form_sheet.dart';
 import 'package:poka_ce/features/debts/presentation/widgets/debt_repayment_sheet.dart';
+import 'package:poka_ce/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/tile/transaction_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
 import 'package:poka_ce/shared/widgets/poka_empty_view.dart';
 import 'package:poka_ce/shared/widgets/poka_header.dart';
 import 'package:poka_ce/shared/widgets/poka_section_label.dart';
@@ -143,6 +147,26 @@ class DebtDetailPage extends ConsumerWidget {
                         categoriesById: categoriesById,
                         category: category,
                         account: account,
+                        onTap: () {
+                          TransactionFormSheet.show(context, initialTransaction: transaction);
+                        },
+                        onEdit: () {
+                          TransactionFormSheet.show(context, initialTransaction: transaction);
+                        },
+                        onDelete: () async {
+                          final confirmed = await showPokaConfirmDialog(
+                            context,
+                            title: t.transactions.deleteTransaction,
+                            body: t.transactions.deleteTransactionWarning,
+                          );
+                          if (confirmed == true) {
+                            await ref.read(transactionRepositoryProvider).deleteTransaction(transaction.id);
+                            ref
+                              ..invalidate(debtListProvider)
+                              ..invalidate(dashboardProvider)
+                              ..invalidate(debtTransactionsProvider(activeDebt));
+                          }
+                        },
                       ),
                     );
                   },

--- a/lib/features/debts/presentation/screens/debt_detail_page.dart
+++ b/lib/features/debts/presentation/screens/debt_detail_page.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/core/enums.dart';
+import 'package:poka_ce/core/error/result.dart';
 import 'package:poka_ce/features/accounts/domain/account_model.dart';
 import 'package:poka_ce/features/accounts/presentation/controllers/account_list_notifier.dart';
 import 'package:poka_ce/features/categories/domain/category_model.dart';
 import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
-import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/debts/domain/debt_model.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_detail_notifier.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_list_notifier.dart';
@@ -160,11 +159,18 @@ class DebtDetailPage extends ConsumerWidget {
                             body: t.transactions.deleteTransactionWarning,
                           );
                           if (confirmed == true) {
-                            await ref.read(transactionRepositoryProvider).deleteTransaction(transaction.id);
-                            ref
-                              ..invalidate(debtListProvider)
-                              ..invalidate(dashboardProvider)
-                              ..invalidate(debtTransactionsProvider(activeDebt));
+                            final result = await ref.read(debtDetailProvider.notifier).deleteRepayment(transaction.id);
+                            if (context.mounted) {
+                              switch (result) {
+                                case Success():
+                                  ref.invalidate(debtTransactionsProvider(activeDebt));
+                                case ErrorResult():
+                                  showFToast(
+                                    context: context,
+                                    title: Text(t.common.error),
+                                  );
+                              }
+                            }
                           }
                         },
                       ),

--- a/test/feature/features/debts/presentation/screens/debt_detail_page_test.dart
+++ b/test/feature/features/debts/presentation/screens/debt_detail_page_test.dart
@@ -75,6 +75,7 @@ void main() {
   setUp(() {
     mockTxRepo = MockTransactionRepo();
     mockUseCase = MockUpdateTransactionUseCase();
+    when(() => mockTxRepo.deleteTransaction(any())).thenAnswer((_) async => const Success(null));
   });
 
   DebtModel debt({DebtType type = DebtType.debt, DebtStatus status = DebtStatus.active}) => DebtModel(
@@ -170,6 +171,47 @@ void main() {
 
       expect(find.text(t.debts.noHistoryFoundForThis(type: t.debts.payable)), findsNothing);
       expect(find.byType(RecentTransactionTile), findsWidgets);
+    });
+
+    testWidgets('repayment transaction tile supports swipe to reveal edit and delete actions', (tester) async {
+      await tester.pumpWidget(
+        wrap(activeDebt: debt(), transactions: [tx()]),
+      );
+      await tester.pumpAndSettle();
+
+      final repaymentTile = find.byType(RecentTransactionTile).first;
+      expect(repaymentTile, findsOneWidget);
+
+      // Drag to reveal start action pane (delete)
+      await tester.drag(repaymentTile, const Offset(300, 0));
+      await tester.pumpAndSettle();
+
+      // Slidable action with trash icon should appear
+      expect(find.byIcon(FPhosphorIcons.trash), findsWidgets);
+    });
+
+    testWidgets('deleting repayment transaction prompts confirmation and deletes transaction', (tester) async {
+      await tester.pumpWidget(
+        wrap(activeDebt: debt(), transactions: [tx()]),
+      );
+      await tester.pumpAndSettle();
+
+      final repaymentTile = find.byType(RecentTransactionTile).first;
+      await tester.drag(repaymentTile, const Offset(300, 0));
+      await tester.pumpAndSettle();
+
+      // Tap delete slidable action
+      await tester.tap(find.byIcon(FPhosphorIcons.trash).last);
+      await tester.pumpAndSettle();
+
+      // Confirmation dialog should be shown
+      expect(find.text(t.transactions.deleteTransaction), findsOneWidget);
+
+      // Confirm deletion
+      await tester.tap(find.text(t.common.delete));
+      await tester.pumpAndSettle();
+
+      verify(() => mockTxRepo.deleteTransaction('tx1')).called(1);
     });
   });
 }


### PR DESCRIPTION
Closes #43

### Summary
- In `DebtDetailPage` (`lib/features/debts/presentation/screens/debt_detail_page.dart`), added `onTap`, `onEdit`, and `onDelete` callbacks to `RecentTransactionTile` in the Repayment History section.
- Tapping or swiping to edit opens `TransactionFormSheet` prefilled with the repayment transaction.
- Swiping to delete presents a `showPokaConfirmDialog` confirmation before deleting the transaction and invalidating relevant debt, dashboard, and transaction providers.
- Added comprehensive widget tests in `test/feature/features/debts/presentation/screens/debt_detail_page_test.dart`.
- Updated `CHANGELOG.md` and `BUG.md` action items.

### Verification
- `flutter test test/feature/features/debts/presentation/screens/debt_detail_page_test.dart` (all passed)
- `rune fix` & `rune check` (No issues found!)