### PR TITLE
fix(transactions): add semantic labels to unassigned debt repayment transactions (#44)

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -777,7 +777,7 @@ On the **Reports Page (`ReportListPage`)**:
 6. [ ] Properly close database connection, clean WAL/SHM files, and reload all providers reactively on restore without requiring app restart (BUG-006 — [#41](https://github.com/getpoka/poka-ce/issues/41)).
 7. [ ] Fix date formatting locale, `TransactionTypeSwitcher` tabs, and default category translations on the Transactions page (BUG-007 — [#42](https://github.com/getpoka/poka-ce/issues/42)).
 8. [x] Enable swipe-to-edit and swipe-to-delete on repayment tiles in [`DebtDetailPage`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/screens/debt_detail_page.dart) (BUG-008 — [#43](https://github.com/getpoka/poka-ce/issues/43)).
-9. [ ] Handle debt repayment semantic labeling and icon in `RecentTransactionTile` to eliminate "Uncategorized" (BUG-009 — [#44](https://github.com/getpoka/poka-ce/issues/44)).
+9. [x] Handle debt repayment semantic labeling and icon in `RecentTransactionTile` to eliminate "Uncategorized" (BUG-009 — [#44](https://github.com/getpoka/poka-ce/issues/44)).
 10. [x] Restore standard 'X' close button on [`DebtFormSheet`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/widgets/debt_form_sheet.dart) by removing the unconfirmed header trash action (BUG-010 — [#45](https://github.com/getpoka/poka-ce/issues/45)).
 11. [ ] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).
 12. [ ] Implement `showPokaToast` with watchdog timer to eliminate stuck toasts across mobile touch events and route transitions (BUG-012 — [#46](https://github.com/getpoka/poka-ce/issues/46)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved category resolution for split transaction child items when expanded, preventing them from falling back to "Uncategorized".
 - Restored standard close button on Debt edit sheet and eliminated unconfirmed direct delete action.
 - Added swipe-to-edit and swipe-to-delete interactions to repayment history items in Debt detail page.
+- Add semantic debt and loan labels and handshake icon for unassigned debt repayment transactions in `RecentTransactionTile` (fixes #44).
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
+++ b/lib/features/transactions/presentation/widgets/tile/transaction_tile.dart
@@ -160,14 +160,26 @@ class RecentTransactionTile extends HookConsumerWidget with FTileMixin {
         category ??
         (!isSubItem && firstItem?.categoryId != null ? effectiveCategoriesById[firstItem!.categoryId] : null);
 
+    final isDebtLinked = transaction.debtId != null;
+
     // ── Category icon + color ──────────────────────────────────────────────
-    var catColor = resolvedCategory?.color?.toColor() ?? theme.colors.primary;
-    var catIcon = IconUtil.getIcon(resolvedCategory?.icon);
+    var catColor =
+        resolvedCategory?.color?.toColor() ??
+        (isDebtLinked
+            ? (transaction.type == TransactionType.expense ? theme.colors.app.expense : theme.colors.app.income)
+            : theme.colors.primary);
+    var catIcon = isDebtLinked && resolvedCategory == null
+        ? FPhosphorIcons.handshake
+        : IconUtil.getIcon(resolvedCategory?.icon);
 
     // ── Category label ─────────────────────────────────────────────────────
     var catLabel =
         resolvedCategory?.name ??
-        (transaction.type == TransactionType.transfer ? t.transactions.transfer : t.common.uncategorized);
+        (transaction.type == TransactionType.transfer
+            ? t.transactions.transfer
+            : (isDebtLinked
+                  ? (transaction.type == TransactionType.expense ? t.debts.debtTypeDebt : t.debts.debtTypeLoan)
+                  : t.common.uncategorized));
 
     IconData? subCatIcon;
     Color? subCatColor;
@@ -319,6 +331,7 @@ class RecentTransactionTile extends HookConsumerWidget with FTileMixin {
                   updatedAt: item.updatedAt,
                   destinationAccountId: transaction.destinationAccountId,
                   note: item.note ?? transaction.note,
+                  debtId: transaction.debtId,
                   items: [item],
                 );
 

--- a/test/feature/features/transactions/presentation/widgets/tile/transaction_tile_test.dart
+++ b/test/feature/features/transactions/presentation/widgets/tile/transaction_tile_test.dart
@@ -7,6 +7,7 @@ import 'package:poka_ce/features/categories/domain/category_model.dart';
 import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
 import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/tile/transaction_tile.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 class MockCategoryListNotifier extends CategoryListNotifier {
@@ -15,6 +16,8 @@ class MockCategoryListNotifier extends CategoryListNotifier {
 }
 
 void main() {
+  setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
+
   Widget buildTestApp(Widget child, ProviderContainer container) {
     return UncontrolledProviderScope(
       container: container,
@@ -158,6 +161,98 @@ void main() {
     // - No item shows "Uncategorized"
     expect(find.text('Food & Dining'), findsNWidgets(2));
     expect(find.text('Transport'), findsOneWidget);
+    expect(find.text('Uncategorized'), findsNothing);
+  });
+
+  testWidgets('RecentTransactionTile renders semantic debt label and handshake icon for unassigned debt expense', (
+    tester,
+  ) async {
+    final debtTransaction = TransactionModel(
+      id: 'tx-debt',
+      accountId: 'acc-1',
+      type: TransactionType.expense,
+      amount: 250000,
+      debtId: 'debt-123',
+      transactionDate: DateTime.now(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      items: [
+        TransactionItemModel(
+          id: 'item-1',
+          transactionId: 'tx-debt',
+          categoryId: null,
+          amount: 250000,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        categoryListProvider.overrideWith(() => MockCategoryListNotifier()),
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildTestApp(
+        RecentTransactionTile(
+          transaction: debtTransaction,
+          isBalanceVisible: true,
+        ),
+        container,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Debt'), findsWidgets);
+    expect(find.byIcon(FPhosphorIcons.handshake), findsWidgets);
+    expect(find.text('Uncategorized'), findsNothing);
+  });
+
+  testWidgets('RecentTransactionTile renders semantic loan label and handshake icon for unassigned loan income', (
+    tester,
+  ) async {
+    final loanTransaction = TransactionModel(
+      id: 'tx-loan',
+      accountId: 'acc-1',
+      type: TransactionType.income,
+      amount: 150000,
+      debtId: 'loan-123',
+      transactionDate: DateTime.now(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      items: [
+        TransactionItemModel(
+          id: 'item-2',
+          transactionId: 'tx-loan',
+          categoryId: null,
+          amount: 150000,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        categoryListProvider.overrideWith(() => MockCategoryListNotifier()),
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildTestApp(
+        RecentTransactionTile(
+          transaction: loanTransaction,
+          isBalanceVisible: true,
+        ),
+        container,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Loan'), findsWidgets);
+    expect(find.byIcon(FPhosphorIcons.handshake), findsWidgets);
     expect(find.text('Uncategorized'), findsNothing);
   });
 }


### PR DESCRIPTION
## Description
Fixes #44 (BUG-009)

When debt repayment transactions are recorded, they are generated with a null category. In transaction lists, these transactions previously rendered as generic 'Uncategorized' with a fallback tag icon.

### Changes
- Automatically resolve category from `effectiveCategoriesById` if not directly provided.
- If a transaction is linked to a debt (`debtId != null`) and has no explicit category:
  - Label resolves to semantic Debt / Loan based on transaction type (`t.debts.debtTypeDebt` for expense, `t.debts.debtTypeLoan` for income).
  - Icon resolves to `FPhosphorIcons.handshake`.
  - Color resolves to theme expense / income color.
- Pass `debtId` to child `fakeTx` transactions in `RecentTransactionTile` sub-item list.
- Add comprehensive widget tests in `transaction_tile_test.dart`.

### Verification
- `rune fix` applied.
- `rune check` -> 'No issues found!'.
- Widget tests pass.