### PR TITLE
fix(dashboard): respect balance privacy toggle across cards and stats

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -781,7 +781,7 @@ On the **Reports Page (`ReportListPage`)**:
 10. [x] Restore standard 'X' close button on [`DebtFormSheet`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/widgets/debt_form_sheet.dart) by removing the unconfirmed header trash action (BUG-010 — [#45](https://github.com/getpoka/poka-ce/issues/45)).
 11. [ ] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).
 12. [ ] Implement `showPokaToast` with watchdog timer to eliminate stuck toasts across mobile touch events and route transitions (BUG-012 — [#46](https://github.com/getpoka/poka-ce/issues/46)).
-13. [ ] Implement privacy eye obfuscation (`isVisible`) across Dashboard Cashflow, Spending Activity, Categories, and Budgets (BUG-013 — [#47](https://github.com/getpoka/poka-ce/issues/47)).
+13. [x] Implement privacy eye obfuscation (`isVisible`) across Dashboard Cashflow, Spending Activity, Categories, and Budgets (BUG-013 — [#47](https://github.com/getpoka/poka-ce/issues/47)).
 14. [ ] Implement privacy eye obfuscation and add header toggle button on Reports page (BUG-014 — [#48](https://github.com/getpoka/poka-ce/issues/48)).
 15. [ ] Implement Notification Permission Rationale Sheet and manual test trigger for Backup Reminder (BUG-015 — [#49](https://github.com/getpoka/poka-ce/issues/49)).
 16. [ ] Run `rune generate`, `rune fix`, `rune check`, and `rune test` to verify zero issues upon bug resolution.

--- a/BUG.md
+++ b/BUG.md
@@ -20,7 +20,7 @@ This document records the bug findings identified during the **Smoke Testing** p
 | **BUG-010** | `Debts / Form Sheet UX` | Debt Edit sheet replaces the standard 'X' close button with an unconfirmed direct delete (trash) button in header trailing | High (Destructive UX / Misleading Action) | ✅ Valid ([#45](https://github.com/getpoka/poka-ce/issues/45)) |
 | **BUG-011** | `Transactions & Feedback / Toast Ergonomics` | Delete confirmation toast with actionable "Undo" button is positioned at topCenter instead of floating bottomCenter, making the time-sensitive "Undo" action unreachable with one thumb on mobile devices | Medium (Ergonomics & Actionable UX Defect) | ✅ Valid (Subsumed by [#46](https://github.com/getpoka/poka-ce/issues/46)) |
 | **BUG-012** | `App Shell / Toast System (FToaster)` | Toasts frequently freeze and fail to auto-dismiss ("tidak hilang-hilang / kadang hilang, kadang stuck") due to mobile touch events killing `_timer` without resuming, tap-to-toggle autoDismiss, and route transition race conditions | High (Reliability & UX Defect) | ✅ Valid ([#46](https://github.com/getpoka/poka-ce/issues/46)) |
-| **BUG-013** | `Dashboard / Privacy Eye (Hide Balance)` | Cashflow, Spending Activity, Categories, and Budget carousel cards ignore `balanceVisibilityProvider` and continue displaying raw monetary values when privacy eye is toggled | High (Privacy & Data Protection Defect) | ✅ Valid ([#47](https://github.com/getpoka/poka-ce/issues/47)) |
+| **BUG-013** | `Dashboard / Privacy Eye (Hide Balance)` | Cashflow, Spending Activity, Categories, and Budget carousel cards ignore `balanceVisibilityProvider` and continue displaying raw monetary values when privacy eye is toggled | High (Privacy & Data Protection Defect) | 🟢 Solved ([#47](https://github.com/getpoka/poka-ce/issues/47)) |
 | **BUG-014** | `Reports / Privacy Eye (Hide Balance)` | Category ranking, spending allocation splits, and chart tooltips bypass `balanceVisibilityProvider`, and ReportListPage lacks a header privacy eye toggle | High (Privacy & Data Protection Defect) | ✅ Valid ([#48](https://github.com/getpoka/poka-ce/issues/48)) |
 | **BUG-015** | `Backup & Notifications / Permission & Testing` | Changing Backup Reminder from 'Off' to 'Weekly'/'Monthly' never requests notification runtime permission on Android 13+ & iOS (silent reminder failure), and app lacks an immediate test notification trigger | High (Core Feature Reliability & Testability) | ✅ Valid ([#49](https://github.com/getpoka/poka-ce/issues/49)) |
 
@@ -613,7 +613,7 @@ Introduce a centralized, battle-tested toast helper in [`lib/shared/widgets/poka
 ### 13. BUG-013: Privacy Eye / Balance Obfuscation Bypassed on Dashboard Sections (Cashflow, Spending Activity, Categories, Budgets)
 
 > [!NOTE]
-> **Verification Status:** ✅ **Valid** | **GitHub Issue:** [#47](https://github.com/getpoka/poka-ce/issues/47)
+> **Verification Status:** 🟢 **Solved** | **GitHub Issue:** [#47](https://github.com/getpoka/poka-ce/issues/47)
 
 #### A. Problem Description
 Poka provides an eye icon toggle (`balanceVisibilityProvider`) to obscure sensitive monetary balances (e.g. `••••••` or `Rp ••••••`) when looking at the screen in public.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure base currency selected during onboarding immediately takes effect across the session by marking `SettingsNotifier` with `keepAlive: true` and removing fragile disposal guards (fixes #39).
 - Fixed unlocalized date headers and month navigation labels on the Transactions page by wiring intl locale initialization and date formatters to active locale.
 - Fixed hardcoded transaction type tab labels in `TransactionTypeSwitcher` to use localized strings.
+- Fixed balance visibility privacy toggle being bypassed across Dashboard cards (Cash Flow, Spending Activity, Categories, and Budgets).
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/core/extensions/num_extension.dart
+++ b/lib/core/extensions/num_extension.dart
@@ -1,10 +1,13 @@
 import 'package:intl/intl.dart';
 
+/// Standard placeholder string used across the app to mask sensitive financial amounts.
+const String kPrivacyMask = '••••••';
+
 /// Formatting helpers for numeric values (integers and doubles).
 extension NumExtension on num {
   /// Converts the number to compact abbreviated string (e.g. 1.2K, 3.4M, 5.0B).
   String toCompactFormat({bool isVisible = true}) {
-    if (!isVisible) return '••••••';
+    if (!isVisible) return kPrivacyMask;
     if (this >= 1000000000) return '${(this / 1000000000).toStringAsFixed(1)}B';
     if (this >= 1000000) return '${(this / 1000000).toStringAsFixed(1)}M';
     if (this >= 1000) return '${(this / 1000).toStringAsFixed(1)}K';
@@ -22,7 +25,7 @@ extension NumExtension on num {
     final cleanSymbol = symbol.trim();
     final effectiveSymbol = cleanSymbol.isEmpty ? '' : '$cleanSymbol ';
 
-    if (!isVisible) return '$effectiveSymbol••••••';
+    if (!isVisible) return '$effectiveSymbol$kPrivacyMask';
 
     final format = NumberFormat.currency(
       locale: (locale == 'system') ? null : locale,

--- a/lib/core/extensions/num_extension.dart
+++ b/lib/core/extensions/num_extension.dart
@@ -3,7 +3,8 @@ import 'package:intl/intl.dart';
 /// Formatting helpers for numeric values (integers and doubles).
 extension NumExtension on num {
   /// Converts the number to compact abbreviated string (e.g. 1.2K, 3.4M, 5.0B).
-  String toCompactFormat() {
+  String toCompactFormat({bool isVisible = true}) {
+    if (!isVisible) return '••••••';
     if (this >= 1000000000) return '${(this / 1000000000).toStringAsFixed(1)}B';
     if (this >= 1000000) return '${(this / 1000000).toStringAsFixed(1)}M';
     if (this >= 1000) return '${(this / 1000).toStringAsFixed(1)}K';

--- a/lib/features/dashboard/presentation/widgets/cards/dashboard_spending_chart.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/dashboard_spending_chart.dart
@@ -2,26 +2,32 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/daily_budget_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/sheets/dashboard_budget_sheet.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/theme/theme.dart';
 
+/// Spending activity chart component displaying weekly velocity bars, totals, and daily budget.
 class DashboardSpendingChart extends HookConsumerWidget {
+  /// Creates a [DashboardSpendingChart].
   const DashboardSpendingChart({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final state = ref.watch(dashboardProvider);
+    final isBalanceVisible = ref.watch(balanceVisibilityProvider);
 
-    final totalExpenseFormatted = state.totalExpense.toCompactFormat();
-    final avgExpenseFormatted = (state.totalExpense / 7).toCompactFormat();
+    final totalExpenseFormatted = state.totalExpense.toCompactFormat(isVisible: isBalanceVisible);
+    final avgExpenseFormatted = (state.totalExpense / 7).toCompactFormat(isVisible: isBalanceVisible);
 
     // Get daily budget
     final dailyBudget = ref.watch(dailyBudgetProvider);
-    final dailyBudgetFormatted = dailyBudget > 0 ? dailyBudget.toCompactFormat() : context.t.dashboard.notSet;
+    final dailyBudgetFormatted = dailyBudget > 0
+        ? dailyBudget.toCompactFormat(isVisible: isBalanceVisible)
+        : context.t.dashboard.notSet;
 
     // Use pre-computed state from DashboardState
     final dailySpending = state.dailySpending;

--- a/lib/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart
@@ -66,8 +66,8 @@ Widget buildCategoryStatRow(BuildContext context, String label, String value, Co
         ),
       ),
       const SizedBox(width: 12),
-      SizedBox(
-        width: 48,
+      ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 48),
         child: Text(
           value,
           style: theme.typography.bodyPrimary.copyWith(color: theme.colors.mutedForeground),

--- a/lib/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view.dart
@@ -2,19 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/enums.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 
+/// Budget allocation carousel slide displaying Needs, Wants, and Savings breakdown.
 class DashboardBudgetView extends ConsumerWidget {
+  /// Creates a [DashboardBudgetView].
   const DashboardBudgetView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final state = ref.watch(dashboardProvider);
+    final isBalanceVisible = ref.watch(balanceVisibilityProvider);
     final allocs = state.budgetAllocations;
 
     final needAmt = allocs[TransactionAllocation.need] ?? 0;
@@ -40,7 +44,7 @@ class DashboardBudgetView extends ConsumerWidget {
                 buildCategoryStatRow(
                   context,
                   context.t.dashboard.needs,
-                  needAmt.toCompactFormat(),
+                  needAmt.toCompactFormat(isVisible: isBalanceVisible),
                   theme.colors.primary,
                   needAmt / total,
                 ),
@@ -48,7 +52,7 @@ class DashboardBudgetView extends ConsumerWidget {
                 buildCategoryStatRow(
                   context,
                   context.t.dashboard.wants,
-                  wantAmt.toCompactFormat(),
+                  wantAmt.toCompactFormat(isVisible: isBalanceVisible),
                   theme.colors.app.warning,
                   wantAmt / total,
                 ),
@@ -56,7 +60,7 @@ class DashboardBudgetView extends ConsumerWidget {
                 buildCategoryStatRow(
                   context,
                   context.t.dashboard.savings,
-                  saveAmt.toCompactFormat(),
+                  saveAmt.toCompactFormat(isVisible: isBalanceVisible),
                   theme.colors.border,
                   saveAmt / total,
                 ),

--- a/lib/features/dashboard/presentation/widgets/cards/views/dashboard_cash_flow_view.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/views/dashboard_cash_flow_view.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/theme/theme.dart';
 
+/// Cash flow overview widget displaying savings rate gauge and income/expense stats.
 class DashboardCashFlowView extends ConsumerWidget {
+  /// Creates a [DashboardCashFlowView].
   const DashboardCashFlowView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final state = ref.watch(dashboardProvider);
+    final isVisible = ref.watch(balanceVisibilityProvider);
 
     final income = state.totalIncome;
     final expense = state.totalExpense;
@@ -63,7 +67,7 @@ class DashboardCashFlowView extends ConsumerWidget {
               _buildStatRow(
                 context,
                 context.t.dashboard.income,
-                income.toCompactFormat(),
+                income.toCompactFormat(isVisible: isVisible),
                 theme.colors.app.income,
                 FPhosphorIcons.arrowDownLeft,
               ),
@@ -71,7 +75,7 @@ class DashboardCashFlowView extends ConsumerWidget {
               _buildStatRow(
                 context,
                 context.t.dashboard.expense,
-                expense.toCompactFormat(),
+                expense.toCompactFormat(isVisible: isVisible),
                 theme.colors.app.expense,
                 FPhosphorIcons.arrowUpRight,
               ),

--- a/lib/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view.dart
+++ b/lib/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view.dart
@@ -2,19 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
 import 'package:poka_ce/core/extensions/string_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/dashboard/presentation/widgets/cards/views/carousel_shared.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/poka_donut_chart.dart';
 import 'package:poka_ce/theme/theme.dart';
 
+/// Category spending carousel slide displaying top category expenses and donut breakdown.
 class DashboardCategoriesView extends ConsumerWidget {
+  /// Creates a [DashboardCategoriesView].
   const DashboardCategoriesView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final state = ref.watch(dashboardProvider);
+    final isBalanceVisible = ref.watch(balanceVisibilityProvider);
     final totalExpense = state.totalExpense > 0 ? state.totalExpense : 1.0;
 
     final sortedExpenses = List.of(state.categoryExpenses)..sort((a, b) => b.amount.compareTo(a.amount));
@@ -31,7 +35,13 @@ class DashboardCategoriesView extends ConsumerWidget {
           color: cat.color.toColor(),
           widget: Padding(
             padding: const EdgeInsets.only(bottom: 8),
-            child: buildCategoryStatRow(context, cat.name, cat.amount.toCompactFormat(), cat.color.toColor(), ratio),
+            child: buildCategoryStatRow(
+              context,
+              cat.name,
+              cat.amount.toCompactFormat(isVisible: isBalanceVisible),
+              cat.color.toColor(),
+              ratio,
+            ),
           ),
         ));
       } else {
@@ -49,7 +59,7 @@ class DashboardCategoriesView extends ConsumerWidget {
           child: buildCategoryStatRow(
             context,
             context.t.dashboard.other,
-            otherAmount.toCompactFormat(),
+            otherAmount.toCompactFormat(isVisible: isBalanceVisible),
             theme.colors.border,
             ratio,
           ),

--- a/lib/shared/widgets/poka_amount_text.dart
+++ b/lib/shared/widgets/poka_amount_text.dart
@@ -73,7 +73,7 @@ class PokaAmountText extends ConsumerWidget {
 
     return Text(
       shouldObscure
-          ? '$prefix••••••'
+          ? '$prefix$kPrivacyMask'
           : '$prefix${amount.abs().toCurrencyFormat(symbol: currencySymbol, precision: precision, locale: localeFormat)}',
       style: effectiveStyle,
     );

--- a/test/feature/features/dashboard/presentation/widgets/cards/dashboard_spending_chart_test.dart
+++ b/test/feature/features/dashboard/presentation/widgets/cards/dashboard_spending_chart_test.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:poka_ce/features/dashboard/presentation/widgets/cards/dashboard_spending_chart.dart';
-import 'package:poka_ce/theme/theme.dart';
-import 'package:poka_ce/i18n/strings.g.dart';
-import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/daily_budget_notifier.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
+import 'package:poka_ce/features/dashboard/presentation/widgets/cards/dashboard_spending_chart.dart';
+import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/theme/theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -37,11 +38,13 @@ void main() {
     ),
     double dailyBudget = 0.0,
     Future<void> Function(double)? onSetBudget,
+    bool isVisible = true,
   }) {
     return ProviderScope(
       overrides: [
         dashboardProvider.overrideWith(() => _FakeDashboardNotifier(dashboardState)),
         dailyBudgetProvider.overrideWith(() => _FakeDailyBudgetNotifier(dailyBudget, onSetBudget)),
+        balanceVisibilityProvider.overrideWith(() => _FakeBalanceVisibilityNotifier(isVisible)),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -265,6 +268,21 @@ void main() {
       expect(find.textContaining('7.0K'), findsWidgets);
       expect(find.textContaining('1.0K'), findsWidgets);
     });
+
+    testWidgets('obscures stats and daily budget when balanceVisibility is false', (tester) async {
+      ignoreOverflow();
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+
+      await tester.pumpWidget(createWidget(dailyBudget: 500, isVisible: false));
+      await tester.pumpAndSettle();
+
+      expect(find.text('••••••'), findsNWidgets(3)); // total, average, daily budget
+      expect(find.text('7.0K'), findsNothing);
+      expect(find.text('1.0K'), findsNothing);
+      expect(find.text('500'), findsNothing);
+    });
   });
 }
 
@@ -286,4 +304,11 @@ class _FakeDailyBudgetNotifier extends DailyBudget {
   Future<void> setBudget(double amount) async {
     if (_onSet != null) await _onSet(amount);
   }
+}
+
+class _FakeBalanceVisibilityNotifier extends BalanceVisibility {
+  final bool _initial;
+  _FakeBalanceVisibilityNotifier(this._initial);
+  @override
+  bool build() => _initial;
 }

--- a/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view_test.dart
+++ b/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_budget_view_test.dart
@@ -9,6 +9,8 @@ import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/core/enums.dart';
 
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -16,10 +18,11 @@ void main() {
     LocaleSettings.setLocaleSync(AppLocale.en);
   });
 
-  Widget createWidget(DashboardState state) {
+  Widget createWidget(DashboardState state, {bool isVisible = true}) {
     return ProviderScope(
       overrides: [
         dashboardProvider.overrideWith(() => _FakeDashboardNotifier(state)),
+        balanceVisibilityProvider.overrideWith(() => _FakeBalanceVisibilityNotifier(isVisible)),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -133,6 +136,27 @@ void main() {
       await tester.pump();
       expect(find.byType(PokaDonutChart), findsOneWidget);
     });
+
+    testWidgets('obscures budget allocation amounts when balanceVisibility is false', (tester) async {
+      await tester.pumpWidget(
+        createWidget(
+          DashboardState(
+            budgetAllocations: {
+              TransactionAllocation.need: 500,
+              TransactionAllocation.want: 300,
+              TransactionAllocation.saving: 200,
+            },
+          ),
+          isVisible: false,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('••••••'), findsNWidgets(3));
+      expect(find.text('500'), findsNothing);
+      expect(find.text('300'), findsNothing);
+      expect(find.text('200'), findsNothing);
+    });
   });
 }
 
@@ -141,4 +165,11 @@ class _FakeDashboardNotifier extends DashboardNotifier {
   _FakeDashboardNotifier(this._state);
   @override
   DashboardState build() => _state;
+}
+
+class _FakeBalanceVisibilityNotifier extends BalanceVisibility {
+  final bool _initial;
+  _FakeBalanceVisibilityNotifier(this._initial);
+  @override
+  bool build() => _initial;
 }

--- a/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_cash_flow_view_test.dart
+++ b/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_cash_flow_view_test.dart
@@ -8,6 +8,8 @@ import 'package:poka_ce/theme/theme.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -15,10 +17,11 @@ void main() {
     LocaleSettings.setLocaleSync(AppLocale.en);
   });
 
-  Widget createWidget(DashboardState state) {
+  Widget createWidget(DashboardState state, {bool isVisible = true}) {
     return ProviderScope(
       overrides: [
         dashboardProvider.overrideWith(() => _FakeDashboardNotifier(state)),
+        balanceVisibilityProvider.overrideWith(() => _FakeBalanceVisibilityNotifier(isVisible)),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -110,6 +113,17 @@ void main() {
       expect(find.text('100%'), findsOneWidget);
       expect(find.text('On track'), findsOneWidget);
     });
+
+    testWidgets('obscures income and expense when balanceVisibility is false', (tester) async {
+      await tester.pumpWidget(
+        createWidget(const DashboardState(totalIncome: 10000, totalExpense: 7000), isVisible: false),
+      );
+      await tester.pump();
+
+      expect(find.text('••••••'), findsNWidgets(2));
+      expect(find.text('10.0K'), findsNothing);
+      expect(find.text('7.0K'), findsNothing);
+    });
   });
 }
 
@@ -118,4 +132,11 @@ class _FakeDashboardNotifier extends DashboardNotifier {
   _FakeDashboardNotifier(this._state);
   @override
   DashboardState build() => _state;
+}
+
+class _FakeBalanceVisibilityNotifier extends BalanceVisibility {
+  final bool _initial;
+  _FakeBalanceVisibilityNotifier(this._initial);
+  @override
+  bool build() => _initial;
 }

--- a/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view_test.dart
+++ b/test/feature/features/dashboard/presentation/widgets/cards/views/dashboard_categories_view_test.dart
@@ -10,6 +10,8 @@ import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/dashboard/domain/services/dashboard_analytics_service.dart';
 
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -17,10 +19,11 @@ void main() {
     LocaleSettings.setLocaleSync(AppLocale.en);
   });
 
-  Widget createWidget(DashboardState state) {
+  Widget createWidget(DashboardState state, {bool isVisible = true}) {
     return ProviderScope(
       overrides: [
         dashboardProvider.overrideWith(() => _FakeDashboardNotifier(state)),
+        balanceVisibilityProvider.overrideWith(() => _FakeBalanceVisibilityNotifier(isVisible)),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -160,6 +163,26 @@ void main() {
       expect(find.text('BadColor'), findsOneWidget);
       expect(find.byType(PokaDonutChart), findsOneWidget);
     });
+
+    testWidgets('obscures category amounts when balanceVisibility is false', (tester) async {
+      await tester.pumpWidget(
+        createWidget(
+          DashboardState(
+            totalExpense: 1000,
+            categoryExpenses: [
+              CategoryExpenseItem('Food', '#FF0000', 500),
+              CategoryExpenseItem('Transport', '#00FF00', 300),
+            ],
+          ),
+          isVisible: false,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('••••••'), findsNWidgets(2));
+      expect(find.text('500'), findsNothing);
+      expect(find.text('300'), findsNothing);
+    });
   });
 }
 
@@ -168,4 +191,11 @@ class _FakeDashboardNotifier extends DashboardNotifier {
   _FakeDashboardNotifier(this._state);
   @override
   DashboardState build() => _state;
+}
+
+class _FakeBalanceVisibilityNotifier extends BalanceVisibility {
+  final bool _initial;
+  _FakeBalanceVisibilityNotifier(this._initial);
+  @override
+  bool build() => _initial;
 }

--- a/test/unit/core/extensions/num_extension_test.dart
+++ b/test/unit/core/extensions/num_extension_test.dart
@@ -48,6 +48,13 @@ void main() {
     test('boundary - just below 1B stays in M', () {
       expect(999999999.toCompactFormat(), '1000.0M');
     });
+
+    test('returns masked value when isVisible is false', () {
+      expect(0.toCompactFormat(isVisible: false), '••••••');
+      expect(500.toCompactFormat(isVisible: false), '••••••');
+      expect(1500.toCompactFormat(isVisible: false), '••••••');
+      expect(1000000.toCompactFormat(isVisible: false), '••••••');
+    });
   });
 
   group('NumExtension toCurrencyFormat', () {

--- a/test/unit/core/extensions/num_extension_test.dart
+++ b/test/unit/core/extensions/num_extension_test.dart
@@ -49,11 +49,15 @@ void main() {
       expect(999999999.toCompactFormat(), '1000.0M');
     });
 
+    test('kPrivacyMask constant has expected placeholder value', () {
+      expect(kPrivacyMask, '••••••');
+    });
+
     test('returns masked value when isVisible is false', () {
-      expect(0.toCompactFormat(isVisible: false), '••••••');
-      expect(500.toCompactFormat(isVisible: false), '••••••');
-      expect(1500.toCompactFormat(isVisible: false), '••••••');
-      expect(1000000.toCompactFormat(isVisible: false), '••••••');
+      expect(0.toCompactFormat(isVisible: false), kPrivacyMask);
+      expect(500.toCompactFormat(isVisible: false), kPrivacyMask);
+      expect(1500.toCompactFormat(isVisible: false), kPrivacyMask);
+      expect(1000000.toCompactFormat(isVisible: false), kPrivacyMask);
     });
   });
 


### PR DESCRIPTION
## Summary
Resolves #47 by wiring `balanceVisibilityProvider` to all Dashboard cards and supporting an `isVisible` parameter in `NumExtension.toCompactFormat()`.

## Changes
- **Number Extension:** Added `isVisible` parameter to `NumExtension.toCompactFormat({bool isVisible = true})` returning `••••••` when hidden.
- **Carousel Shared Row:** Updated `buildCategoryStatRow` to wrap the value in a `ConstrainedBox(constraints: BoxConstraints(minWidth: 48))` so masked values display without truncation.
- **Dashboard Views:** Connected `ref.watch(balanceVisibilityProvider)` to:
  - `DashboardCashFlowView` (income & expense)
  - `DashboardSpendingChart` (total expense, daily average, daily budget)
  - `DashboardCategoriesView` (top categories & other amount)
  - `DashboardBudgetView` (Needs, Wants, Savings amounts)
- **Tests:** Updated unit and widget test suites with coverage for obscured state when `balanceVisibilityProvider` is false.
- **Documentation:** Updated `CHANGELOG.md` and marked `BUG-013` as solved in `BUG.md`.

## Verification
- `rtk rune fix`: Passed
- `rtk rune check`: "No issues found!"
- `rtk flutter test`: All 31 dashboard tests and num_extension tests passed