### PR TITLE
fix(backup): cleanly close database and reload state on restore (#41)

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -774,7 +774,7 @@ On the **Reports Page (`ReportListPage`)**:
 3. [x] ~~Add `recurring_period` column in Drift schema and snapshot period in `RecurringProcessorService`~~ (BUG-003 — **Marked Invalid / Working as Designed per `database-schema.md`**; candidate for future feature discussion).
 4. [ ] Make `SettingsNotifier` keep-alive (`@Riverpod(keepAlive: true)`), remove `_disposed` flag issue, and ensure base currency changes take effect immediately across all sessions (BUG-004 — [#39](https://github.com/getpoka/poka-ce/issues/39)).
 5. [x] Add `restoreWarningDesc` localization key and fix copy in restore confirmation dialog (BUG-005 — [#40](https://github.com/getpoka/poka-ce/issues/40)).
-6. [ ] Properly close database connection, clean WAL/SHM files, and reload all providers reactively on restore without requiring app restart (BUG-006 — [#41](https://github.com/getpoka/poka-ce/issues/41)).
+6. [x] Properly close database connection, clean WAL/SHM files, and reload all providers reactively on restore without requiring app restart (BUG-006 — [#41](https://github.com/getpoka/poka-ce/issues/41)).
 7. [ ] Fix date formatting locale, `TransactionTypeSwitcher` tabs, and default category translations on the Transactions page (BUG-007 — [#42](https://github.com/getpoka/poka-ce/issues/42)).
 8. [x] Enable swipe-to-edit and swipe-to-delete on repayment tiles in [`DebtDetailPage`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/screens/debt_detail_page.dart) (BUG-008 — [#43](https://github.com/getpoka/poka-ce/issues/43)).
 9. [x] Handle debt repayment semantic labeling and icon in `RecentTransactionTile` to eliminate "Uncategorized" (BUG-009 — [#44](https://github.com/getpoka/poka-ce/issues/44)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added swipe-to-edit and swipe-to-delete interactions to repayment history items in Debt detail page.
 - Add semantic debt and loan labels and handshake icon for unassigned debt repayment transactions in `RecentTransactionTile` (fixes #44).
 - Correct confirmation dialog description for backup restore to accurately describe data replacement instead of data deletion (fixes #40).
+- Ensure clean database teardown and WAL/SHM file cleanup before disk write on backup restore, and reload all feature state providers reactively without requiring app restart (fixes #41).
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/app/providers/repository_providers.dart
+++ b/lib/app/providers/repository_providers.dart
@@ -22,7 +22,9 @@ import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
 
 /// Provides the singleton instance of the AppDatabase.
 final databaseProvider = Provider<AppDatabase>((ref) {
-  return AppDatabase();
+  final db = AppDatabase();
+  ref.onDispose(db.close);
+  return db;
 });
 
 /// Provides the [IUnitOfWork] implementation.

--- a/lib/app/providers/repository_providers.dart
+++ b/lib/app/providers/repository_providers.dart
@@ -23,7 +23,11 @@ import 'package:poka_ce/features/transactions/domain/transaction_model.dart';
 /// Provides the singleton instance of the AppDatabase.
 final databaseProvider = Provider<AppDatabase>((ref) {
   final db = AppDatabase();
-  ref.onDispose(db.close);
+  ref.onDispose(() async {
+    try {
+      await db.close();
+    } on Object catch (_) {}
+  });
   return db;
 });
 

--- a/lib/features/backup/data/backup_service.dart
+++ b/lib/features/backup/data/backup_service.dart
@@ -109,7 +109,11 @@ class BackupService {
   ///
   /// Unpacks the binary envelope, derives the AES key with the embedded salt, and verifies
   /// the authentication tag before writing back to disk to prevent corrupted restores.
-  Future<Result<Unit>> restoreEncryptedBackup(String backupFilePath, String password) async {
+  Future<Result<Unit>> restoreEncryptedBackup(
+    String backupFilePath,
+    String password, {
+    Future<void> Function()? onBeforeWrite,
+  }) async {
     try {
       final backupFile = File(backupFilePath);
       if (!backupFile.existsSync()) {
@@ -145,6 +149,9 @@ class BackupService {
         secretKey: key,
       );
 
+      // Cleanly teardown any active database handles before modifying files on disk
+      await onBeforeWrite?.call();
+
       // Overwrite db file
       final docsFolder = await getApplicationDocumentsDirectory();
       final supportFolder = await getApplicationSupportDirectory();
@@ -164,6 +171,20 @@ class BackupService {
       }
 
       dbFile ??= File(p.join(supportFolder.path, dbName));
+
+      // Clean up stale WAL and SHM journal files to prevent SQLite from reading cached pages
+      final walFile = File('${dbFile.path}-wal');
+      if (walFile.existsSync()) {
+        try {
+          await walFile.delete();
+        } on Exception catch (_) {}
+      }
+      final shmFile = File('${dbFile.path}-shm');
+      if (shmFile.existsSync()) {
+        try {
+          await shmFile.delete();
+        } on Exception catch (_) {}
+      }
 
       await dbFile.writeAsBytes(clearText, flush: true);
 

--- a/lib/features/backup/presentation/controllers/backup_controller.dart
+++ b/lib/features/backup/presentation/controllers/backup_controller.dart
@@ -56,6 +56,7 @@ class BackupController extends _$BackupController {
   /// Returns `true` if decryption and database replacement succeeded.
   Future<bool> restore(String password, String filePath) async {
     state = const AsyncLoading();
+    var dbClosed = false;
     try {
       final service = ref.read(backupServiceProvider);
       final result = await service.restoreEncryptedBackup(
@@ -63,6 +64,7 @@ class BackupController extends _$BackupController {
         password,
         onBeforeWrite: () async {
           await ref.read(databaseProvider).close();
+          dbClosed = true;
         },
       );
       if (result.isSuccess()) {
@@ -78,6 +80,10 @@ class BackupController extends _$BackupController {
     } on Object catch (e, st) {
       state = AsyncError(e, st);
       return false;
+    } finally {
+      if (dbClosed) {
+        ref.invalidate(databaseProvider);
+      }
     }
   }
 }

--- a/lib/features/backup/presentation/controllers/backup_controller.dart
+++ b/lib/features/backup/presentation/controllers/backup_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/features/backup/data/backup_service.dart';
 import 'package:poka_ce/features/backup/domain/backup_reminder_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -57,7 +58,13 @@ class BackupController extends _$BackupController {
     state = const AsyncLoading();
     try {
       final service = ref.read(backupServiceProvider);
-      final result = await service.restoreEncryptedBackup(filePath, password);
+      final result = await service.restoreEncryptedBackup(
+        filePath,
+        password,
+        onBeforeWrite: () async {
+          await ref.read(databaseProvider).close();
+        },
+      );
       if (result.isSuccess()) {
         state = const AsyncData(null);
         return true;

--- a/lib/features/settings/presentation/widgets/sections/data_management_section.dart
+++ b/lib/features/settings/presentation/widgets/sections/data_management_section.dart
@@ -14,8 +14,13 @@ import 'package:poka_ce/features/backup/presentation/controllers/backup_controll
 import 'package:poka_ce/features/backup/presentation/sheets/backup_password_sheet.dart';
 import 'package:poka_ce/features/backup/presentation/sheets/backup_reminder_sheet.dart';
 import 'package:poka_ce/features/backup/presentation/sheets/backup_restore_action_sheet.dart';
+import 'package:poka_ce/features/budgets/presentation/controllers/budget_list_notifier.dart';
 import 'package:poka_ce/features/categories/presentation/controllers/category_list_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
+import 'package:poka_ce/features/debts/presentation/controllers/debt_list_notifier.dart';
+import 'package:poka_ce/features/goals/presentation/controllers/goal_notifier.dart';
+import 'package:poka_ce/features/recurring/presentation/controllers/recurring_list_notifier.dart';
+import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/settings/presentation/controllers/app_lock_controller.dart';
 import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
 import 'package:poka_ce/features/settings/presentation/sheets/pin_setup_sheet.dart';
@@ -145,17 +150,19 @@ class DataManagementSection extends ConsumerWidget {
               if (password == null) return;
               if (!context.mounted) return;
 
-              // Invalidate root database provider to force recreation
-              unawaited(container.read(databaseProvider).close());
-
-              // Refresh all Riverpod state like in Reset Data
+              // Refresh all Riverpod state
               container
                 ..invalidate(databaseProvider)
                 ..invalidate(settingsProvider)
                 ..invalidate(dashboardProvider)
                 ..invalidate(accountListProvider)
                 ..invalidate(categoryListProvider)
-                ..invalidate(transactionListNotifierProvider);
+                ..invalidate(transactionListNotifierProvider)
+                ..invalidate(budgetListProvider)
+                ..invalidate(goalProvider)
+                ..invalidate(debtListProvider)
+                ..invalidate(recurringListProvider)
+                ..invalidate(reportProvider);
 
               showFToast(
                 context: context,
@@ -248,7 +255,12 @@ class DataManagementSection extends ConsumerWidget {
               ..invalidate(dashboardProvider)
               ..invalidate(accountListProvider)
               ..invalidate(categoryListProvider)
-              ..invalidate(transactionListNotifierProvider);
+              ..invalidate(transactionListNotifierProvider)
+              ..invalidate(budgetListProvider)
+              ..invalidate(goalProvider)
+              ..invalidate(debtListProvider)
+              ..invalidate(recurringListProvider)
+              ..invalidate(reportProvider);
 
             if (!context.mounted) return;
             showFToast(

--- a/test/unit/features/backup/data/backup_service_test.dart
+++ b/test/unit/features/backup/data/backup_service_test.dart
@@ -213,5 +213,30 @@ void main() {
       final res = await service.restoreEncryptedBackup(corruptFile.path, 'pass123');
       expect(res.isSuccess(), isFalse);
     });
+
+    test('restoreEncryptedBackup — cleans up WAL/SHM files and invokes onBeforeWrite', () async {
+      const dbContent = 'wal-shm-test-content';
+      final dbFile = await createFakeDb(content: dbContent);
+      final walFile = File('${dbFile.path}-wal')..writeAsStringSync('wal-bytes');
+      final shmFile = File('${dbFile.path}-shm')..writeAsStringSync('shm-bytes');
+
+      final enc = await service.createEncryptedBackup('walPass');
+      expect(enc.isSuccess(), isTrue);
+      final backupFile = enc.getOrThrow();
+
+      var beforeWriteCalled = false;
+      final res = await service.restoreEncryptedBackup(
+        backupFile.path,
+        'walPass',
+        onBeforeWrite: () async {
+          beforeWriteCalled = true;
+        },
+      );
+
+      expect(res.isSuccess(), isTrue);
+      expect(beforeWriteCalled, isTrue);
+      expect(walFile.existsSync(), isFalse);
+      expect(shmFile.existsSync(), isFalse);
+    });
   });
 }

--- a/test/unit/features/backup/presentation/controllers/backup_controller_test.dart
+++ b/test/unit/features/backup/presentation/controllers/backup_controller_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:poka_ce/app/providers/repository_providers.dart';
+import 'package:poka_ce/database/database.dart';
 import 'package:poka_ce/features/backup/data/backup_service.dart';
 import 'package:poka_ce/features/backup/domain/backup_reminder_service.dart';
 import 'package:poka_ce/features/backup/presentation/controllers/backup_controller.dart';
@@ -13,6 +15,8 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class MockBackupService extends Mock implements BackupService {}
 
 class MockBackupReminderService extends Mock implements BackupReminderService {}
+
+class MockAppDatabase extends Mock implements AppDatabase {}
 
 class FakeSharePlatform extends SharePlatform with MockPlatformInterfaceMixin {
   @override
@@ -26,11 +30,14 @@ void main() {
 
   late MockBackupService mockService;
   late MockBackupReminderService mockReminderService;
+  late MockAppDatabase mockDb;
   late SharePlatform originalSharePlatform;
 
   setUp(() {
     mockService = MockBackupService();
     mockReminderService = MockBackupReminderService();
+    mockDb = MockAppDatabase();
+    when(() => mockDb.close()).thenAnswer((_) async {});
     when(() => mockReminderService.recordBackupCompleted(any())).thenAnswer((_) async {});
     when(() => mockReminderService.recordBackupCompleted()).thenAnswer((_) async {});
     originalSharePlatform = SharePlatform.instance;
@@ -45,6 +52,7 @@ void main() {
   ProviderContainer createContainer() {
     final container = ProviderContainer(
       overrides: [
+        databaseProvider.overrideWithValue(mockDb),
         backupServiceProvider.overrideWithValue(mockService),
         backupReminderServiceProvider.overrideWithValue(mockReminderService),
       ],
@@ -120,7 +128,12 @@ void main() {
     });
 
     test('restore() — on success: state = data, returns true', () async {
-      when(() => mockService.restoreEncryptedBackup(any(), any())).thenAnswer((_) async => const Success(unit));
+      when(() => mockService.restoreEncryptedBackup(any(), any(), onBeforeWrite: any(named: 'onBeforeWrite')))
+          .thenAnswer((invocation) async {
+            final onBefore = invocation.namedArguments[#onBeforeWrite] as Future<void> Function()?;
+            await onBefore?.call();
+            return const Success(unit);
+          });
 
       final container = createContainer();
       final notifier = container.read(backupControllerProvider.notifier);
@@ -132,12 +145,16 @@ void main() {
       expect(result, isTrue);
       expect(container.read(backupControllerProvider).hasValue, isTrue);
       expect(container.read(backupControllerProvider).hasError, isFalse);
-      verify(() => mockService.restoreEncryptedBackup('/tmp/file.enc.db', 'pass')).called(1);
+      verify(
+        () =>
+            mockService.restoreEncryptedBackup('/tmp/file.enc.db', 'pass', onBeforeWrite: any(named: 'onBeforeWrite')),
+      ).called(1);
+      verify(() => mockDb.close()).called(1);
     });
 
     test('restore() — on failure: state = error, returns false', () async {
       when(
-        () => mockService.restoreEncryptedBackup(any(), any()),
+        () => mockService.restoreEncryptedBackup(any(), any(), onBeforeWrite: any(named: 'onBeforeWrite')),
       ).thenAnswer((_) async => Failure(Exception('wrong password')));
 
       final container = createContainer();
@@ -153,7 +170,8 @@ void main() {
     });
 
     test('restore() — on Exception thrown: state = error, returns false', () async {
-      when(() => mockService.restoreEncryptedBackup(any(), any())).thenThrow(Exception('io error'));
+      when(() => mockService.restoreEncryptedBackup(any(), any(), onBeforeWrite: any(named: 'onBeforeWrite')))
+          .thenThrow(Exception('io error'));
 
       final container = createContainer();
       final result = await container.read(backupControllerProvider.notifier).restore('pass', '/tmp/x');


### PR DESCRIPTION
## Description
Fixes #41 (BUG-006)

After restoring a database backup, the app previously did not reflect restored accounts, transactions, or settings without restarting the application. The root cause was that the active SQLite database was overwritten while connection handles and WAL/SHM journal files remained active, coupled with incomplete state invalidation.

### Changes
- Registered `ref.onDispose(db.close)` on `databaseProvider` in `repository_providers.dart`.
- Added `onBeforeWrite` hook to `BackupService.restoreEncryptedBackup` and wired it in `BackupController.restore` to cleanly await `databaseProvider.close()` before modifying files on disk.
- Cleaned up stale SQLite `-wal` and `-shm` journal files before overwriting the primary database file.
- Comprehensive invalidation of all domain state providers (`databaseProvider`, `settingsProvider`, `dashboardProvider`, `accountListProvider`, `categoryListProvider`, `transactionListNotifierProvider`, `budgetListProvider`, `goalProvider`, `debtListProvider`, `recurringListProvider`, `reportProvider`) upon restore and reset.
- Added tests for `onBeforeWrite` and WAL/SHM file cleanup.

### Verification
- `rune fix` & `rune check` -> 'No issues found!'.
- Backup unit tests and widget tests pass.