### PR TITLE
fix: resolve toast notifications freeze and optimize thumb ergonomics

### DIFF
--- a/BUG.md
+++ b/BUG.md
@@ -779,8 +779,8 @@ On the **Reports Page (`ReportListPage`)**:
 8. [x] Enable swipe-to-edit and swipe-to-delete on repayment tiles in [`DebtDetailPage`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/screens/debt_detail_page.dart) (BUG-008 — [#43](https://github.com/getpoka/poka-ce/issues/43)).
 9. [x] Handle debt repayment semantic labeling and icon in `RecentTransactionTile` to eliminate "Uncategorized" (BUG-009 — [#44](https://github.com/getpoka/poka-ce/issues/44)).
 10. [x] Restore standard 'X' close button on [`DebtFormSheet`](file:///Users/SupianIDz/Work/getpoka/poka-ce/lib/features/debts/presentation/widgets/debt_form_sheet.dart) by removing the unconfirmed header trash action (BUG-010 — [#45](https://github.com/getpoka/poka-ce/issues/45)).
-11. [ ] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).
-12. [ ] Implement `showPokaToast` with watchdog timer to eliminate stuck toasts across mobile touch events and route transitions (BUG-012 — [#46](https://github.com/getpoka/poka-ce/issues/46)).
+11. [x] Create standardized `showPokaActionToast` / `showPokaUndoToast` with `bottomCenter` floating card ergonomics (BUG-011 — **Subsumed by BUG-012 [#46](https://github.com/getpoka/poka-ce/issues/46)**).
+12. [x] Implement `showPokaToast` with watchdog timer to eliminate stuck toasts across mobile touch events and route transitions (BUG-012 — [#46](https://github.com/getpoka/poka-ce/issues/46)).
 13. [x] Implement privacy eye obfuscation (`isVisible`) across Dashboard Cashflow, Spending Activity, Categories, and Budgets (BUG-013 — [#47](https://github.com/getpoka/poka-ce/issues/47)).
 14. [x] Implement privacy eye obfuscation and add header toggle button on Reports page (BUG-014 — [#48](https://github.com/getpoka/poka-ce/issues/48)).
 15. [ ] Implement Notification Permission Rationale Sheet and manual test trigger for Backup Reminder (BUG-015 — [#49](https://github.com/getpoka/poka-ce/issues/49)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed hardcoded transaction type tab labels in `TransactionTypeSwitcher` to use localized strings.
 - Fixed balance visibility privacy toggle being bypassed across Dashboard cards (Cash Flow, Spending Activity, Categories, and Budgets).
 - Added header privacy eye action button on the Reports page and obscured financial amounts across category rankings, spending allocation rules, and cashflow charts when privacy mode is enabled.
+- Resolved toast notification freeze on mobile touch interactions and route transitions by introducing `showPokaToast` with an independent watchdog timer and post-frame dismissal.
+- Standardized actionable undo toast positioning to `bottomCenter` (`showPokaActionToast`) for optimal one-handed thumb ergonomics.
 
 ## [v1.0.0-rc.1] - 2026-09-09
 

--- a/lib/features/accounts/presentation/widgets/forms/account_form_sheet.dart
+++ b/lib/features/accounts/presentation/widgets/forms/account_form_sheet.dart
@@ -11,6 +11,7 @@ import 'package:poka_ce/features/accounts/presentation/widgets/forms/fields/cate
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/pickers/poka_color_picker.dart';
 import 'package:poka_ce/shared/widgets/pickers/poka_icon_picker.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -86,7 +87,7 @@ class AccountFormSheet extends HookConsumerWidget {
           Navigator.of(context).pop();
         }
         if (next.error != null && next.error != prev?.error) {
-          showFToast(
+          showPokaToast(
             context: context,
             title: Text(next.error!),
             variant: FToastVariant.destructive,

--- a/lib/features/budgets/presentation/widgets/forms/budget_form_sheet.dart
+++ b/lib/features/budgets/presentation/widgets/forms/budget_form_sheet.dart
@@ -19,6 +19,7 @@ import 'package:poka_ce/shared/widgets/poka_category_selector.dart';
 import 'package:poka_ce/shared/widgets/poka_form_label.dart';
 import 'package:poka_ce/shared/widgets/poka_icon.dart';
 import 'package:poka_ce/shared/widgets/poka_pocket_selector.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 
 class BudgetFormSheet extends HookConsumerWidget {
@@ -134,7 +135,7 @@ class BudgetFormSheet extends HookConsumerWidget {
         Navigator.of(context).pop();
       }
       if (next.error != null && next.error != prev?.error) {
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(next.error!),
           variant: FToastVariant.destructive,

--- a/lib/features/categories/presentation/widgets/forms/category_form_sheet.dart
+++ b/lib/features/categories/presentation/widgets/forms/category_form_sheet.dart
@@ -8,6 +8,7 @@ import 'package:poka_ce/features/categories/presentation/controllers/category_fo
 import 'package:poka_ce/features/categories/presentation/widgets/pickers/category_icon_picker_button.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/pickers/poka_color_picker.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 
 /// Bottom sheet for creating or editing a category.
@@ -79,7 +80,7 @@ class CategoryFormSheet extends HookConsumerWidget {
         if (next.isSuccess && (prev?.isSuccess != true)) {
           Navigator.of(context).pop();
         } else if (next.error != null && next.error != prev?.error) {
-          showFToast(
+          showPokaToast(
             context: context,
             title: Text(next.error!),
             variant: FToastVariant.destructive,

--- a/lib/features/debts/presentation/widgets/debt_form_sheet.dart
+++ b/lib/features/debts/presentation/widgets/debt_form_sheet.dart
@@ -14,6 +14,7 @@ import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/poka_category_selector.dart';
 import 'package:poka_ce/shared/widgets/poka_form_label.dart';
 import 'package:poka_ce/shared/widgets/poka_pocket_selector.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -141,7 +142,7 @@ class DebtFormSheet extends HookConsumerWidget {
         Navigator.of(context).pop();
       }
       if (next.error != null && next.error != prev?.error) {
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(next.error!),
           variant: FToastVariant.destructive,

--- a/lib/features/goals/presentation/widgets/goal_form_sheet.dart
+++ b/lib/features/goals/presentation/widgets/goal_form_sheet.dart
@@ -5,6 +5,7 @@ import 'package:poka_ce/features/goals/domain/goal_model.dart';
 import 'package:poka_ce/features/goals/presentation/controllers/goal_form_notifier.dart';
 import 'package:poka_ce/features/goals/presentation/widgets/goal_date_picker_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -95,7 +96,7 @@ class GoalFormSheet extends HookConsumerWidget {
         Navigator.of(context).pop();
       }
       if (next.error != null && next.error != prev?.error) {
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(next.error!),
           variant: FToastVariant.destructive,

--- a/lib/features/recurring/presentation/widgets/recurring_form_sheet.dart
+++ b/lib/features/recurring/presentation/widgets/recurring_form_sheet.dart
@@ -25,6 +25,7 @@ import 'package:poka_ce/shared/widgets/poka_form_label.dart';
 import 'package:poka_ce/shared/widgets/poka_icon.dart';
 import 'package:poka_ce/shared/widgets/poka_pocket_selector.dart';
 import 'package:poka_ce/shared/widgets/poka_switch.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -79,7 +80,7 @@ class RecurringFormSheet extends HookConsumerWidget {
         Navigator.of(context).pop();
       }
       if (next.error != null && next.error != prev?.error) {
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(next.error!),
           variant: FToastVariant.destructive,

--- a/lib/features/reports/presentation/screens/report_list_page.dart
+++ b/lib/features/reports/presentation/screens/report_list_page.dart
@@ -14,6 +14,7 @@ import 'package:poka_ce/features/reports/presentation/widgets/report_summary_car
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/poka_header.dart';
 import 'package:poka_ce/shared/widgets/poka_section_label.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 
 /// Reports screen presenting cashflow trends, spending by category, budget utilization, and allocation splits.
 class ReportListPage extends ConsumerWidget {
@@ -44,7 +45,7 @@ class ReportListPage extends ConsumerWidget {
 
               final success = await ref.read(reportProvider.notifier).exportExcel(sharePositionOrigin: rect);
               if (context.mounted) {
-                showFToast(
+                showPokaToast(
                   context: context,
                   title: Text(success ? t.exportExcelSuccess : t.exportExcelError),
                 );

--- a/lib/features/settings/presentation/screens/lock_screen.dart
+++ b/lib/features/settings/presentation/screens/lock_screen.dart
@@ -8,6 +8,7 @@ import 'package:poka_ce/features/settings/presentation/controllers/app_lock_cont
 import 'package:poka_ce/features/settings/presentation/widgets/pin_dots.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/keypad.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 /// Dedicated screen for unlocking the app via PIN or Biometrics.
@@ -74,7 +75,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
   Future<void> _triggerBiometric() async {
     final authenticated = await ref.read(appLockControllerProvider.notifier).authenticateBiometric();
     if (authenticated && mounted) {
-      showFToast(
+      showPokaToast(
         context: context,
         title: Text(context.t.lock.unlocked),
       );
@@ -111,7 +112,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
 
     switch (result) {
       case PinVerificationResult.success:
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(context.t.lock.unlocked),
         );
@@ -121,7 +122,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
           _isError = true;
           _pin = '';
         });
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(context.t.lock.invalidPin),
         );
@@ -131,7 +132,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
           _isError = true;
           _pin = '';
         });
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(context.t.lock.tooManyAttempts),
           description: Text(context.t.lock.temporarilyLocked),

--- a/lib/features/settings/presentation/widgets/easter_egg_icon.dart
+++ b/lib/features/settings/presentation/widgets/easter_egg_icon.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 import 'package:forui_phosphor/forui_phosphor.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 
 /// An interactive app icon widget that reveals an easter egg dialog upon multiple rapid taps.
 class EasterEggIcon extends StatefulWidget {
@@ -42,7 +43,7 @@ class _EasterEggIconState extends State<EasterEggIcon> {
 
     final remaining = _requiredTaps - _tapCount;
     if (remaining > 0 && remaining <= 3) {
-      showFToast(
+      showPokaToast(
         context: context,
         title: Text(t.settings.easterEggRemaining(remaining: remaining)),
       );
@@ -52,7 +53,7 @@ class _EasterEggIconState extends State<EasterEggIcon> {
       _tapCount = 0;
       _firstTapTime = null;
 
-      showFToast(
+      showPokaToast(
         context: context,
         title: Text(t.settings.easterEggFound),
       );

--- a/lib/features/settings/presentation/widgets/sections/data_management_section.dart
+++ b/lib/features/settings/presentation/widgets/sections/data_management_section.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:forui/forui.dart';
 import 'package:forui_phosphor/forui_phosphor.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/app/providers/repository_providers.dart';
@@ -30,6 +29,7 @@ import 'package:poka_ce/features/settings/presentation/widgets/settings_menu_sec
 import 'package:poka_ce/features/transactions/presentation/controllers/transaction_list_notifier.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 
 class DataManagementSection extends ConsumerWidget {
   const DataManagementSection({super.key});
@@ -38,7 +38,7 @@ class DataManagementSection extends ConsumerWidget {
     final appLockState = ref.read(appLockControllerProvider);
     if (!appLockState.isEnabled) {
       // Force setup if not active
-      showFToast(
+      showPokaToast(
         context: context,
         title: Text(context.t.lock.setupPinBody),
       );
@@ -88,7 +88,7 @@ class DataManagementSection extends ConsumerWidget {
                     sharePositionOrigin: rect,
                   );
                   if (!success && context.mounted) {
-                    showFToast(
+                    showPokaToast(
                       context: context,
                       title: Text(context.t.common.error),
                     );
@@ -100,7 +100,7 @@ class DataManagementSection extends ConsumerWidget {
               if (password == null) return;
 
               if (!context.mounted) return;
-              showFToast(
+              showPokaToast(
                 context: context,
                 title: Text(context.t.backup.backupSuccess),
               );
@@ -164,7 +164,7 @@ class DataManagementSection extends ConsumerWidget {
                 ..invalidate(recurringListProvider)
                 ..invalidate(reportProvider);
 
-              showFToast(
+              showPokaToast(
                 context: context,
                 title: Text(context.t.backup.restoreSuccess),
               );
@@ -190,7 +190,7 @@ class DataManagementSection extends ConsumerWidget {
             if (selected != null) {
               await ref.read(backupReminderNotifierProvider.notifier).setInterval(selected);
               if (context.mounted) {
-                showFToast(
+                showPokaToast(
                   context: context,
                   title: Text(context.t.backup.reminderSaved),
                 );
@@ -218,7 +218,7 @@ class DataManagementSection extends ConsumerWidget {
             await ref.read(databaseProvider).transactionsDao.clearOldTransactions(oneYearAgo);
 
             if (!context.mounted) return;
-            showFToast(
+            showPokaToast(
               context: context,
               title: Text(t.settings.oldTransactionsCleared),
             );
@@ -263,7 +263,7 @@ class DataManagementSection extends ConsumerWidget {
               ..invalidate(reportProvider);
 
             if (!context.mounted) return;
-            showFToast(
+            showPokaToast(
               context: context,
               title: Text(t.settings.appDataReset),
             );

--- a/lib/features/transactions/presentation/screens/transaction_list_page.dart
+++ b/lib/features/transactions/presentation/screens/transaction_list_page.dart
@@ -18,6 +18,7 @@ import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
 import 'package:poka_ce/shared/widgets/poka_amount_text.dart';
 import 'package:poka_ce/shared/widgets/poka_empty_view.dart';
 import 'package:poka_ce/shared/widgets/poka_header.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/theme/theme.dart';
 
 /// Transaction list page — displays all transactions for a given date window
@@ -565,24 +566,19 @@ class _DateGroupSection extends ConsumerWidget {
                     if (confirmed == true) {
                       await ref.read(transactionListNotifierProvider.notifier).deleteTransaction(tx.id);
                       if (context.mounted) {
-                        showFToast(
+                        showPokaActionToast(
                           context: context,
                           title: Text(t.transactions.transactionDeleted),
-                          suffixBuilder: (toastContext, entry) => FButton(
-                            size: FButtonSizeVariant.sm,
-                            variant: FButtonVariant.outline,
-                            onPress: () async {
-                              entry.dismiss();
-                              await ref.read(transactionListNotifierProvider.notifier).restoreTransaction(tx);
-                              if (context.mounted) {
-                                showFToast(
-                                  context: context,
-                                  title: Text(t.transactions.transactionRestored),
-                                );
-                              }
-                            },
-                            child: Text(t.common.undo),
-                          ),
+                          actionLabel: t.common.undo,
+                          onAction: () async {
+                            await ref.read(transactionListNotifierProvider.notifier).restoreTransaction(tx);
+                            if (context.mounted) {
+                              showPokaToast(
+                                context: context,
+                                title: Text(t.transactions.transactionRestored),
+                              );
+                            }
+                          },
                         );
                       }
                     }

--- a/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
@@ -23,6 +23,7 @@ import 'package:poka_ce/features/transactions/presentation/widgets/split/transac
 import 'package:poka_ce/features/transactions/presentation/widgets/split/transaction_split_summary_card.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 import 'package:poka_ce/shared/widgets/sheets/poka_sheet.dart';
 import 'package:poka_ce/theme/theme.dart';
 
@@ -135,7 +136,7 @@ class TransactionFormSheet extends HookConsumerWidget {
         ref.read(transactionListNotifierProvider.notifier).refresh();
         Navigator.of(context).pop(true);
       } else if (next.error != null && next.error != prev?.error) {
-        showFToast(
+        showPokaToast(
           context: context,
           title: Text(next.error.toString()),
           variant: FToastVariant.destructive,

--- a/lib/features/transactions/presentation/widgets/list/transaction_group_sliver.dart
+++ b/lib/features/transactions/presentation/widgets/list/transaction_group_sliver.dart
@@ -12,6 +12,7 @@ import 'package:poka_ce/features/transactions/presentation/widgets/list/transact
 import 'package:poka_ce/features/transactions/presentation/widgets/tile/transaction_tile.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
 import 'package:poka_ce/shared/widgets/dialogs/poka_confirm_dialog.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
 
 /// Renders transactions as grouped date sections inside a [SliverList].
 class TransactionGroupSliver extends HookWidget {
@@ -134,24 +135,19 @@ class _SliverDateGroupSection extends ConsumerWidget {
                     if (confirmed == true) {
                       await ref.read(transactionListNotifierProvider.notifier).deleteTransaction(tx.id);
                       if (context.mounted) {
-                        showFToast(
+                        showPokaActionToast(
                           context: context,
                           title: Text(t.transactions.transactionDeleted),
-                          suffixBuilder: (toastContext, entry) => FButton(
-                            size: FButtonSizeVariant.sm,
-                            variant: FButtonVariant.outline,
-                            onPress: () async {
-                              entry.dismiss();
-                              await ref.read(transactionListNotifierProvider.notifier).restoreTransaction(tx);
-                              if (context.mounted) {
-                                showFToast(
-                                  context: context,
-                                  title: Text(t.transactions.transactionRestored),
-                                );
-                              }
-                            },
-                            child: Text(t.common.undo),
-                          ),
+                          actionLabel: t.common.undo,
+                          onAction: () async {
+                            await ref.read(transactionListNotifierProvider.notifier).restoreTransaction(tx);
+                            if (context.mounted) {
+                              showPokaToast(
+                                context: context,
+                                title: Text(t.transactions.transactionRestored),
+                              );
+                            }
+                          },
                         );
                       }
                     }

--- a/lib/shared/widgets/poka_toast.dart
+++ b/lib/shared/widgets/poka_toast.dart
@@ -15,12 +15,8 @@ FToasterEntry showPokaToast({
   Widget? icon,
   Widget? description,
   Widget Function(BuildContext context, FToasterEntry entry)? suffixBuilder,
-  FToastAlignment alignment = FToastAlignment.bottomCenter,
-  List<AxisDirection> swipeToDismiss = const [
-    AxisDirection.down,
-    AxisDirection.left,
-    AxisDirection.right,
-  ],
+  FToastAlignment? alignment,
+  List<AxisDirection>? swipeToDismiss,
   Duration duration = const Duration(seconds: 4),
   VoidCallback? onDismiss,
 }) {

--- a/lib/shared/widgets/poka_toast.dart
+++ b/lib/shared/widgets/poka_toast.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+/// Displays an auto-dismissing toast notification with watchdog timer protection.
+///
+/// Prevents mobile touch hover traps, gesture arena cancel traps, and route transition
+/// race conditions by attaching an independent timer that safely dismisses the toast
+/// post-frame if ForUI's internal timer is cancelled or interrupted.
+FToasterEntry showPokaToast({
+  required BuildContext context,
+  required Widget title,
+  FToastVariant variant = FToastVariant.primary,
+  Widget? icon,
+  Widget? description,
+  Widget Function(BuildContext context, FToasterEntry entry)? suffixBuilder,
+  FToastAlignment alignment = FToastAlignment.bottomCenter,
+  List<AxisDirection> swipeToDismiss = const [
+    AxisDirection.down,
+    AxisDirection.left,
+    AxisDirection.right,
+  ],
+  Duration duration = const Duration(seconds: 4),
+  VoidCallback? onDismiss,
+}) {
+  Timer? watchdogTimer;
+  late final FToasterEntry entry;
+
+  entry = showFToast(
+    context: context,
+    title: title,
+    variant: variant,
+    icon: icon,
+    description: description,
+    suffixBuilder: suffixBuilder,
+    alignment: alignment,
+    swipeToDismiss: swipeToDismiss,
+    duration: duration,
+    onDismiss: () {
+      watchdogTimer?.cancel();
+      onDismiss?.call();
+    },
+  );
+
+  // Watchdog timer ensures the toast auto-dismisses even if mobile touch / hover events
+  // or gesture arena cancellations froze the internal timer.
+  watchdogTimer = Timer(duration + const Duration(milliseconds: 300), () {
+    if (entry.showing) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (entry.showing) {
+          entry.dismiss();
+        }
+      });
+    }
+  });
+
+  return entry;
+}
+
+/// Displays an actionable toast notification (e.g. Delete with Undo button)
+/// positioned at [FToastAlignment.bottomCenter] for optimal thumb ergonomics.
+FToasterEntry showPokaActionToast({
+  required BuildContext context,
+  required Widget title,
+  required String actionLabel,
+  required VoidCallback onAction,
+  FToastVariant variant = FToastVariant.primary,
+  Widget? icon,
+  Widget? description,
+  FToastAlignment alignment = FToastAlignment.bottomCenter,
+  List<AxisDirection> swipeToDismiss = const [
+    AxisDirection.down,
+    AxisDirection.left,
+    AxisDirection.right,
+  ],
+  Duration duration = const Duration(seconds: 5),
+  VoidCallback? onDismiss,
+}) {
+  return showPokaToast(
+    context: context,
+    title: title,
+    variant: variant,
+    icon: icon,
+    description: description,
+    alignment: alignment,
+    swipeToDismiss: swipeToDismiss,
+    duration: duration,
+    onDismiss: onDismiss,
+    suffixBuilder: (toastContext, entry) => FButton(
+      size: FButtonSizeVariant.sm,
+      variant: FButtonVariant.outline,
+      onPress: () {
+        entry.dismiss();
+        onAction();
+      },
+      child: Text(actionLabel),
+    ),
+  );
+}

--- a/lib/shared/widgets/poka_toast.dart
+++ b/lib/shared/widgets/poka_toast.dart
@@ -48,6 +48,7 @@ FToasterEntry showPokaToast({
           entry.dismiss();
         }
       });
+      WidgetsBinding.instance.ensureVisualUpdate();
     }
   });
 

--- a/test/shared/widgets/poka_toast_test.dart
+++ b/test/shared/widgets/poka_toast_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:poka_ce/shared/widgets/poka_toast.dart';
+import 'package:poka_ce/theme/theme.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      builder: (context, child) => FTheme(
+        data: lightTheme,
+        child: FToaster(child: child!),
+      ),
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('showPokaToast', () {
+    testWidgets('displays title and auto-dismisses after duration', (tester) async {
+      var dismissed = false;
+
+      await tester.pumpWidget(
+        buildApp(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                showPokaToast(
+                  context: context,
+                  title: const Text('Saved successfully'),
+                  duration: const Duration(seconds: 3),
+                  onDismiss: () => dismissed = true,
+                );
+              },
+              child: const Text('Show Toast'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Toast'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Saved successfully'), findsOneWidget);
+      expect(dismissed, isFalse);
+
+      // Advance past duration + watchdog
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Saved successfully'), findsNothing);
+      expect(dismissed, isTrue);
+    });
+
+    testWidgets('watchdog timer dismisses toast when still showing', (tester) async {
+      var dismissed = false;
+
+      await tester.pumpWidget(
+        buildApp(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                showPokaToast(
+                  context: context,
+                  title: const Text('Watchdog Test'),
+                  duration: const Duration(seconds: 2),
+                  onDismiss: () => dismissed = true,
+                );
+              },
+              child: const Text('Trigger'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Watchdog Test'), findsOneWidget);
+
+      // Advance time to allow duration + watchdog (2s + 300ms) to trigger
+      await tester.pump(const Duration(milliseconds: 2500));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Watchdog Test'), findsNothing);
+      expect(dismissed, isTrue);
+    });
+  });
+
+  group('showPokaActionToast', () {
+    testWidgets('renders action button and triggers onAction callback when tapped', (tester) async {
+      var actionTriggered = false;
+
+      await tester.pumpWidget(
+        buildApp(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                showPokaActionToast(
+                  context: context,
+                  title: const Text('Item deleted'),
+                  actionLabel: 'Undo',
+                  onAction: () => actionTriggered = true,
+                  duration: const Duration(seconds: 5),
+                );
+              },
+              child: const Text('Delete'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Delete'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Item deleted'), findsOneWidget);
+      expect(find.text('Undo'), findsOneWidget);
+
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+
+      expect(actionTriggered, isTrue);
+      expect(find.text('Item deleted'), findsNothing);
+    });
+  });
+}

--- a/test/shared/widgets/poka_toast_test.dart
+++ b/test/shared/widgets/poka_toast_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
@@ -54,7 +56,7 @@ void main() {
       expect(dismissed, isTrue);
     });
 
-    testWidgets('watchdog timer dismisses toast when still showing', (tester) async {
+    testWidgets('watchdog timer dismisses toast when internal timer is interrupted by hover', (tester) async {
       var dismissed = false;
 
       await tester.pumpWidget(
@@ -80,12 +82,27 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.text('Watchdog Test'), findsOneWidget);
 
-      // Advance time to allow duration + watchdog (2s + 300ms) to trigger
-      await tester.pump(const Duration(milliseconds: 2500));
+      // Simulate mouse hovering over toast to interrupt/cancel ForUI's internal timer via MouseRegion.onEnter
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      await gesture.moveTo(tester.getCenter(find.text('Watchdog Test')));
+      await tester.pump();
+
+      // Advance past normal duration (2s). Internal timer was cancelled by MouseRegion.onEnter,
+      // so without watchdog it would remain indefinitely.
+      await tester.pump(const Duration(seconds: 2));
+      expect(find.text('Watchdog Test'), findsOneWidget);
+      expect(dismissed, isFalse);
+
+      // Advance past watchdog duration (+300ms post-frame)
+      await tester.pump(const Duration(milliseconds: 400));
       await tester.pumpAndSettle();
 
       expect(find.text('Watchdog Test'), findsNothing);
       expect(dismissed, isTrue);
+
+      await gesture.removePointer();
+      await tester.pump(const Duration(milliseconds: 300));
     });
   });
 


### PR DESCRIPTION
## Summary
Resolves #46 (BUG-011 and BUG-012).

### Problem
1. **Toast Freezing Indefinitely (BUG-012)**: Across multiple flows (Backup restore, reset data, form submissions, and route navigation), toasts displayed via ForUI's `showFToast` frequently became permanently stuck on screen due to internal timer cancellation on mobile touch/hover events, gesture arena interruptions, or route transition race conditions.
2. **Top-Center Undo Ergonomics (BUG-011)**: Deletion confirmation toasts with actionable "Undo" buttons appeared at `topCenter`, placing time-sensitive actions into the unreachable one-handed mobile thumb zone.

### Changes
- Created `showPokaToast` in `lib/shared/widgets/poka_toast.dart` with an independent watchdog timer (`duration + 300ms`) that guarantees safe post-frame dismissal even if the internal timer freezes.
- Created `showPokaActionToast` placing actionable undo toasts at `bottomCenter` for effortless one-handed thumb reachability without grip adjustment.
- Replaced all raw `showFToast` calls across the entire codebase (forms, sheets, pages, lock screen, and easter egg) with `showPokaToast` and `showPokaActionToast`.
- Added test suite `test/shared/widgets/poka_toast_test.dart` covering presentation, timer auto-dismissal, watchdog timer safety, and action tap handling.
- Updated `CHANGELOG.md` and `BUG.md` action items.

### Verification
- `rune fix` applied.
- `rune check` reports: "No issues found!".
- `flutter test test/shared/widgets/poka_toast_test.dart` passed (3/3).
- `flutter test test/feature/features/debts/presentation/widgets/debt_form_sheet_test.dart` passed (18/18).