### PR TITLE
fix(reports): respect balance privacy toggle across reports page and add header eye action

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -21,7 +21,7 @@ This document records the bug findings identified during the **Smoke Testing** p
 | **BUG-011** | `Transactions & Feedback / Toast Ergonomics` | Delete confirmation toast with actionable "Undo" button is positioned at topCenter instead of floating bottomCenter, making the time-sensitive "Undo" action unreachable with one thumb on mobile devices | Medium (Ergonomics & Actionable UX Defect) | ✅ Valid (Subsumed by [#46](https://github.com/getpoka/poka-ce/issues/46)) |
 | **BUG-012** | `App Shell / Toast System (FToaster)` | Toasts frequently freeze and fail to auto-dismiss ("tidak hilang-hilang / kadang hilang, kadang stuck") due to mobile touch events killing `_timer` without resuming, tap-to-toggle autoDismiss, and route transition race conditions | High (Reliability & UX Defect) | ✅ Valid ([#46](https://github.com/getpoka/poka-ce/issues/46)) |
 | **BUG-013** | `Dashboard / Privacy Eye (Hide Balance)` | Cashflow, Spending Activity, Categories, and Budget carousel cards ignore `balanceVisibilityProvider` and continue displaying raw monetary values when privacy eye is toggled | High (Privacy & Data Protection Defect) | 🟢 Solved ([#47](https://github.com/getpoka/poka-ce/issues/47)) |
-| **BUG-014** | `Reports / Privacy Eye (Hide Balance)` | Category ranking, spending allocation splits, and chart tooltips bypass `balanceVisibilityProvider`, and ReportListPage lacks a header privacy eye toggle | High (Privacy & Data Protection Defect) | ✅ Valid ([#48](https://github.com/getpoka/poka-ce/issues/48)) |
+| **BUG-014** | `Reports / Privacy Eye (Hide Balance)` | Category ranking, spending allocation splits, and chart tooltips bypass `balanceVisibilityProvider`, and ReportListPage lacks a header privacy eye toggle | High (Privacy & Data Protection Defect) | 🟢 Solved ([#48](https://github.com/getpoka/poka-ce/issues/48)) |
 | **BUG-015** | `Backup & Notifications / Permission & Testing` | Changing Backup Reminder from 'Off' to 'Weekly'/'Monthly' never requests notification runtime permission on Android 13+ & iOS (silent reminder failure), and app lacks an immediate test notification trigger | High (Core Feature Reliability & Testability) | ✅ Valid ([#49](https://github.com/getpoka/poka-ce/issues/49)) |
 
 ---
@@ -782,7 +782,7 @@ On the **Reports Page (`ReportListPage`)**:
 11. [ ] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).
 12. [ ] Implement `showPokaToast` with watchdog timer to eliminate stuck toasts across mobile touch events and route transitions (BUG-012 — [#46](https://github.com/getpoka/poka-ce/issues/46)).
 13. [x] Implement privacy eye obfuscation (`isVisible`) across Dashboard Cashflow, Spending Activity, Categories, and Budgets (BUG-013 — [#47](https://github.com/getpoka/poka-ce/issues/47)).
-14. [ ] Implement privacy eye obfuscation and add header toggle button on Reports page (BUG-014 — [#48](https://github.com/getpoka/poka-ce/issues/48)).
+14. [x] Implement privacy eye obfuscation and add header toggle button on Reports page (BUG-014 — [#48](https://github.com/getpoka/poka-ce/issues/48)).
 15. [ ] Implement Notification Permission Rationale Sheet and manual test trigger for Backup Reminder (BUG-015 — [#49](https://github.com/getpoka/poka-ce/issues/49)).
 16. [ ] Run `rune generate`, `rune fix`, `rune check`, and `rune test` to verify zero issues upon bug resolution.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unlocalized date headers and month navigation labels on the Transactions page by wiring intl locale initialization and date formatters to active locale.
 - Fixed hardcoded transaction type tab labels in `TransactionTypeSwitcher` to use localized strings.
 - Fixed balance visibility privacy toggle being bypassed across Dashboard cards (Cash Flow, Spending Activity, Categories, and Budgets).
+- Added header privacy eye action button on the Reports page and obscured financial amounts across category rankings, spending allocation rules, and cashflow charts when privacy mode is enabled.
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/features/reports/presentation/screens/report_list_page.dart
+++ b/lib/features/reports/presentation/screens/report_list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:forui/forui.dart';
 import 'package:forui_phosphor/forui_phosphor.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_budget_utilization.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_cashflow_chart.dart';
@@ -21,6 +22,7 @@ class ReportListPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(reportProvider);
+    final isBalanceVisible = ref.watch(balanceVisibilityProvider);
     final t = context.t.reports;
 
     return FScaffold(
@@ -28,6 +30,11 @@ class ReportListPage extends ConsumerWidget {
         title: t.title,
         subtitle: t.overview,
         suffixes: [
+          FHeaderAction(
+            key: const Key('report-privacy-toggle-button'),
+            icon: Icon(isBalanceVisible ? FPhosphorIcons.eye : FPhosphorIcons.eyeSlash, size: 20),
+            onPress: () => ref.read(balanceVisibilityProvider.notifier).toggle(),
+          ),
           FHeaderAction(
             key: const Key('report-export-excel-button'),
             icon: const Icon(FPhosphorIcons.fileXls, size: 20),

--- a/lib/features/reports/presentation/widgets/allocation_row_tile.dart
+++ b/lib/features/reports/presentation/widgets/allocation_row_tile.dart
@@ -1,27 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/theme/theme.dart';
 
-class AllocationRowTile extends StatelessWidget {
+/// Row widget rendering an allocation category (e.g. 50% Needs), ratio, and compact amount.
+class AllocationRowTile extends ConsumerWidget {
+  /// Creates an [AllocationRowTile].
   const AllocationRowTile({
     required this.label,
     required this.hint,
     required this.amount,
     required this.color,
     required this.ratio,
+    this.isVisible,
     super.key,
   });
 
+  /// The category label.
   final String label;
+
+  /// Subtitle hint (e.g. "50%").
   final String hint;
+
+  /// Monetary amount allocated.
   final double amount;
+
+  /// The accent color of the allocation bar and dot.
   final Color color;
+
+  /// The ratio of this allocation against the total budget.
   final double ratio;
 
+  /// Optional explicit visibility override. Defaults to [balanceVisibilityProvider].
+  final bool? isVisible;
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final pct = '${(ratio * 100).toStringAsFixed(1)}%';
+    final effectiveVisible = isVisible ?? ref.watch(balanceVisibilityProvider) ?? true;
 
     return Row(
       children: [
@@ -52,7 +70,7 @@ class AllocationRowTile extends StatelessWidget {
         ),
         const SizedBox(width: 6),
         Text(
-          amount.toCompactFormat(),
+          amount.toCompactFormat(isVisible: effectiveVisible),
           style: theme.typography.bodySecondary.copyWith(fontWeight: FontWeight.bold),
         ),
       ],

--- a/lib/features/reports/presentation/widgets/allocation_row_tile.dart
+++ b/lib/features/reports/presentation/widgets/allocation_row_tile.dart
@@ -39,7 +39,8 @@ class AllocationRowTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final pct = '${(ratio * 100).toStringAsFixed(1)}%';
-    final effectiveVisible = isVisible ?? ref.watch(balanceVisibilityProvider) ?? true;
+    final v = ref.watch(balanceVisibilityProvider);
+    final effectiveVisible = isVisible ?? v;
 
     return Row(
       children: [

--- a/lib/features/reports/presentation/widgets/budget_item_tile.dart
+++ b/lib/features/reports/presentation/widgets/budget_item_tile.dart
@@ -68,7 +68,7 @@ class BudgetItemTile extends ConsumerWidget {
             ),
             PokaAmountText(
               amount: budget.amount,
-              type: TransactionType.income,
+              type: TransactionType.transfer,
               style: theme.typography.bodySecondary.copyWith(color: theme.colors.mutedForeground),
             ),
           ],

--- a/lib/features/reports/presentation/widgets/category_item_tile.dart
+++ b/lib/features/reports/presentation/widgets/category_item_tile.dart
@@ -37,7 +37,8 @@ class CategoryItemTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final color = _parseColor(context, item.color);
-    final effectiveVisible = isVisible ?? ref.watch(balanceVisibilityProvider) ?? true;
+    final v = ref.watch(balanceVisibilityProvider);
+    final effectiveVisible = isVisible ?? v;
 
     return Row(
       children: [

--- a/lib/features/reports/presentation/widgets/category_item_tile.dart
+++ b/lib/features/reports/presentation/widgets/category_item_tile.dart
@@ -1,13 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/theme/theme.dart';
 
-class CategoryItemTile extends StatelessWidget {
-  const CategoryItemTile({required this.item, required this.rank, super.key});
+/// Row widget rendering a category rank, dot, title, compact amount, and percentage.
+class CategoryItemTile extends ConsumerWidget {
+  /// Creates a [CategoryItemTile].
+  const CategoryItemTile({
+    required this.item,
+    required this.rank,
+    this.isVisible,
+    super.key,
+  });
 
+  /// The category item analytics data.
   final ReportCategoryItem item;
+
+  /// The numeric rank (1-indexed).
   final int rank;
+
+  /// Optional explicit visibility override. Defaults to [balanceVisibilityProvider].
+  final bool? isVisible;
 
   Color _parseColor(BuildContext context, String hex) {
     try {
@@ -19,9 +34,10 @@ class CategoryItemTile extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final color = _parseColor(context, item.color);
+    final effectiveVisible = isVisible ?? ref.watch(balanceVisibilityProvider) ?? true;
 
     return Row(
       children: [
@@ -58,7 +74,7 @@ class CategoryItemTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
             Text(
-              item.amount.toCompactFormat(),
+              item.amount.toCompactFormat(isVisible: effectiveVisible),
               style: theme.typography.bodySecondary.copyWith(fontWeight: FontWeight.w700),
             ),
             Text(

--- a/lib/features/reports/presentation/widgets/report_cashflow_chart.dart
+++ b/lib/features/reports/presentation/widgets/report_cashflow_chart.dart
@@ -2,6 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
@@ -16,6 +17,7 @@ class ReportCashflowChart extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final state = ref.watch(reportProvider);
+    final isBalanceVisible = ref.watch(balanceVisibilityProvider);
     final trendPoints = state.data.trendPoints;
     final t = context.t.reports;
     final expenseColor = theme.colors.app.expense;
@@ -37,8 +39,10 @@ class ReportCashflowChart extends ConsumerWidget {
                 _QuickStat(
                   label: t.average,
                   value: trendPoints.isNotEmpty
-                      ? (state.data.summary.totalExpense / trendPoints.length).toCompactFormat()
-                      : '0',
+                      ? (state.data.summary.totalExpense / trendPoints.length).toCompactFormat(
+                          isVisible: isBalanceVisible,
+                        )
+                      : (isBalanceVisible ? '0' : '••••••'),
                   color: theme.colors.mutedForeground,
                 ),
               ],
@@ -64,6 +68,7 @@ class ReportCashflowChart extends ConsumerWidget {
                   incomeColor: incomeColor,
                   expenseColor: expenseColor,
                   theme: theme,
+                  isBalanceVisible: isBalanceVisible,
                 ),
               ),
           ],
@@ -81,12 +86,14 @@ class _CashflowBarChart extends StatelessWidget {
     required this.incomeColor,
     required this.expenseColor,
     required this.theme,
+    required this.isBalanceVisible,
   });
 
   final List<ReportTrendPoint> points;
   final Color incomeColor;
   final Color expenseColor;
   final FThemeData theme;
+  final bool isBalanceVisible;
 
   @override
   Widget build(BuildContext context) {
@@ -107,7 +114,9 @@ class _CashflowBarChart extends StatelessWidget {
               final point = points[groupIndex];
               final isIncome = rodIndex == 0;
               return BarTooltipItem(
-                isIncome ? point.income.toCompactFormat() : point.expense.toCompactFormat(),
+                isIncome
+                    ? point.income.toCompactFormat(isVisible: isBalanceVisible)
+                    : point.expense.toCompactFormat(isVisible: isBalanceVisible),
                 theme.typography.labelBadge.copyWith(
                   color: isIncome ? incomeColor : expenseColor,
                 ),
@@ -121,7 +130,7 @@ class _CashflowBarChart extends StatelessWidget {
           leftTitles: AxisTitles(
             sideTitles: SideTitles(
               showTitles: true,
-              reservedSize: 40,
+              reservedSize: isBalanceVisible ? 40 : 44,
               getTitlesWidget: (value, meta) {
                 if (value == meta.max || value == 0 && meta.min > 0) {
                   return const SizedBox.shrink();
@@ -129,7 +138,7 @@ class _CashflowBarChart extends StatelessWidget {
                 return Padding(
                   padding: const EdgeInsets.only(right: 4),
                   child: Text(
-                    value.toCompactFormat(),
+                    value.toCompactFormat(isVisible: isBalanceVisible),
                     style: theme.typography.caption.copyWith(
                       color: theme.colors.mutedForeground,
                     ),

--- a/lib/features/reports/presentation/widgets/report_spending_allocation.dart
+++ b/lib/features/reports/presentation/widgets/report_spending_allocation.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/extensions/num_extension.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/allocation_row_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
@@ -16,6 +17,7 @@ class ReportSpendingAllocation extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.theme;
     final state = ref.watch(reportProvider);
+    final isBalanceVisible = ref.watch(balanceVisibilityProvider);
     final alloc = state.data.budgetAllocation;
     final t = context.t.reports;
 
@@ -43,7 +45,7 @@ class ReportSpendingAllocation extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  '${t.total}: ${alloc.total.toCompactFormat()}',
+                  '${t.total}: ${alloc.total.toCompactFormat(isVisible: isBalanceVisible)}',
                   style: theme.typography.bodySecondary.copyWith(
                     fontWeight: FontWeight.bold,
                   ),

--- a/test/feature/features/reports/presentation/screens/report_list_page_test.dart
+++ b/test/feature/features/reports/presentation/screens/report_list_page_test.dart
@@ -126,12 +126,15 @@ void main() {
 
       final toggleButton = find.byKey(const Key('report-privacy-toggle-button'));
       expect(toggleButton, findsOneWidget);
+      expect(find.byIcon(FPhosphorIcons.eye), findsOneWidget);
 
       await tester.tap(toggleButton);
       await tester.pumpAndSettle();
+      expect(find.byIcon(FPhosphorIcons.eyeSlash), findsOneWidget);
 
       await tester.tap(toggleButton);
       await tester.pumpAndSettle();
+      expect(find.byIcon(FPhosphorIcons.eye), findsOneWidget);
     });
 
     testWidgets('triggers exportAndShare and shows success toast when export button tapped', (tester) async {

--- a/test/feature/features/reports/presentation/screens/report_list_page_test.dart
+++ b/test/feature/features/reports/presentation/screens/report_list_page_test.dart
@@ -85,9 +85,53 @@ void main() {
 
       expect(find.text('Reports'), findsOneWidget);
       expect(find.text('Financial Overview'), findsOneWidget);
+      expect(find.byKey(const Key('report-privacy-toggle-button')), findsOneWidget);
       expect(find.byKey(const Key('report-export-excel-button')), findsOneWidget);
       expect(find.text('Cashflow'), findsOneWidget);
       expect(find.text('Budgets & Goals'), findsOneWidget);
+    });
+
+    testWidgets('renders privacy toggle button and toggles visibility state', (tester) async {
+      const state = ReportState(
+        isLoading: false,
+        data: ReportData(),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            reportProvider.overrideWith(() => _FakeReportNotifier(state)),
+            excelExportServiceProvider.overrideWithValue(mockExcelExportService),
+            settingsProvider.overrideWithValue(const SettingsState(isLoading: false)),
+          ],
+          child: TranslationProvider(
+            child: MaterialApp(
+              supportedLocales: AppLocaleUtils.supportedLocales,
+              localizationsDelegates: const [
+                ...FLocalizations.localizationsDelegates,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              builder: (context, child) => FTheme(
+                data: lightTheme,
+                child: FToaster(child: child!),
+              ),
+              home: const ReportListPage(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final toggleButton = find.byKey(const Key('report-privacy-toggle-button'));
+      expect(toggleButton, findsOneWidget);
+
+      await tester.tap(toggleButton);
+      await tester.pumpAndSettle();
+
+      await tester.tap(toggleButton);
+      await tester.pumpAndSettle();
     });
 
     testWidgets('triggers exportAndShare and shows success toast when export button tapped', (tester) async {

--- a/test/feature/features/reports/presentation/widgets/allocation_row_tile_test.dart
+++ b/test/feature/features/reports/presentation/widgets/allocation_row_tile_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/allocation_row_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/theme/theme.dart';
@@ -9,19 +11,25 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
 
-  Widget wrap() {
-    return TranslationProvider(
-      child: MaterialApp(
-        builder: (context, child) => FTheme(data: lightTheme, child: child!),
-        home: Scaffold(
-          body: Padding(
-            padding: const EdgeInsets.all(16),
-            child: AllocationRowTile(
-              label: 'Needs',
-              hint: '50%',
-              amount: 5000,
-              color: Colors.blue,
-              ratio: 0.5,
+  Widget wrap({bool? isVisible, bool isBalanceVisible = true}) {
+    return ProviderScope(
+      overrides: [
+        balanceVisibilityProvider.overrideWithValue(isBalanceVisible),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: AllocationRowTile(
+                label: 'Needs',
+                hint: '50%',
+                amount: 5000,
+                color: Colors.blue,
+                ratio: 0.5,
+                isVisible: isVisible,
+              ),
             ),
           ),
         ),
@@ -37,6 +45,20 @@ void main() {
       expect(find.text('50%'), findsOneWidget);
       expect(find.text('50.0%'), findsOneWidget);
       expect(find.text('5.0K'), findsOneWidget);
+    });
+
+    testWidgets('obscures amount when balance visibility is false', (tester) async {
+      await tester.pumpWidget(wrap(isBalanceVisible: false));
+
+      expect(find.text('••••••'), findsOneWidget);
+      expect(find.text('5.0K'), findsNothing);
+    });
+
+    testWidgets('respects explicit isVisible override parameter', (tester) async {
+      await tester.pumpWidget(wrap(isVisible: false));
+
+      expect(find.text('••••••'), findsOneWidget);
+      expect(find.text('5.0K'), findsNothing);
     });
   });
 }

--- a/test/feature/features/reports/presentation/widgets/budget_item_tile_test.dart
+++ b/test/feature/features/reports/presentation/widgets/budget_item_tile_test.dart
@@ -69,6 +69,13 @@ void main() {
 
       expect(find.text('Over budget'), findsOneWidget);
     });
+
+    testWidgets('renders budget cap amount without plus sign', (tester) async {
+      await tester.pumpWidget(wrap(spent: 500, limit: 1000));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('+'), findsNothing);
+    });
   });
 }
 

--- a/test/feature/features/reports/presentation/widgets/budget_item_tile_test.dart
+++ b/test/feature/features/reports/presentation/widgets/budget_item_tile_test.dart
@@ -25,11 +25,11 @@ void main() {
     updatedAt: DateTime(2026, 1, 1),
   );
 
-  Widget wrap({required int spent, required int limit}) {
+  Widget wrap({required int spent, required int limit, bool isVisible = true}) {
     return ProviderScope(
       overrides: [
         budgetProgressProvider.overrideWith((ref, arg) async => spent),
-        balanceVisibilityProvider.overrideWithValue(true),
+        balanceVisibilityProvider.overrideWithValue(isVisible),
         settingsProvider.overrideWith(() => _FakeSettingsNotifier()),
       ],
       child: TranslationProvider(
@@ -75,6 +75,13 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('+'), findsNothing);
+    });
+
+    testWidgets('obscures spent and budget limit when balanceVisibility is false', (tester) async {
+      await tester.pumpWidget(wrap(spent: 500, limit: 1000, isVisible: false));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('••••••'), findsWidgets);
     });
   });
 }

--- a/test/feature/features/reports/presentation/widgets/category_item_tile_test.dart
+++ b/test/feature/features/reports/presentation/widgets/category_item_tile_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/category_item_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
@@ -10,14 +12,23 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
 
-  Widget wrap(ReportCategoryItem item) {
-    return TranslationProvider(
-      child: MaterialApp(
-        builder: (context, child) => FTheme(data: lightTheme, child: child!),
-        home: Scaffold(
-          body: Padding(
-            padding: const EdgeInsets.all(16),
-            child: CategoryItemTile(item: item, rank: 1),
+  Widget wrap(
+    ReportCategoryItem item, {
+    bool? isVisible,
+    bool isBalanceVisible = true,
+  }) {
+    return ProviderScope(
+      overrides: [
+        balanceVisibilityProvider.overrideWithValue(isBalanceVisible),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          builder: (context, child) => FTheme(data: lightTheme, child: child!),
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: CategoryItemTile(item: item, rank: 1, isVisible: isVisible),
+            ),
           ),
         ),
       ),
@@ -39,6 +50,34 @@ void main() {
       expect(find.text('Food'), findsOneWidget);
       expect(find.text('1.5K'), findsOneWidget);
       expect(find.text('50.0%'), findsOneWidget);
+    });
+
+    testWidgets('obscures amount when balance visibility is false', (tester) async {
+      final item = ReportCategoryItem(
+        name: 'Food',
+        color: '#FF0000',
+        amount: 1500,
+        ratio: 0.5,
+        txCount: 3,
+      );
+      await tester.pumpWidget(wrap(item, isBalanceVisible: false));
+
+      expect(find.text('••••••'), findsOneWidget);
+      expect(find.text('1.5K'), findsNothing);
+    });
+
+    testWidgets('respects explicit isVisible override parameter', (tester) async {
+      final item = ReportCategoryItem(
+        name: 'Food',
+        color: '#FF0000',
+        amount: 1500,
+        ratio: 0.5,
+        txCount: 3,
+      );
+      await tester.pumpWidget(wrap(item, isVisible: false));
+
+      expect(find.text('••••••'), findsOneWidget);
+      expect(find.text('1.5K'), findsNothing);
     });
 
     testWidgets('falls back to theme color for invalid hex', (tester) async {

--- a/test/feature/features/reports/presentation/widgets/report_cashflow_chart_test.dart
+++ b/test/feature/features/reports/presentation/widgets/report_cashflow_chart_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_cashflow_chart.dart';
@@ -12,10 +13,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
 
-  Widget wrap(ReportData data) {
+  Widget wrap(ReportData data, {bool isBalanceVisible = true}) {
     return ProviderScope(
       overrides: [
         reportProvider.overrideWithValue(ReportState(isLoading: false, data: data)),
+        balanceVisibilityProvider.overrideWithValue(isBalanceVisible),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -57,6 +59,21 @@ void main() {
       expect(find.text('W2'), findsOneWidget);
       // average = 1200 / 2 = 600
       expect(find.text('600'), findsOneWidget);
+    });
+
+    testWidgets('obscures average when balance visibility is false', (tester) async {
+      final data = ReportData(
+        summary: const ReportSummary(totalExpense: 1200),
+        trendPoints: const [
+          ReportTrendPoint(label: 'W1', income: 500, expense: 400),
+          ReportTrendPoint(label: 'W2', income: 700, expense: 800),
+        ],
+      );
+      await tester.pumpWidget(wrap(data, isBalanceVisible: false));
+      await tester.pumpAndSettle();
+
+      expect(find.text('••••••'), findsWidgets);
+      expect(find.text('600'), findsNothing);
     });
   });
 }

--- a/test/feature/features/reports/presentation/widgets/report_category_chart_test.dart
+++ b/test/feature/features/reports/presentation/widgets/report_category_chart_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_category_chart.dart';
@@ -12,10 +13,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
 
-  Widget wrap(ReportData data) {
+  Widget wrap(ReportData data, {bool isBalanceVisible = true}) {
     return ProviderScope(
       overrides: [
         reportProvider.overrideWithValue(ReportState(isLoading: false, data: data)),
+        balanceVisibilityProvider.overrideWithValue(isBalanceVisible),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -60,6 +62,21 @@ void main() {
       expect(find.text('30.0%'), findsWidgets);
       expect(find.text('500'), findsOneWidget);
       expect(find.text('300'), findsOneWidget);
+    });
+
+    testWidgets('obscures category amounts when balance visibility is false', (tester) async {
+      final data = ReportData(
+        expenseCategoryItems: [
+          item('Food', '#FF0000', 500, 0.5),
+          item('Transport', '#00FF00', 300, 0.3),
+        ],
+      );
+      await tester.pumpWidget(wrap(data, isBalanceVisible: false));
+      await tester.pumpAndSettle();
+
+      expect(find.text('••••••'), findsWidgets);
+      expect(find.text('500'), findsNothing);
+      expect(find.text('300'), findsNothing);
     });
 
     testWidgets('tapping Income tab switches to income items', (tester) async {

--- a/test/feature/features/reports/presentation/widgets/report_spending_allocation_test.dart
+++ b/test/feature/features/reports/presentation/widgets/report_spending_allocation_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:poka_ce/features/dashboard/presentation/controllers/balance_visibility_provider.dart';
 import 'package:poka_ce/features/reports/domain/services/report_analytics_service.dart';
 import 'package:poka_ce/features/reports/presentation/controllers/report_notifier.dart';
 import 'package:poka_ce/features/reports/presentation/widgets/report_spending_allocation.dart';
@@ -12,7 +13,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
 
-  Widget wrap(ReportBudgetAllocation allocation) {
+  Widget wrap(ReportBudgetAllocation allocation, {bool isBalanceVisible = true}) {
     return ProviderScope(
       overrides: [
         reportProvider.overrideWithValue(
@@ -21,6 +22,7 @@ void main() {
             data: ReportData(budgetAllocation: allocation),
           ),
         ),
+        balanceVisibilityProvider.overrideWithValue(isBalanceVisible),
       ],
       child: TranslationProvider(
         child: MaterialApp(
@@ -61,6 +63,21 @@ void main() {
       expect(find.text('500'), findsWidgets);
       expect(find.text('300'), findsWidgets);
       expect(find.text('200'), findsWidgets);
+    });
+
+    testWidgets('obscures total and row amounts when balance visibility is false', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const ReportBudgetAllocation(need: 500, want: 300, saving: 200),
+          isBalanceVisible: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('••••••'), findsWidgets);
+      expect(find.text('500'), findsNothing);
+      expect(find.text('300'), findsNothing);
+      expect(find.text('200'), findsNothing);
     });
   });
 }

--- a/test/unit/core/extensions/num_extension_test.dart
+++ b/test/unit/core/extensions/num_extension_test.dart
@@ -8,6 +8,11 @@ void main() {
       expect(0.toCompactFormat(), '0');
     });
 
+    test('returns masked string when isVisible is false', () {
+      expect(1500.toCompactFormat(isVisible: false), '••••••');
+      expect(0.toCompactFormat(isVisible: false), '••••••');
+    });
+
     test('returns plain number for values below 1000', () {
       expect(999.toCompactFormat(), '999');
       expect(500.toCompactFormat(), '500');


### PR DESCRIPTION
## Summary
Resolves #48 by adding a privacy eye action button to the Reports page header and obscuring monetary amounts across category rankings, spending allocation rules, budget caps, and cashflow charts when privacy mode is enabled.

## Changes
- **Header Action:** Added an eye toggle action button (`FPhosphorIcons.eye` / `FPhosphorIcons.eyeSlash`) to `ReportListPage` header `suffixes` triggering `balanceVisibilityProvider.notifier.toggle()`.
- **Category Ranking (`CategoryItemTile`):** Converted to `ConsumerWidget` and hooked to `balanceVisibilityProvider` with an optional `isVisible` override parameter. Obscures `item.amount.toCompactFormat()`.
- **Spending Allocation (`AllocationRowTile` & `ReportSpendingAllocation`):** Hooked both the 50/30/20 total amount and category row amounts to `balanceVisibilityProvider`.
- **Cashflow Chart (`ReportCashflowChart`):** Masked average expense quickstat, y-axis labels, and bar touch tooltips when `isBalanceVisible` is false.
- **Budget Item Tile (`BudgetItemTile`):** Updated budget cap from `TransactionType.income` to `TransactionType.transfer` to remove misleading `+` sign.
- **Tests:** Added comprehensive test coverage across `ReportListPage`, `CategoryItemTile`, `AllocationRowTile`, `ReportSpendingAllocation`, `ReportCashflowChart`, `ReportCategoryChart`, and `BudgetItemTile`.
- **Documentation:** Updated `CHANGELOG.md` under `## [Unreleased] > ### Fixed` and marked `BUG-014` as solved in `BUG.md`.

## Verification
- `rtk rune fix`: Passed
- `rtk rune check`: "No issues found!"
- `rtk flutter test test/feature/features/reports/`: All 37 tests passed