### PR TITLE
chore: prepare v1.0.0 release and standardize branding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,27 +54,54 @@ jobs:
 
       - name: Build Universal & Split APKs
         run: |
-          # Build Universal Fat APK first
-          flutter build apk --release --dart-define=APP_VERSION=${{ github.event.inputs.tag || github.ref_name }}
-          # Rename it so it's clear and won't be overwritten
-          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/app-universal-release.apk
-          
-          # Build Split APKs
-          flutter build apk --release --split-per-abi --dart-define=APP_VERSION=${{ github.event.inputs.tag || github.ref_name }}
+          TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
 
-      - name: Upload Release APKs
+          # Build Universal Fat APK with Obfuscation & Symbol Stripping
+          flutter build apk --release \
+            --obfuscate --split-debug-info=build/app/outputs/symbols \
+            --dart-define=APP_VERSION="$TAG_NAME"
+          mv build/app/outputs/flutter-apk/app-release.apk "build/app/outputs/flutter-apk/poka-$TAG_NAME-universal.apk"
+          
+          # Build Split APKs with Obfuscation & Symbol Stripping
+          flutter build apk --release --split-per-abi \
+            --obfuscate --split-debug-info=build/app/outputs/symbols \
+            --dart-define=APP_VERSION="$TAG_NAME"
+
+          # Rename Split APKs to poka-vX.X.X-<abi>.apk
+          mv build/app/outputs/flutter-apk/app-arm64-v8a-release.apk "build/app/outputs/flutter-apk/poka-$TAG_NAME-arm64-v8a.apk"
+          mv build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk "build/app/outputs/flutter-apk/poka-$TAG_NAME-armeabi-v7a.apk"
+          mv build/app/outputs/flutter-apk/app-x86_64-release.apk "build/app/outputs/flutter-apk/poka-$TAG_NAME-x86_64.apk"
+
+          # Generate SHA-256 Checksums for all release APKs
+          cd build/app/outputs/flutter-apk
+          sha256sum poka-*.apk > checksums.txt
+          cd -
+
+      - name: Upload Release Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: poka-ce-release
-          path: build/app/outputs/flutter-apk/app-*-release.apk
+          path: |
+            build/app/outputs/flutter-apk/poka-*.apk
+            build/app/outputs/flutter-apk/checksums.txt
+            build/app/outputs/symbols
 
       - name: Attach APKs to Release
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: build/app/outputs/flutter-apk/app-*-release.apk
+          file: build/app/outputs/flutter-apk/poka-*.apk
           file_glob: true
+          tag: ${{ github.event.inputs.tag || github.ref_name }}
+          overwrite: true
+
+      - name: Attach Checksums to Release
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/app/outputs/flutter-apk/checksums.txt
           tag: ${{ github.event.inputs.tag || github.ref_name }}
           overwrite: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,14 @@ jobs:
           # Build Universal Fat APK with Obfuscation & Symbol Stripping
           flutter build apk --release \
             --obfuscate --split-debug-info=build/app/outputs/symbols \
+            --extra-gen-snapshot-options=--strip \
             --dart-define=APP_VERSION="$TAG_NAME"
           mv build/app/outputs/flutter-apk/app-release.apk "build/app/outputs/flutter-apk/poka-$TAG_NAME-universal.apk"
           
           # Build Split APKs with Obfuscation & Symbol Stripping
           flutter build apk --release --split-per-abi \
             --obfuscate --split-debug-info=build/app/outputs/symbols \
+            --extra-gen-snapshot-options=--strip \
             --dart-define=APP_VERSION="$TAG_NAME"
 
           # Rename Split APKs to poka-vX.X.X-<abi>.apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added informative subtitles and descriptions to empty views across Debt, Goal, Budget, Recurring, Account, Dashboard, and Report sections.
+
+### Fixed
+
+- Resolved `RecurringListNotifier` lifecycle disposal error during active screen navigation and background runner processing.
+- Fixed content clipping in `PokaEmptyViewCentered` on tall viewports by enforcing safe min-height constraints.
+- Standardized container borders on empty view components to appear only when succeeded by additional page sections.
+
 ## [v1.0.0-rc.2] - 2026-09-10
 
 Release Candidate 2 for Poka CE v1.0.0. Incorporates all smoke testing bug fixes and stabilization improvements discovered during RC.1 evaluation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced empty views across Debt, Goal, Budget, Recurring, Account, Dashboard, and Report sections with informative subtitles and contextual descriptions.
 - Streamlined Goals page into a unified single-stream layout, replacing header filter chips with a dedicated section for completed goals.
 - Aligned Debt repayment sheet layout with the transaction form sheet, replacing the floating outline button with an integrated meta bar featuring note editing and an interactive quick pay-in-full toggle action.
+- Excluded sub-pockets and virtual goal accounts from the active accounts counter badge on Net Worth cards while preserving full balance aggregation across all active accounts and pockets.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Added informative subtitles and descriptions to empty views across Debt, Goal, Budget, Recurring, Account, Dashboard, and Report sections.
-
 ### Changed
 
+- Hardened Android ProGuard/R8 rules for local notifications, biometric authentication, secure storage, and Drift SQLite engine.
+- Configured Dart code obfuscation, debug symbol splitting, and packaging metadata stripping for release builds.
+- Standardized release APK distribution naming convention to `poka-v<version>-<abi>.apk` and automated SHA-256 checksums generation in release workflow.
+- Enhanced About settings page with a direct 'Check for Updates' release link referencing centralized repository configuration.
+- Enhanced empty views across Debt, Goal, Budget, Recurring, Account, Dashboard, and Report sections with informative subtitles and contextual descriptions.
 - Streamlined Goals page into a unified single-stream layout, replacing header filter chips with a dedicated section for completed goals.
 - Aligned Debt repayment sheet layout with the transaction form sheet, replacing the floating outline button with an integrated meta bar featuring note editing and an interactive quick pay-in-full toggle action.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.0] - 2026-09-11
+
+Initial General Availability release of Poka CE.
+
 ### Changed
 
+- Enforced offline-only typography runtime mode (`allowRuntimeFetching = false`), guaranteeing Inter and Plus Jakarta Sans render from local assets with zero external network access.
+- Standardized Android application launcher label to TitleCase `Poka CE`.
+- Expanded default category catalog to 62 expense and income categories with rich sub-categories and diverse iconography.
+- Excluded sub-pockets and virtual goal accounts from the active accounts counter badge on Net Worth cards while preserving full balance aggregation across all active accounts and pockets.
 - Hardened Android ProGuard/R8 rules for local notifications, biometric authentication, secure storage, and Drift SQLite engine.
 - Configured Dart code obfuscation, debug symbol splitting, and packaging metadata stripping for release builds.
 - Standardized release APK distribution naming convention to `poka-v<version>-<abi>.apk` and automated SHA-256 checksums generation in release workflow.
@@ -16,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced empty views across Debt, Goal, Budget, Recurring, Account, Dashboard, and Report sections with informative subtitles and contextual descriptions.
 - Streamlined Goals page into a unified single-stream layout, replacing header filter chips with a dedicated section for completed goals.
 - Aligned Debt repayment sheet layout with the transaction form sheet, replacing the floating outline button with an integrated meta bar featuring note editing and an interactive quick pay-in-full toggle action.
-- Excluded sub-pockets and virtual goal accounts from the active accounts counter badge on Net Worth cards while preserving full balance aggregation across all active accounts and pockets.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added informative subtitles and descriptions to empty views across Debt, Goal, Budget, Recurring, Account, Dashboard, and Report sections.
 
+### Changed
+
+- Streamlined Goals page into a unified single-stream layout, replacing header filter chips with a dedicated section for completed goals.
+
 ### Fixed
 
 - Resolved `RecurringListNotifier` lifecycle disposal error during active screen navigation and background runner processing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Streamlined Goals page into a unified single-stream layout, replacing header filter chips with a dedicated section for completed goals.
+- Aligned Debt repayment sheet layout with the transaction form sheet, replacing the floating outline button with an integrated meta bar featuring note editing and an interactive quick pay-in-full toggle action.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -122,23 +122,21 @@ Download the latest release directly from the [GitHub Releases page](https://git
 
 - Flutter SDK **3.47.1** or newer
 - Dart SDK **3.13.1** or newer
-- [Rune](https://github.com/octopyid/rune) task runner (recommended)
+- [Rune](https://github.com/octopyid/rune) task runner:
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/octopyid/rune/main/install.sh | sh
+  ```
+  <details><summary>Other methods (Homebrew, Go)</summary>
 
-#### Installing Rune
+  ```bash
+  # Homebrew
+  brew install octopyid/tap/rune
 
-Poka CE uses [Rune](https://github.com/octopyid/rune) — a fast, opinionated project-local task runner written in Go by [@octopyid](https://github.com/octopyid).
+  # Go
+  go install github.com/octopyid/rune/cmd/rune@latest
+  ```
 
-**Homebrew (macOS / Linux):**
-
-```bash
-brew install octopyid/tap/rune
-```
-
-**Go:**
-
-```bash
-go install github.com/octopyid/rune/cmd/rune@latest
-```
+  </details>
 
 ### Steps
 

--- a/Runefile
+++ b/Runefile
@@ -111,15 +111,15 @@ test:coverage:
 #[Build Android APK (defaults to fat Universal APK; pass --split for fat + split-per-abi)]
 # --split: Build split-per-ABI APKs alongside universal APK
 build:apk --split?:
-    flutter build apk --release --obfuscate --split-debug-info=build/app/outputs/symbols --dart-define-from-file=.env
+    flutter build apk --release --obfuscate --split-debug-info=build/app/outputs/symbols --extra-gen-snapshot-options=--strip --dart-define-from-file=.env
     mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/poka-universal.apk
     cp build/app/outputs/flutter-apk/poka-universal.apk build/app/outputs/flutter-apk/app-universal-release.apk
-    sh -c '[ -n "{{split}}" ] && flutter build apk --release --split-per-abi --obfuscate --split-debug-info=build/app/outputs/symbols --dart-define-from-file=.env && cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk build/app/outputs/flutter-apk/poka-arm64-v8a.apk && cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk build/app/outputs/flutter-apk/poka-armeabi-v7a.apk && cp build/app/outputs/flutter-apk/app-x86_64-release.apk build/app/outputs/flutter-apk/poka-x86_64.apk || true'
+    sh -c '[ -n "{{split}}" ] && flutter build apk --release --split-per-abi --obfuscate --split-debug-info=build/app/outputs/symbols --extra-gen-snapshot-options=--strip --dart-define-from-file=.env && cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk build/app/outputs/flutter-apk/poka-arm64-v8a.apk && cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk build/app/outputs/flutter-apk/poka-armeabi-v7a.apk && cp build/app/outputs/flutter-apk/app-x86_64-release.apk build/app/outputs/flutter-apk/poka-x86_64.apk || true'
     rune done "APK build completed successfully!"
 
 #[Build an Android App Bundle (AAB)]
 build:aab:
-    flutter build appbundle --release --obfuscate --split-debug-info=build/app/outputs/symbols --dart-define-from-file=.env
+    flutter build appbundle --release --obfuscate --split-debug-info=build/app/outputs/symbols --extra-gen-snapshot-options=--strip --dart-define-from-file=.env
     rune done "App Bundle (AAB) built successfully!"
 
 #[Generate a new Android Keystore for release signing]

--- a/Runefile
+++ b/Runefile
@@ -34,7 +34,7 @@ uninstall:
 
 #[Run build_runner and slang to generate code (Riverpod, Freezed, Drift, Slang)]
 generate:
-    rm -f lib/i18n/*.g.dart
+    rm -f lib/i18n/*.g.dart lib/_slang_temp.json
     dart run build_runner build
     dart run slang
     dart format .

--- a/Runefile
+++ b/Runefile
@@ -12,11 +12,6 @@
 run *args:
     flutter run --dart-define-from-file=.env {{args}}
 
-#[Alias for run — start local app on connected emulator/device]
-# args: Arguments forwarded directly to flutter run (e.g. -d macos, --release)
-dev *args:
-    flutter run --dart-define-from-file=.env {{args}}
-
 #[Clean Flutter build cache and fetch dependencies]
 clean:
     flutter clean
@@ -113,34 +108,21 @@ test:coverage:
 # Build & Distribution
 # ==========================================
 
-#[Alias for build:apk — build Android APK (defaults to fat; pass --split for fat + split)]
-# --split: Build split-per-ABI APKs alongside universal APK
-build --split?:
-    rune build:apk {{split}}
-
 #[Build Android APK (defaults to fat Universal APK; pass --split for fat + split-per-abi)]
 # --split: Build split-per-ABI APKs alongside universal APK
 build:apk --split?:
-    flutter build apk --dart-define-from-file=.env
-    mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/app-universal-release.apk
-    sh -c '[ -n "{{split}}" ] && flutter build apk --split-per-abi --dart-define-from-file=.env || true'
+    flutter build apk --release --obfuscate --split-debug-info=build/app/outputs/symbols --dart-define-from-file=.env
+    mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/poka-universal.apk
+    cp build/app/outputs/flutter-apk/poka-universal.apk build/app/outputs/flutter-apk/app-universal-release.apk
+    sh -c '[ -n "{{split}}" ] && flutter build apk --release --split-per-abi --obfuscate --split-debug-info=build/app/outputs/symbols --dart-define-from-file=.env && cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk build/app/outputs/flutter-apk/poka-arm64-v8a.apk && cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk build/app/outputs/flutter-apk/poka-armeabi-v7a.apk && cp build/app/outputs/flutter-apk/app-x86_64-release.apk build/app/outputs/flutter-apk/poka-x86_64.apk || true'
     rune done "APK build completed successfully!"
 
 #[Build an Android App Bundle (AAB)]
 build:aab:
-    flutter build appbundle --dart-define-from-file=.env
+    flutter build appbundle --release --obfuscate --split-debug-info=build/app/outputs/symbols --dart-define-from-file=.env
     rune done "App Bundle (AAB) built successfully!"
 
 #[Generate a new Android Keystore for release signing]
 build:keystore:
     chmod +x scripts/keystore.sh
     ./scripts/keystore.sh
-
-#[Alias for build:keystore — generate Android Keystore]
-keystore:
-    rune build:keystore
-
-#[Alias for install — install built APK on connected device]
-# arch: Target architecture (default: fat/universal; options: fat, arm64, armeabi-v7a, x86_64)
-build:install arch="fat":
-    rune install "{{arch}}"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -60,6 +60,21 @@ android {
             )
         }
     }
+
+    packaging {
+        resources {
+            excludes += listOf(
+                "META-INF/*.version",
+                "META-INF/DEPENDENCIES",
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.txt",
+                "META-INF/license.txt",
+                "META-INF/NOTICE",
+                "META-INF/NOTICE.txt",
+                "META-INF/notice.txt"
+            )
+        }
+    }
 }
 
 kotlin {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -20,3 +20,21 @@
 -keep class androidx.core.content.pm.ShortcutManagerCompat** { *; }
 -keep class androidx.core.graphics.drawable.IconCompat** { *; }
 
+# Flutter Local Notifications
+-keep class com.dexterous.** { *; }
+-keepattributes Signature
+-keepattributes *Annotation*
+-dontwarn sun.misc.**
+
+# SQLite / Drift
+-keep class org.sqlite.** { *; }
+-dontwarn org.sqlite.**
+
+# Local Auth & Biometrics
+-keep class io.flutter.plugins.localauth.** { *; }
+-keep class androidx.biometric.** { *; }
+
+# Flutter Secure Storage
+-keep class com.it_nomads.fluttersecurestorage.** { *; }
+
+

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
-        android:label="POKA CE"
+        android:label="Poka CE"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/assets/data/categories.json
+++ b/assets/data/categories.json
@@ -1,214 +1,468 @@
 [
   {
-    "id": "01a031e6-4381-7f4c-a22c-a543bfa8fcc4",
-    "name": "Food & Dining",
-    "type": "expense",
-    "icon": "bowl-food",
+    "id": "01a08cc1-a96a-7041-9258-86dc773d4ac1",
+    "name": "Food & Drinks",
+    "icon": "fork-knife",
     "color": "#F97316",
-    "sort": 1,
+    "type": "expense",
     "children": [
       {
-        "id": "01a031e6-4383-795d-941a-bd56910ad828",
+        "id": "01a08cc1-a96a-78cb-9e03-3f8cba51250d",
         "name": "Groceries",
-        "type": "expense",
         "icon": "shopping-cart",
-        "color": "#F97316",
-        "sort": 1
+        "color": "#10B981",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-70ac-be30-25a5cff2ee0a",
-        "name": "Restaurant",
-        "type": "expense",
-        "icon": "fork-knife",
-        "color": "#F97316",
-        "sort": 2
+        "id": "01a08cc1-a96a-704c-ab58-0cd31b6dd570",
+        "name": "Dining Out",
+        "icon": "bowl-food",
+        "color": "#EF4444",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-72e7-8629-7dbc40dea76f",
-        "name": "Coffee & Snacks",
-        "type": "expense",
+        "id": "01a08cc1-a96a-70e1-88eb-ff9ec72b61b9",
+        "name": "Coffee & Drinks",
         "icon": "coffee",
-        "color": "#F97316",
-        "sort": 3
+        "color": "#D97706",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7e62-b4c2-2afeab924666",
+        "name": "Food Delivery",
+        "icon": "bag",
+        "color": "#EC4899",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7d82-a2f7-6175594b2739",
+        "name": "Snacks",
+        "icon": "cookie",
+        "color": "#F59E0B",
+        "type": "expense"
       }
     ]
   },
   {
-    "id": "01a031e6-4383-7f10-aca9-917f48351ced",
-    "name": "Transport",
-    "type": "expense",
+    "id": "01a08cc1-a96a-792a-a9b2-d2cbfa7faba8",
+    "name": "Transportation",
     "icon": "car",
     "color": "#3B82F6",
-    "sort": 2,
+    "type": "expense",
     "children": [
       {
-        "id": "01a031e6-4383-7383-b710-53fa05e8a1c9",
-        "name": "Fuel",
-        "type": "expense",
+        "id": "01a08cc1-a96a-7fe1-9c68-f0c6cdbf4fc9",
+        "name": "Fuel & Gas",
         "icon": "gas-pump",
-        "color": "#3B82F6",
-        "sort": 1
+        "color": "#EF4444",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-754f-a2ad-a8c0ca755e1d",
-        "name": "Public Transport",
-        "type": "expense",
+        "id": "01a08cc1-a96a-7536-b0fa-7762d52dd826",
+        "name": "Public Transit",
         "icon": "bus",
-        "color": "#3B82F6",
-        "sort": 2
+        "color": "#10B981",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-70cf-96bf-5c2861b60287",
-        "name": "Ride Hailing",
-        "type": "expense",
+        "id": "01a08cc1-a96a-7a88-9693-f0ec75ca9349",
+        "name": "Ride-Hailing",
         "icon": "taxi",
-        "color": "#3B82F6",
-        "sort": 3
+        "color": "#F59E0B",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-73ea-a23c-f2068865a58b",
+        "name": "Parking & Tolls",
+        "icon": "ticket",
+        "color": "#8B5CF6",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7c4e-8a57-5f125e56939c",
+        "name": "Vehicle Maintenance",
+        "icon": "wrench",
+        "color": "#64748B",
+        "type": "expense"
       }
     ]
   },
   {
-    "id": "01a031e6-4383-7f11-b1ac-e958fbfb03be",
-    "name": "Housing",
-    "type": "expense",
-    "icon": "house",
+    "id": "01a08cc1-a96a-7adc-91b3-e17ab468edcc",
+    "name": "Bills & Utilities",
+    "icon": "lightning",
     "color": "#8B5CF6",
-    "sort": 3,
+    "type": "expense",
     "children": [
       {
-        "id": "01a031e6-4383-753a-a14c-0f3c97513eb4",
-        "name": "Rent",
-        "type": "expense",
-        "icon": "key",
-        "color": "#8B5CF6",
-        "sort": 1
-      },
-      {
-        "id": "01a031e6-4383-71b6-8dc4-5671f1e0e740",
-        "name": "Utilities",
-        "type": "expense",
+        "id": "01a08cc1-a96a-72d9-a95a-d0fb81d1fde2",
+        "name": "Electricity",
         "icon": "lightning",
-        "color": "#8B5CF6",
-        "sort": 2
+        "color": "#F59E0B",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-7960-8e18-1cb754afadb8",
-        "name": "Internet & Phone",
-        "type": "expense",
+        "id": "01a08cc1-a96a-79d4-9342-9007d3f46d8a",
+        "name": "Water",
+        "icon": "drop",
+        "color": "#06B6D4",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7bcf-8c50-f1f8bb49b32c",
+        "name": "Internet & WiFi",
         "icon": "wifi-high",
-        "color": "#8B5CF6",
-        "sort": 3
+        "color": "#3B82F6",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-72d8-840c-1573404c4507",
+        "name": "Mobile Data",
+        "icon": "device-mobile",
+        "color": "#10B981",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7288-92f1-12ad66cc6146",
+        "name": "Rent",
+        "icon": "key",
+        "color": "#EC4899",
+        "type": "expense"
       }
     ]
   },
   {
-    "id": "01a031e6-4383-7987-bd20-370fc5b61756",
+    "id": "01a08cc1-a96a-7b33-9e75-72d17c08ed15",
     "name": "Shopping",
-    "type": "expense",
     "icon": "bag",
     "color": "#EC4899",
-    "sort": 4,
+    "type": "expense",
     "children": [
       {
-        "id": "01a031e6-4383-7df8-ad08-c80dcdc7328d",
-        "name": "Clothing",
-        "type": "expense",
-        "icon": "tshirt",
-        "color": "#EC4899",
-        "sort": 1
+        "id": "01a08cc1-a96a-7b52-b87b-c7c980951dc8",
+        "name": "Clothing & Apparel",
+        "icon": "t-shirt",
+        "color": "#8B5CF6",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-7046-ab7e-f87139e7c2c7",
-        "name": "Electronics",
-        "type": "expense",
+        "id": "01a08cc1-a96a-7de4-aa9f-f0a1dab7a2ce",
+        "name": "Electronics & Gadgets",
         "icon": "devices",
-        "color": "#EC4899",
-        "sort": 2
+        "color": "#3B82F6",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7043-bcec-25a87f2882e9",
+        "name": "Home & Living",
+        "icon": "house-line",
+        "color": "#F97316",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-77d4-8b51-c11eb980ab4b",
+        "name": "Personal Care",
+        "icon": "heart",
+        "color": "#F43F5E",
+        "type": "expense"
       }
     ]
   },
   {
-    "id": "01a031e6-4383-784f-b596-7bce86d1e6bc",
-    "name": "Health",
-    "type": "expense",
+    "id": "01a08cc1-a96a-794a-b77b-dd00ec8a5706",
+    "name": "Healthcare",
     "icon": "first-aid",
     "color": "#EF4444",
-    "sort": 5,
-    "children": [
-      {
-        "id": "01a031e6-4383-7fe0-9af9-c9042a8cc9ac",
-        "name": "Medicine",
-        "type": "expense",
-        "icon": "pill",
-        "color": "#EF4444",
-        "sort": 1
-      },
-      {
-        "id": "01a031e6-4383-7ad8-9cc5-100f08a0e839",
-        "name": "Doctor",
-        "type": "expense",
-        "icon": "stethoscope",
-        "color": "#EF4444",
-        "sort": 2
-      }
-    ]
-  },
-  {
-    "id": "01a031e6-4383-7e1c-b64d-36fe1ee3e18c",
-    "name": "Entertainment",
     "type": "expense",
-    "icon": "game-controller",
-    "color": "#14B8A6",
-    "sort": 6,
     "children": [
       {
-        "id": "01a031e6-4383-78ab-9a52-76d9cd0c39c5",
-        "name": "Streaming",
-        "type": "expense",
-        "icon": "monitor-play",
-        "color": "#14B8A6",
-        "sort": 1
+        "id": "01a08cc1-a96a-797e-9e14-460fb66266d2",
+        "name": "Medicine & Pharmacy",
+        "icon": "pill",
+        "color": "#3B82F6",
+        "type": "expense"
       },
       {
-        "id": "01a031e6-4383-704b-95b7-4f033a724841",
-        "name": "Games",
-        "type": "expense",
-        "icon": "game-controller",
-        "color": "#14B8A6",
-        "sort": 2
+        "id": "01a08cc1-a96a-7bb5-b04d-28f9b773df77",
+        "name": "Doctor & Clinic",
+        "icon": "stethoscope",
+        "color": "#10B981",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-72e5-9d4d-e98ec2e85218",
+        "name": "Health Insurance",
+        "icon": "shield-check",
+        "color": "#8B5CF6",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7e9e-86e2-7de783490bfc",
+        "name": "Fitness & Sports",
+        "icon": "barbell",
+        "color": "#F59E0B",
+        "type": "expense"
       }
     ]
   },
   {
-    "id": "01a031e6-4383-70cc-9328-3230277a212d",
+    "id": "01a08cc1-a96a-7874-87d5-80905e496cd4",
+    "name": "Entertainment",
+    "icon": "game-controller",
+    "color": "#06B6D4",
+    "type": "expense",
+    "children": [
+      {
+        "id": "01a08cc1-a96a-7a06-bf78-e752297137a4",
+        "name": "Streaming & Subscriptions",
+        "icon": "monitor-play",
+        "color": "#8B5CF6",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7394-a12d-eeac98c7cf10",
+        "name": "Cinema & Events",
+        "icon": "ticket",
+        "color": "#F59E0B",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7e31-baf0-f3b1d281073c",
+        "name": "Gaming & Hobbies",
+        "icon": "game-controller",
+        "color": "#EC4899",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7083-86a3-60f3561dc425",
+        "name": "Travel & Vacation",
+        "icon": "airplane",
+        "color": "#10B981",
+        "type": "expense"
+      }
+    ]
+  },
+  {
+    "id": "01a08cc1-a96a-7216-b15a-2d273cc7896d",
+    "name": "Education",
+    "icon": "graduation-cap",
+    "color": "#0EA5E9",
+    "type": "expense",
+    "children": [
+      {
+        "id": "01a08cc1-a96a-7d1c-aec4-139d5ac1aaaf",
+        "name": "Tuition & Courses",
+        "icon": "student",
+        "color": "#6366F1",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-72d8-93d1-175b1532a3e0",
+        "name": "Books & Supplies",
+        "icon": "books",
+        "color": "#F97316",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-749b-ad25-c0e1153523ec",
+        "name": "Online Learning",
+        "icon": "laptop",
+        "color": "#10B981",
+        "type": "expense"
+      }
+    ]
+  },
+  {
+    "id": "01a08cc1-a96a-7aff-8df4-fb4ba0c78980",
+    "name": "Other",
+    "icon": "dots-three",
+    "color": "#64748B",
+    "type": "expense",
+    "children": [
+      {
+        "id": "01a08cc1-a96a-7b14-bf88-0ed6532cc9d7",
+        "name": "Donations & Charity",
+        "icon": "heart",
+        "color": "#EC4899",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7bb5-accf-5418fbdc43c8",
+        "name": "Fees & Bank Charges",
+        "icon": "receipt",
+        "color": "#F97316",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-70c3-8508-83db27c347b9",
+        "name": "Taxes",
+        "icon": "scales",
+        "color": "#6366F1",
+        "type": "expense"
+      },
+      {
+        "id": "01a08cc1-a96a-7439-b4a5-34f69cd31b03",
+        "name": "Miscellaneous",
+        "icon": "tag",
+        "color": "#64748B",
+        "type": "expense"
+      }
+    ]
+  },
+  {
+    "id": "01a08cc1-a96a-7c6f-a2cc-248b4ce19507",
     "name": "Salary",
-    "type": "income",
     "icon": "bank",
     "color": "#22C55E",
-    "sort": 1
+    "type": "income",
+    "children": [
+      {
+        "id": "01a08cc1-a96a-7b01-9351-0165daeacb51",
+        "name": "Monthly Salary",
+        "icon": "briefcase",
+        "color": "#16A34A",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7219-9a08-175bd858fce2",
+        "name": "Bonus & Allowance",
+        "icon": "gift",
+        "color": "#F59E0B",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7bae-a008-3d542ae12d47",
+        "name": "Overtime Pay",
+        "icon": "clock",
+        "color": "#3B82F6",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-798b-9b25-e13eec735f4c",
+        "name": "Commissions",
+        "icon": "trend-up",
+        "color": "#8B5CF6",
+        "type": "income"
+      }
+    ]
   },
   {
-    "id": "01a031e6-4383-7ad0-909e-d4a890d6eb6c",
-    "name": "Business",
-    "type": "income",
+    "id": "01a08cc1-a96a-7414-8892-1607fe842d5d",
+    "name": "Business & Freelance",
     "icon": "briefcase",
-    "color": "#22C55E",
-    "sort": 2
-  },
-  {
-    "id": "01a031e6-4383-7fc5-8f2c-5c31810ba6a0",
-    "name": "Investment",
+    "color": "#10B981",
     "type": "income",
-    "icon": "trend-up",
-    "color": "#22C55E",
-    "sort": 3
+    "children": [
+      {
+        "id": "01a08cc1-a96a-7472-957b-a20fde29a45e",
+        "name": "Freelance Projects",
+        "icon": "laptop",
+        "color": "#06B6D4",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-75b7-9960-6f51f1a229d9",
+        "name": "Consulting Services",
+        "icon": "users",
+        "color": "#6366F1",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7948-aed7-b31d2d9bac33",
+        "name": "Online Sales",
+        "icon": "storefront",
+        "color": "#F97316",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7dca-986b-b1c055eb773b",
+        "name": "Side Projects",
+        "icon": "code",
+        "color": "#A855F7",
+        "type": "income"
+      }
+    ]
   },
   {
-    "id": "01a031e6-4383-7f2e-a030-3254111cad6c",
+    "id": "01a08cc1-a96a-73cb-997d-0ac1860a538e",
+    "name": "Investments",
+    "icon": "chart-line-up",
+    "color": "#059669",
+    "type": "income",
+    "children": [
+      {
+        "id": "01a08cc1-a96a-79fb-956f-1dba909184c8",
+        "name": "Stock Dividends",
+        "icon": "coins",
+        "color": "#10B981",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7c3e-aba7-40affe4c3e36",
+        "name": "Interest & Savings",
+        "icon": "vault",
+        "color": "#0284C7",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7d74-a0c2-39e97b9f62c5",
+        "name": "Capital Gains",
+        "icon": "trend-up",
+        "color": "#D97706",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7103-add8-8025d67233b5",
+        "name": "Rental Income",
+        "icon": "house",
+        "color": "#7C3AED",
+        "type": "income"
+      }
+    ]
+  },
+  {
+    "id": "01a08cc1-a96a-7a34-ba9b-3c975fdbbb7a",
+    "name": "Other",
+    "icon": "dots-three",
+    "color": "#14B8A6",
+    "type": "income",
+    "children": [
+      {
+        "id": "01a08cc1-a96a-7400-b1ee-268075414c4e",
+        "name": "Cashback & Rewards",
+        "icon": "ticket",
+        "color": "#06B6D4",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7717-a71f-39b3307d4f37",
+        "name": "Refunds",
+        "icon": "receipt",
+        "color": "#3B82F6",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7ed5-b473-6d9177653275",
+        "name": "Gifts",
+        "icon": "gift",
+        "color": "#EC4899",
+        "type": "income"
+      },
+      {
+        "id": "01a08cc1-a96a-7ea4-a5e3-28dfd0702816",
+        "name": "Miscellaneous",
+        "icon": "asterisk",
+        "color": "#8B5CF6",
+        "type": "income"
+      }
+    ]
+  },
+  {
+    "id": "01a08cc1-a96a-77fc-8e4c-713049353868",
     "name": "Transfer",
-    "type": "transfer",
     "icon": "arrows-left-right",
-    "color": "#64748B",
-    "sort": 1
+    "color": "#6366F1",
+    "type": "transfer",
+    "children": []
   }
 ]

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -20,4 +20,7 @@ class AppConfig {
   static const bool seedDummyData = bool.fromEnvironment(
     'POKA_SEED_DUMMY_DATA',
   );
+
+  /// The official GitHub repository URL for Poka CE.
+  static const String githubRepoUrl = 'https://github.com/getpoka/poka-ce';
 }

--- a/lib/core/utils/icon_util.dart
+++ b/lib/core/utils/icon_util.dart
@@ -51,6 +51,7 @@ class IconUtil {
         'carrot': FPhosphorIcons.carrot,
         'cake': FPhosphorIcons.cake,
         'ice_cream': FPhosphorIcons.iceCream,
+        'cookie': FPhosphorIcons.cookie,
       },
     ),
     IconCategory(
@@ -101,6 +102,7 @@ class IconUtil {
         'house_line': FPhosphorIcons.houseLine,
         'building': FPhosphorIcons.building,
         'building_apartment': FPhosphorIcons.buildingApartment,
+        'key': FPhosphorIcons.key,
         'lightning': FPhosphorIcons.lightning,
         'drop': FPhosphorIcons.drop,
         'fire': FPhosphorIcons.fire,
@@ -134,6 +136,7 @@ class IconUtil {
         'wheelchair': FPhosphorIcons.wheelchair,
         'activity': FPhosphorIcons.activity,
         'tooth': FPhosphorIcons.tooth,
+        'shield_check': FPhosphorIcons.shieldCheck,
       },
     ),
     IconCategory(
@@ -158,6 +161,7 @@ class IconUtil {
       icons: {
         'game_controller': FPhosphorIcons.gameController,
         'film_strip': FPhosphorIcons.filmStrip,
+        'monitor_play': FPhosphorIcons.monitorPlay,
         'music_notes': FPhosphorIcons.musicNotes,
         'headphones': FPhosphorIcons.headphones,
         'barbell': FPhosphorIcons.barbell,
@@ -183,6 +187,7 @@ class IconUtil {
         'laptop': FPhosphorIcons.laptop,
         'desktop': FPhosphorIcons.desktop,
         'device_mobile': FPhosphorIcons.deviceMobile,
+        'devices': FPhosphorIcons.devices,
         'briefcase': FPhosphorIcons.briefcase,
         'pen_nib': FPhosphorIcons.penNib,
         'code': FPhosphorIcons.code,
@@ -245,9 +250,12 @@ class IconUtil {
 
   /// Looks up an icon by its identifier [name], falling back to a wallet icon if not found.
   static IconData getIcon(String? name) {
-    if (name == null || !availableIcons.containsKey(name)) {
-      return FPhosphorIcons.wallet;
-    }
-    return availableIcons[name]!;
+    if (name == null) return FPhosphorIcons.wallet;
+    if (availableIcons.containsKey(name)) return availableIcons[name]!;
+    final normalized = name.replaceAll('-', '_');
+    if (availableIcons.containsKey(normalized)) return availableIcons[normalized]!;
+    final hyphenated = name.replaceAll('_', '-');
+    if (availableIcons.containsKey(hyphenated)) return availableIcons[hyphenated]!;
+    return FPhosphorIcons.wallet;
   }
 }

--- a/lib/database/seeder.dart
+++ b/lib/database/seeder.dart
@@ -70,13 +70,13 @@ class DatabaseSeeder {
     final goalAccount2Id = uuid.v7();
     final goalAccount3Id = uuid.v7();
 
-    // Categories UUIDs
-    const foodId = '01a031e6-4381-7f4c-a22c-a543bfa8fcc4';
-    const transportId = '01a031e6-4383-7f10-aca9-917f48351ced';
-    const billsId = '01a031e6-4383-7f11-b1ac-e958fbfb03be';
-    const salaryId = '01a031e6-4383-70cc-9328-3230277a212d';
-    const lunchId = '01a031e6-4383-795d-941a-bd56910ad828';
-    const electricityId = '01a031e6-4383-71b6-8dc4-5671f1e0e740';
+    // Categories UUIDs — must stay in sync with assets/data/categories.json
+    const foodId = '01a08cc1-a96a-7041-9258-86dc773d4ac1'; // Food & Drinks
+    const transportId = '01a08cc1-a96a-792a-a9b2-d2cbfa7faba8'; // Transportation
+    const billsId = '01a08cc1-a96a-7adc-91b3-e17ab468edcc'; // Bills & Utilities
+    const salaryId = '01a08cc1-a96a-7c6f-a2cc-248b4ce19507'; // Salary
+    const lunchId = '01a08cc1-a96a-78cb-9e03-3f8cba51250d'; // Groceries
+    const electricityId = '01a08cc1-a96a-72d9-a95a-d0fb81d1fde2'; // Electricity
 
     // Other UUIDs
     final budgetId = uuid.v7();

--- a/lib/features/accounts/presentation/screens/pocket_detail_page.dart
+++ b/lib/features/accounts/presentation/screens/pocket_detail_page.dart
@@ -101,7 +101,7 @@ class PocketDetailPage extends HookConsumerWidget {
               child: PokaEmptyView(
                 icon: FPhosphorIcons.receipt,
                 title: t.accounts.noTransactionsYet,
-                hasBorder: true,
+                subtitle: t.accounts.pocketTransactionsSubtitle,
               ).animate().fade(duration: 300.ms, delay: 240.ms).slideY(begin: 0.05, end: 0),
             )
           else

--- a/lib/features/accounts/presentation/widgets/sections/recent_transactions_section.dart
+++ b/lib/features/accounts/presentation/widgets/sections/recent_transactions_section.dart
@@ -65,7 +65,7 @@ class RecentTransactionsSection extends HookConsumerWidget {
           PokaEmptyView(
             icon: FPhosphorIcons.receipt,
             title: t.accounts.noTransactionsYet,
-            hasBorder: true,
+            subtitle: t.accounts.accountTransactionsSubtitle,
           ).animate().fade(duration: 300.ms, delay: 120.ms).slideY(begin: 0.05, end: 0)
         else
           AccountTransactionList(

--- a/lib/features/backup/presentation/controllers/backup_controller.g.dart
+++ b/lib/features/backup/presentation/controllers/backup_controller.g.dart
@@ -38,7 +38,7 @@ final class BackupControllerProvider extends $AsyncNotifierProvider<BackupContro
   BackupController create() => BackupController();
 }
 
-String _$backupControllerHash() => r'6913eb310c6af521c352a7dd1be6fcc3b5c4ae9e';
+String _$backupControllerHash() => r'c33ac93a240f945063edff8f10898d1dd7eb6cb8';
 
 /// Controller managing the execution of encrypted backup and restore operations,
 /// updating its async state and invoking system share sheets.

--- a/lib/features/budgets/presentation/screens/budget_detail_page.dart
+++ b/lib/features/budgets/presentation/screens/budget_detail_page.dart
@@ -164,9 +164,10 @@ class BudgetDetailPage extends ConsumerWidget {
             data: (transactions) {
               if (transactions.isEmpty) {
                 return SliverToBoxAdapter(
-                  child: PokaEmptyViewCentered(
+                  child: PokaEmptyView(
                     icon: FPhosphorIcons.receipt,
                     title: t.budgets.noTransactionsFoundForThisBudgetPeriod,
+                    subtitle: t.budgets.budgetTransactionsSubtitle,
                   ),
                 );
               }

--- a/lib/features/categories/presentation/screens/category_detail_page.dart
+++ b/lib/features/categories/presentation/screens/category_detail_page.dart
@@ -90,7 +90,6 @@ class CategoryDetailPage extends ConsumerWidget {
                   title: t.categories.noSubcategoriesYet,
                   subtitle: t.categories.emptySubcategorySubtitle,
                   actionLabel: t.categories.addSubcategory,
-                  hasBorder: true,
                   onAction: () => CategoryFormSheet.show(
                     context,
                     parentId: activeCategory.id,

--- a/lib/features/dashboard/domain/services/dashboard_analytics_service.dart
+++ b/lib/features/dashboard/domain/services/dashboard_analytics_service.dart
@@ -23,6 +23,9 @@ class DashboardAnalyticsService {
   DashboardAnalyticsService._();
 
   /// Calculates global net worth, total positive assets, and liabilities across all active accounts.
+  ///
+  /// Note that `activeAccountCount` only counts top-level primary accounts (excluding pockets
+  /// and virtual goal accounts), while monetary totals include all active accounts and sub-accounts.
   static ({
     double netWorth,
     double totalAssets,
@@ -37,7 +40,9 @@ class DashboardAnalyticsService {
 
     for (final account in accounts) {
       if (account.isActive) {
-        activeAccountCount++;
+        if (!account.isPocket && account.type != AccountType.goal) {
+          activeAccountCount++;
+        }
         netWorth += account.balance;
         if (account.balance > 0) {
           totalAssets += account.balance;

--- a/lib/features/dashboard/presentation/widgets/sections/dashboard_recent_transactions.dart
+++ b/lib/features/dashboard/presentation/widgets/sections/dashboard_recent_transactions.dart
@@ -57,7 +57,7 @@ class DashboardRecentTransactions extends ConsumerWidget {
           PokaEmptyView(
             icon: FPhosphorIcons.receipt,
             title: context.t.dashboard.noRecentTransactions,
-            hasBorder: true,
+            subtitle: context.t.dashboard.recentTransactionsSubtitle,
           ).animate().fade(duration: 300.ms).slideY(begin: 0.05, end: 0)
         else
           _buildFlatTransactions(

--- a/lib/features/debts/presentation/controllers/debt_detail_notifier.g.dart
+++ b/lib/features/debts/presentation/controllers/debt_detail_notifier.g.dart
@@ -122,7 +122,7 @@ final class DebtDetailNotifierProvider extends $NotifierProvider<DebtDetailNotif
   }
 }
 
-String _$debtDetailNotifierHash() => r'e746cd7de6ab99f0151ba0b0403b6b1e64d6f500';
+String _$debtDetailNotifierHash() => r'659b0a30a395656fd331304a41b472409aa7e062';
 
 /// Notifier handling detail-level actions on debts including deletion and forgiveness write-offs.
 

--- a/lib/features/debts/presentation/screens/debt_detail_page.dart
+++ b/lib/features/debts/presentation/screens/debt_detail_page.dart
@@ -123,9 +123,12 @@ class DebtDetailPage extends ConsumerWidget {
             data: (transactions) {
               if (transactions.isEmpty) {
                 return SliverToBoxAdapter(
-                  child: PokaEmptyViewCentered(
+                  child: PokaEmptyView(
                     icon: FPhosphorIcons.receipt,
                     title: t.debts.noHistoryFoundForThis(type: isPayable ? t.debts.payable : t.debts.receivable),
+                    subtitle: t.debts.repaymentHistorySubtitle(
+                      type: isPayable ? t.debts.payable.toLowerCase() : t.debts.receivable.toLowerCase(),
+                    ),
                   ),
                 );
               }

--- a/lib/features/debts/presentation/widgets/debt_repayment_sheet.dart
+++ b/lib/features/debts/presentation/widgets/debt_repayment_sheet.dart
@@ -7,6 +7,7 @@ import 'package:poka_ce/features/accounts/presentation/widgets/pickers/account_s
 import 'package:poka_ce/features/dashboard/presentation/controllers/dashboard_notifier.dart';
 import 'package:poka_ce/features/debts/domain/debt_model.dart';
 import 'package:poka_ce/features/debts/presentation/controllers/debt_repayment_notifier.dart';
+import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/calculator/transaction_amount_display.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/calculator/transaction_calculator_numpad.dart';
 import 'package:poka_ce/features/transactions/presentation/widgets/forms/components/transaction_date_nav.dart';
@@ -41,6 +42,8 @@ class DebtRepaymentSheet extends HookConsumerWidget {
     final accounts = ref.watch(dashboardProvider).accounts;
     final state = ref.watch(debtRepaymentProvider);
     final notifier = ref.read(debtRepaymentProvider.notifier);
+    final settings = ref.watch(settingsProvider).settings;
+    final currencyCode = settings?.baseCurrency?.symbol;
 
     useEffect(() {
       if (accounts.isNotEmpty && state.accountId == null) {
@@ -53,6 +56,8 @@ class DebtRepaymentSheet extends HookConsumerWidget {
     // For loan (we lent), repayment means money comes IN (Income).
     final isPayable = debt.type == DebtType.debt;
     final typeColor = isPayable ? theme.colors.app.expense : theme.colors.app.income;
+    final currentAmount = int.tryParse(state.amountExpression) ?? 0;
+    final isFullAmount = currentAmount == debt.remainingAmount && debt.remainingAmount > 0;
 
     Future<void> handleSave() async {
       final amount = int.tryParse(state.amountExpression) ?? 0;
@@ -127,7 +132,7 @@ class DebtRepaymentSheet extends HookConsumerWidget {
                         child: FButton(
                           onPress: () => Navigator.of(ctx).pop(),
                           variant: FButtonVariant.outline,
-                          child: Text(t.transactions.cancel),
+                          child: Text(t.debts.cancel),
                         ),
                       ),
                       const SizedBox(width: 12),
@@ -137,7 +142,7 @@ class DebtRepaymentSheet extends HookConsumerWidget {
                             notifier.setNote(controller.text.trim());
                             Navigator.of(ctx).pop();
                           },
-                          child: Text(t.transactions.save),
+                          child: Text(t.debts.save),
                         ),
                       ),
                     ],
@@ -183,48 +188,31 @@ class DebtRepaymentSheet extends HookConsumerWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 14),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const SizedBox(),
-                  if (debt.remainingAmount > 0)
-                    FButton(
-                      variant: FButtonVariant.outline,
-                      onPress: () {
-                        HapticFeedback.lightImpact();
-                        notifier
-                          ..setAmountExpression(debt.remainingAmount.toString())
-                          ..setHistoryExpression(null);
-                      },
-                      child: Text(
-                        t.debts.payInFull,
-                        style: theme.typography.bodyPrimary.copyWith(color: typeColor),
-                      ),
-                    ),
-                ],
-              ),
               TransactionAmountDisplay(
                 amountExpression: state.amountExpression,
                 historyExpression: state.historyExpression,
+                currencyCode: currencyCode,
               ),
-              const SizedBox(height: 14),
-              if (state.note.isNotEmpty)
-                GestureDetector(
-                  onTap: showNoteEditor,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                    margin: const EdgeInsets.only(bottom: 12),
-                    decoration: BoxDecoration(
-                      color: theme.colors.muted,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Text(
-                      state.note,
-                      style: theme.typography.bodyPrimary,
-                    ),
-                  ),
-                ),
+              _DebtRepaymentMetaBar(
+                note: state.note,
+                isFullAmount: isFullAmount,
+                typeColor: typeColor,
+                remainingAmount: debt.remainingAmount,
+                onPickNote: showNoteEditor,
+                onPayInFull: () {
+                  HapticFeedback.selectionClick();
+                  if (isFullAmount) {
+                    notifier
+                      ..setAmountExpression('0')
+                      ..setHistoryExpression(null);
+                  } else {
+                    notifier
+                      ..setAmountExpression(debt.remainingAmount.toString())
+                      ..setHistoryExpression(null);
+                  }
+                },
+              ),
+              const SizedBox(height: 6),
               if (state.isSaving)
                 const Padding(
                   padding: EdgeInsets.symmetric(vertical: 32),
@@ -247,6 +235,106 @@ class DebtRepaymentSheet extends HookConsumerWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Meta bar component rendering note trigger and quick "Pay in Full" action.
+class _DebtRepaymentMetaBar extends StatelessWidget {
+  const _DebtRepaymentMetaBar({
+    required this.note,
+    required this.isFullAmount,
+    required this.typeColor,
+    required this.remainingAmount,
+    required this.onPickNote,
+    required this.onPayInFull,
+  });
+
+  final String note;
+  final bool isFullAmount;
+  final Color typeColor;
+  final int remainingAmount;
+  final VoidCallback onPickNote;
+  final VoidCallback onPayInFull;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 2, bottom: 6),
+      child: SizedBox(
+        height: 32,
+        child: Row(
+          children: [
+            // Note Section
+            Expanded(
+              child: GestureDetector(
+                onTap: onPickNote,
+                behavior: HitTestBehavior.opaque,
+                child: Row(
+                  children: [
+                    Icon(
+                      FPhosphorIcons.notePencil,
+                      size: 18,
+                      color: note.isEmpty ? theme.colors.mutedForeground : theme.colors.foreground,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        note.isEmpty ? t.transactions.addNoteEllipsis : note,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.typography.bodyPrimary.copyWith(
+                          color: note.isEmpty ? theme.colors.mutedForeground : theme.colors.foreground,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (remainingAmount > 0) ...[
+              const SizedBox(width: 8),
+              GestureDetector(
+                onTap: onPayInFull,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: isFullAmount ? typeColor.withValues(alpha: 0.15) : theme.colors.background,
+                    borderRadius: theme.style.borderRadius.lg,
+                    border: Border.all(
+                      color: isFullAmount ? typeColor.withValues(alpha: 0.5) : theme.colors.border,
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        FPhosphorIcons.lightning,
+                        size: 16,
+                        color: isFullAmount ? typeColor : theme.colors.mutedForeground,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        t.debts.payInFull,
+                        style: theme.typography.bodySecondary.copyWith(
+                          color: isFullAmount ? typeColor : theme.colors.mutedForeground,
+                          fontWeight: isFullAmount ? FontWeight.w600 : FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/goals/presentation/screens/goal_detail_page.dart
+++ b/lib/features/goals/presentation/screens/goal_detail_page.dart
@@ -115,9 +115,10 @@ class GoalDetailPage extends ConsumerWidget {
             data: (transactions) {
               if (transactions.isEmpty) {
                 return SliverToBoxAdapter(
-                  child: PokaEmptyViewCentered(
+                  child: PokaEmptyView(
                     icon: FPhosphorIcons.receipt,
                     title: t.goals.noTransactionsFoundForThisGoal,
+                    subtitle: t.goals.goalTransactionsSubtitle,
                   ),
                 );
               }

--- a/lib/features/goals/presentation/screens/goal_list_page.dart
+++ b/lib/features/goals/presentation/screens/goal_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/features/goals/presentation/controllers/goal_list_view_notifier.dart';
 import 'package:poka_ce/features/goals/presentation/controllers/goal_notifier.dart';
@@ -16,14 +15,11 @@ import 'package:poka_ce/theme/theme.dart';
 /// Goal list page — displays all user savings goals with progress.
 /// Each goal is linked to a dedicated Pocket account whose balance reflects
 /// the amount saved so far (per PLANS.md §5).
-class GoalListPage extends HookConsumerWidget {
+class GoalListPage extends ConsumerWidget {
   const GoalListPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // 0 = active, 1 = past
-    final filterIndex = useState(0);
-
     final goalStates = ref.watch(goalListStatesProvider);
     final asyncGoals = ref.watch(goalProvider);
 
@@ -31,21 +27,6 @@ class GoalListPage extends HookConsumerWidget {
       header: PokaHeader(
         title: context.t.dashboard.goals,
         showBack: true,
-        suffixes: [
-          // Filter toggle: Active / Past
-          _GoalFilterChip(
-            label: t.goals.active,
-            isSelected: filterIndex.value == 0,
-            onTap: () => filterIndex.value = 0,
-          ),
-          const SizedBox(width: 6),
-          _GoalFilterChip(
-            label: t.goals.past,
-            isSelected: filterIndex.value == 1,
-            onTap: () => filterIndex.value = 1,
-          ),
-          const SizedBox(width: 4),
-        ],
       ),
       child: asyncGoals.when(
         data: (_) {
@@ -61,7 +42,7 @@ class GoalListPage extends HookConsumerWidget {
               ),
             );
           }
-          return _GoalContent(filterIndex: filterIndex.value);
+          return const _GoalContent();
         },
         loading: () => const Center(child: FCircularProgress()),
         error: (error, _) => Center(child: Text(t.goals.errorPrefix(error: error.toString()))),
@@ -71,59 +52,18 @@ class GoalListPage extends HookConsumerWidget {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Filter chip for header
-// ─────────────────────────────────────────────────────────────────────────────
-
-class _GoalFilterChip extends StatelessWidget {
-  const _GoalFilterChip({
-    required this.label,
-    required this.isSelected,
-    required this.onTap,
-  });
-
-  final String label;
-  final bool isSelected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = context.theme;
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 180),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-        decoration: BoxDecoration(
-          color: isSelected ? theme.colors.primary : theme.colors.muted,
-          borderRadius: theme.style.borderRadius.sm,
-        ),
-        child: Text(
-          label,
-          style: theme.typography.labelField.copyWith(
-            color: isSelected ? theme.colors.primaryForeground : theme.colors.mutedForeground,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Main content: summary card + goal list
+// Main content: summary card + active goals + completed goals
 // ─────────────────────────────────────────────────────────────────────────────
 
 class _GoalContent extends ConsumerWidget {
-  const _GoalContent({required this.filterIndex});
-
-  final int filterIndex;
+  const _GoalContent();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final viewState = ref.watch(goalListViewProvider);
     final activeGoals = viewState.activeGoals;
     final pastGoals = viewState.pastGoals;
-    final displayedGoals = filterIndex == 0 ? activeGoals : pastGoals;
+    final hasPastGoals = pastGoals.isNotEmpty;
 
     return SingleChildScrollView(
       physics: const AlwaysScrollableScrollPhysics(),
@@ -133,10 +73,14 @@ class _GoalContent extends ConsumerWidget {
         children: [
           GoalSummaryCard(totalGoals: activeGoals.length).animate().fade(duration: 300.ms).slideY(begin: 0.05, end: 0),
           const SizedBox(height: 20),
+
+          // ── Active Goals Section ──────────────────────────────────────────
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              PokaSectionLabel(title: context.t.dashboard.goals),
+              PokaSectionLabel(
+                title: hasPastGoals ? t.goals.activeGoals : context.t.dashboard.goals,
+              ),
               Builder(
                 builder: (context) => GestureDetector(
                   key: const Key('goal-add-button'),
@@ -160,41 +104,64 @@ class _GoalContent extends ConsumerWidget {
             ],
           ).animate().fade(duration: 300.ms, delay: 80.ms).slideY(begin: 0.05, end: 0),
           const SizedBox(height: 8),
-          if (displayedGoals.isEmpty)
+
+          if (activeGoals.isEmpty)
             Builder(
-              builder: (context) => filterIndex == 0
-                  ? PokaEmptyView(
-                      icon: FPhosphorIcons.piggyBank,
-                      title: t.goals.noGoalsYet,
-                      subtitle: t.goals.setSavingsTargetsADedicatedPocketIsCreatedAutomaticallyForEachGoal,
-                      actionLabel: t.goals.createGoal,
-                      actionKey: const Key('goal-add-button'),
-                      onAction: () => GoalFormSheet.show(context),
-                    )
-                  : PokaEmptyView(
-                      icon: FPhosphorIcons.checkCircle,
-                      title: t.goals.noCompletedGoalsYet,
-                      subtitle: t.goals.completedGoalsWillAppearHere,
-                    ),
+              builder: (context) => PokaEmptyView(
+                icon: FPhosphorIcons.piggyBank,
+                title: t.goals.noActiveGoalsYet,
+                subtitle: t.goals.noActiveGoalsSubtitle,
+                actionLabel: t.goals.createGoal,
+                actionKey: const Key('goal-add-button'),
+                onAction: () => GoalFormSheet.show(context),
+                hasBorder: hasPastGoals,
+              ),
             ).animate().fade(duration: 300.ms, delay: 120.ms)
           else
             Padding(
-              padding: const EdgeInsets.only(bottom: 20),
+              padding: EdgeInsets.only(bottom: hasPastGoals ? 0 : 20),
               child: ListView.separated(
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 padding: EdgeInsets.zero,
-                itemCount: displayedGoals.length,
+                itemCount: activeGoals.length,
                 separatorBuilder: (_, _) => const SizedBox(height: 10),
                 itemBuilder: (context, index) {
                   final delay = (80 + index * 50).clamp(0, 320);
-                  return GoalCard(state: displayedGoals[index])
+                  return GoalCard(state: activeGoals[index])
                       .animate()
                       .fade(duration: 280.ms, delay: delay.ms)
                       .slideY(begin: 0.05, end: 0, duration: 280.ms, delay: delay.ms);
                 },
               ),
             ),
+
+          // ── Completed / Past Goals Section ────────────────────────────────
+          if (hasPastGoals) ...[
+            const SizedBox(height: 20),
+            PokaSectionLabel(title: t.goals.completedGoals)
+                .animate()
+                .fade(duration: 300.ms, delay: 80.ms)
+                .slideY(begin: 0.05, end: 0),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 20),
+              child: ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                padding: EdgeInsets.zero,
+                itemCount: pastGoals.length,
+                separatorBuilder: (_, _) => const SizedBox(height: 10),
+                itemBuilder: (context, index) {
+                  final delay = (80 + index * 50).clamp(0, 320);
+                  return GoalCard(state: pastGoals[index])
+                      .animate()
+                      .fade(duration: 280.ms, delay: delay.ms)
+                      .slideY(begin: 0.05, end: 0, duration: 280.ms, delay: delay.ms);
+                },
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/features/recurring/presentation/controllers/recurring_list_notifier.dart
+++ b/lib/features/recurring/presentation/controllers/recurring_list_notifier.dart
@@ -18,7 +18,7 @@ abstract class RecurringListState with _$RecurringListState {
 }
 
 /// Notifier managing recurring transaction schedules, deletion, and pause/resume toggling.
-@riverpod
+@Riverpod(keepAlive: true)
 class RecurringListNotifier extends _$RecurringListNotifier {
   @override
   RecurringListState build() {
@@ -28,10 +28,12 @@ class RecurringListNotifier extends _$RecurringListNotifier {
 
   /// Reloads all recurring transactions from the repository.
   Future<void> refresh() async {
+    if (!ref.mounted) return;
     state = state.copyWith(isLoading: true);
 
     final repo = ref.read(recurringRepositoryProvider);
     final result = await repo.getRecurringTransactions();
+    if (!ref.mounted) return;
 
     result.fold(
       (recurrings) {
@@ -51,8 +53,10 @@ class RecurringListNotifier extends _$RecurringListNotifier {
 
   /// Permanently removes a recurring transaction schedule by [id].
   Future<void> deleteRecurring(String id) async {
+    if (!ref.mounted) return;
     final repo = ref.read(recurringRepositoryProvider);
     final result = await repo.deleteRecurring(id);
+    if (!ref.mounted) return;
     if (result is Success) {
       await refresh();
     }
@@ -60,6 +64,7 @@ class RecurringListNotifier extends _$RecurringListNotifier {
 
   /// Toggles whether this recurring schedule is active or paused.
   Future<void> toggleActive(String id) async {
+    if (!ref.mounted) return;
     final index = state.recurrings.indexWhere((r) => r.id == id);
     if (index == -1) return;
 
@@ -72,6 +77,7 @@ class RecurringListNotifier extends _$RecurringListNotifier {
 
     final repo = ref.read(recurringRepositoryProvider);
     final result = await repo.updateRecurring(updated);
+    if (!ref.mounted) return;
     if (result is ErrorResult) {
       // Roll back to server state on persistence failure.
       await refresh();

--- a/lib/features/recurring/presentation/controllers/recurring_list_notifier.g.dart
+++ b/lib/features/recurring/presentation/controllers/recurring_list_notifier.g.dart
@@ -22,7 +22,7 @@ final class RecurringListNotifierProvider extends $NotifierProvider<RecurringLis
         argument: null,
         retry: null,
         name: r'recurringListProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -43,7 +43,7 @@ final class RecurringListNotifierProvider extends $NotifierProvider<RecurringLis
   }
 }
 
-String _$recurringListNotifierHash() => r'03eb65b234863f5ab79499257717d7f2f810b084';
+String _$recurringListNotifierHash() => r'6fdaf42eb6b2baf8104e97a4b7c9a81ada42d012';
 
 /// Notifier managing recurring transaction schedules, deletion, and pause/resume toggling.
 

--- a/lib/features/recurring/presentation/controllers/recurring_runner_notifier.dart
+++ b/lib/features/recurring/presentation/controllers/recurring_runner_notifier.dart
@@ -51,12 +51,14 @@ class RecurringRunnerNotifier extends Notifier<RecurringRunnerState> {
 
     final today = DateTime.now();
     final result = await service.run(today);
+    if (!ref.mounted) return;
 
     switch (result) {
       case Success(:final value) when value > 0:
         talker.info('RecurringRunner: processed $value recurring transaction(s).');
         // Refresh list so UI reflects newly created entries.
         await ref.read(recurringListProvider.notifier).refresh();
+        if (!ref.mounted) return;
         state = RecurringRunnerDone(value);
       case Success():
         state = const RecurringRunnerDone(0);

--- a/lib/features/recurring/presentation/screens/recurring_detail_page.dart
+++ b/lib/features/recurring/presentation/screens/recurring_detail_page.dart
@@ -111,9 +111,10 @@ class RecurringDetailPage extends ConsumerWidget {
             data: (transactions) {
               if (transactions.isEmpty) {
                 return SliverToBoxAdapter(
-                  child: PokaEmptyViewCentered(
+                  child: PokaEmptyView(
                     icon: FPhosphorIcons.receipt,
                     title: t.recurring.noHistoryFoundForThisSchedule,
+                    subtitle: t.recurring.scheduleHistorySubtitle,
                   ),
                 );
               }

--- a/lib/features/reports/presentation/widgets/report_spending_allocation.dart
+++ b/lib/features/reports/presentation/widgets/report_spending_allocation.dart
@@ -30,7 +30,7 @@ class ReportSpendingAllocation extends ConsumerWidget {
       return PokaEmptyView(
         icon: FPhosphorIcons.chartPieSlice,
         title: t.noData,
-        hasBorder: true,
+        subtitle: t.noExpenseDataDesc,
       );
     }
 

--- a/lib/features/settings/presentation/controllers/settings_notifier.g.dart
+++ b/lib/features/settings/presentation/controllers/settings_notifier.g.dart
@@ -43,9 +43,7 @@ final class SettingsNotifierProvider extends $NotifierProvider<SettingsNotifier,
   }
 }
 
-String _$settingsNotifierHash() => r'9668502654e3c0029a681373cccf6d198cb49a1c';
-
-/// Notifier coordinating user preferences (theme, language, number format, base currency).
+String _$settingsNotifierHash() => r'f0774daf1253be2132b5a62e898739a52cf6eb2c';
 
 /// Notifier coordinating user preferences (theme, language, number format, base currency).
 

--- a/lib/features/settings/presentation/screens/about_page.dart
+++ b/lib/features/settings/presentation/screens/about_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:poka_ce/app/router/router.dart';
+import 'package:poka_ce/core/config.dart';
 import 'package:poka_ce/core/utils/log_exporter.dart';
 import 'package:poka_ce/core/utils/logger.dart';
 import 'package:poka_ce/features/settings/presentation/widgets/easter_egg_icon.dart';
@@ -74,10 +75,16 @@ class AboutPage extends StatelessWidget {
                   title: t.settings.support,
                   items: [
                     SettingsMenuItem(
+                      title: t.settings.checkForUpdates,
+                      subtitle: t.settings.viewLatestReleasesOnGithub,
+                      icon: FPhosphorIcons.downloadSimple,
+                      onTap: () => _launchUrl('${AppConfig.githubRepoUrl}/releases/latest'),
+                    ),
+                    SettingsMenuItem(
                       title: t.settings.helpIssues,
                       subtitle: t.settings.reportBugsOrRequestFeatures,
                       icon: FPhosphorIcons.question,
-                      onTap: () => _launchUrl('https://github.com/getpoka/poka-ce/issues'),
+                      onTap: () => _launchUrl('${AppConfig.githubRepoUrl}/issues'),
                     ),
                   ],
                 ),

--- a/lib/i18n/en/accounts.i18n.json
+++ b/lib/i18n/en/accounts.i18n.json
@@ -30,6 +30,8 @@
   "permanentlyRemoveThisAccount": "Permanently remove this account",
   "seeAll": "See All",
   "noTransactionsYet": "No transactions yet",
+  "accountTransactionsSubtitle": "Transactions recorded in this account will appear here.",
+  "pocketTransactionsSubtitle": "Transactions recorded in this pocket will appear here.",
   "addAccount": "Add Account",
   "noAccountsFound": "No accounts found.",
   "addPocket": "Add Pocket",

--- a/lib/i18n/en/budgets.i18n.json
+++ b/lib/i18n/en/budgets.i18n.json
@@ -22,6 +22,7 @@
   "totalLimit": "Total limit",
   "selectEndDate": "Select end date",
   "noTransactionsFoundForThisBudgetPeriod": "No transactions found for this budget period.",
+  "budgetTransactionsSubtitle": "Transactions matching this budget will appear here.",
   "addBudget": "Add Budget",
   "spent": "Spent ",
   "noBudgetsYet": "No budgets yet",

--- a/lib/i18n/en/dashboard.i18n.json
+++ b/lib/i18n/en/dashboard.i18n.json
@@ -34,6 +34,7 @@
   "recentTransactions": "Recent Transactions",
   "thisMonth": "This month",
   "noRecentTransactions": "No recent transactions",
+  "recentTransactionsSubtitle": "Transactions you recently record will appear here.",
   "seeAll": "See All",
   "notSet": "Not set",
   "insight": {

--- a/lib/i18n/en/debts.i18n.json
+++ b/lib/i18n/en/debts.i18n.json
@@ -35,6 +35,7 @@
   "reminder": "Reminder {{type}}: {{name}}",
   "due": "{{type}} Due: {{name}}",
   "noHistoryFoundForThis": "No history found for this {{type}}",
+  "repaymentHistorySubtitle": "Payment or installment records for this {{type}} will appear here.",
   "failedToLoadDebts": "Failed to load debts: {{error}}",
   "percentOf": "{{percent}}% of ",
   "settled": "{{count}} settled",

--- a/lib/i18n/en/goals.i18n.json
+++ b/lib/i18n/en/goals.i18n.json
@@ -23,6 +23,7 @@
   "totalTarget": "Total target",
   "selectTargetDate": "Select target date",
   "noTransactionsFoundForThisGoal": "No transactions found for this goal.",
+  "goalTransactionsSubtitle": "Transfers or savings recorded for this goal will appear here.",
   "addGoal": "Add Goal",
   "aDedicatedPocketAccountWillBeCreatedAutomaticallyToTrackThisGoal": "A dedicated Pocket account will be created automatically to track this goal.",
   "saved": "saved",

--- a/lib/i18n/en/goals.i18n.json
+++ b/lib/i18n/en/goals.i18n.json
@@ -41,5 +41,9 @@
   "nameCannotBeEmpty": "Name cannot be empty",
   "targetAmountGreaterThanZero": "Target amount must be greater than 0",
   "saveChanges": "Save Changes",
-  "targetDateLabel": "Target Date"
+  "targetDateLabel": "Target Date",
+  "activeGoals": "Active Goals",
+  "completedGoals": "Completed Goals",
+  "noActiveGoalsYet": "No active goals",
+  "noActiveGoalsSubtitle": "Create a new goal to start saving for your next milestone."
 }

--- a/lib/i18n/en/recurring.i18n.json
+++ b/lib/i18n/en/recurring.i18n.json
@@ -21,6 +21,7 @@
   "noRecurringTransactions": "No recurring transactions",
   "automateBillsLikeSubscriptionsOrSalary": "Automate bills like subscriptions or salary. The app will record them on schedule.",
   "noHistoryFoundForThisSchedule": "No history found for this schedule.",
+  "scheduleHistorySubtitle": "Transactions generated from this schedule will appear here.",
   "allocation": "Allocation",
   "active": "Active",
   "eachTimeTheAppOpensOverdueRecurringTransactionsAre": "Each time the app opens, overdue recurring transactions are automatically recorded in your ledger.",

--- a/lib/i18n/en/reports.i18n.json
+++ b/lib/i18n/en/reports.i18n.json
@@ -24,6 +24,7 @@
   "budgetUtilization": "Budget Utilization",
   "spendingAllocation": "Spending Allocation",
   "noData": "No data for this period",
+  "noExpenseDataDesc": "Record expense transactions to see your spending allocation.",
   "noBudgets": "No budgets configured",
   "noBudgetsDesc": "Add budgets to track your spending limits",
   "onTrack": "On track",

--- a/lib/i18n/en/settings.i18n.json
+++ b/lib/i18n/en/settings.i18n.json
@@ -41,6 +41,8 @@
   "easterEggFound": "\ud83c\udf89 You found the easter egg!",
   "selectCurrency": "Select Currency",
   "openSourceLicenses": "Open Source Licenses",
+  "checkForUpdates": "Check for Updates",
+  "viewLatestReleasesOnGithub": "View latest releases on GitHub",
   "helpIssues": "Help & Issues",
   "reportBugsOrRequestFeatures": "Report bugs or request features",
   "legal": "Legal",

--- a/lib/i18n/id/accounts.i18n.json
+++ b/lib/i18n/id/accounts.i18n.json
@@ -30,6 +30,8 @@
   "permanentlyRemoveThisAccount": "Hapus permanen akun ini",
   "seeAll": "Lihat Semua",
   "noTransactionsYet": "Belum ada transaksi",
+  "accountTransactionsSubtitle": "Transaksi yang dicatat di akun ini akan muncul di sini.",
+  "pocketTransactionsSubtitle": "Transaksi yang dicatat di kantong ini akan muncul di sini.",
   "addAccount": "Tambah Akun",
   "noAccountsFound": "Akun tidak ditemukan.",
   "addPocket": "Tambah Kantong",

--- a/lib/i18n/id/budgets.i18n.json
+++ b/lib/i18n/id/budgets.i18n.json
@@ -22,6 +22,7 @@
   "totalLimit": "Total batas",
   "selectEndDate": "Pilih tanggal berakhir",
   "noTransactionsFoundForThisBudgetPeriod": "Tidak ada transaksi yang ditemukan untuk periode anggaran ini.",
+  "budgetTransactionsSubtitle": "Transaksi yang terkait dengan anggaran ini akan muncul di sini.",
   "addBudget": "Tambah Anggaran",
   "spent": "Terpakai ",
   "noBudgetsYet": "Belum ada anggaran",

--- a/lib/i18n/id/dashboard.i18n.json
+++ b/lib/i18n/id/dashboard.i18n.json
@@ -34,6 +34,7 @@
   "recentTransactions": "Transaksi Terakhir",
   "thisMonth": "Bulan ini",
   "noRecentTransactions": "Tidak ada transaksi baru",
+  "recentTransactionsSubtitle": "Transaksi yang baru saja Anda catat akan muncul di sini.",
   "seeAll": "Lihat Semua",
   "notSet": "Belum diatur",
   "insight": {

--- a/lib/i18n/id/debts.i18n.json
+++ b/lib/i18n/id/debts.i18n.json
@@ -35,6 +35,7 @@
   "reminder": "Pengingat {{type}}: {{name}}",
   "due": "{{type}} Jatuh Tempo: {{name}}",
   "noHistoryFoundForThis": "Tidak ada riwayat untuk {{type}} ini",
+  "repaymentHistorySubtitle": "Catatan pembayaran atau cicilan untuk {{type}} ini akan muncul di sini.",
   "failedToLoadDebts": "Gagal memuat utang: {{error}}",
   "percentOf": "{{percent}}% dari ",
   "settled": "{{count}} diselesaikan",

--- a/lib/i18n/id/goals.i18n.json
+++ b/lib/i18n/id/goals.i18n.json
@@ -41,5 +41,9 @@
   "nameCannotBeEmpty": "Nama tidak boleh kosong",
   "targetAmountGreaterThanZero": "Jumlah target harus lebih besar dari 0",
   "saveChanges": "Simpan Perubahan",
-  "targetDateLabel": "Tanggal Target"
+  "targetDateLabel": "Tanggal Target",
+  "activeGoals": "Target Aktif",
+  "completedGoals": "Target Selesai",
+  "noActiveGoalsYet": "Belum ada target aktif",
+  "noActiveGoalsSubtitle": "Buat target baru untuk mulai menabung impian Anda berikutnya."
 }

--- a/lib/i18n/id/goals.i18n.json
+++ b/lib/i18n/id/goals.i18n.json
@@ -23,6 +23,7 @@
   "totalTarget": "Total target",
   "selectTargetDate": "Pilih tanggal target",
   "noTransactionsFoundForThisGoal": "Tidak ada transaksi yang ditemukan untuk target ini.",
+  "goalTransactionsSubtitle": "Transaksi atau simpanan untuk target ini akan muncul di sini.",
   "addGoal": "Tambah Target",
   "aDedicatedPocketAccountWillBeCreatedAutomaticallyToTrackThisGoal": "Akun Kantong khusus akan dibuat secara otomatis untuk melacak target ini.",
   "saved": "terkumpul",

--- a/lib/i18n/id/recurring.i18n.json
+++ b/lib/i18n/id/recurring.i18n.json
@@ -21,6 +21,7 @@
   "noRecurringTransactions": "Tidak ada transaksi berulang",
   "automateBillsLikeSubscriptionsOrSalary": "Otomatiskan tagihan seperti langganan atau gaji. Aplikasi akan mencatatnya sesuai jadwal.",
   "noHistoryFoundForThisSchedule": "Tidak ada riwayat untuk jadwal ini.",
+  "scheduleHistorySubtitle": "Transaksi yang dibuat dari jadwal ini akan muncul di sini.",
   "allocation": "Alokasi",
   "active": "Aktif",
   "eachTimeTheAppOpensOverdueRecurringTransactionsAre": "Setiap kali aplikasi dibuka, transaksi berulang yang telah lewat jatuh tempo akan otomatis dicatat dalam buku kas Anda.",

--- a/lib/i18n/id/reports.i18n.json
+++ b/lib/i18n/id/reports.i18n.json
@@ -24,6 +24,7 @@
   "budgetUtilization": "Pemanfaatan Anggaran",
   "spendingAllocation": "Alokasi Pengeluaran",
   "noData": "Tidak ada data untuk periode ini",
+  "noExpenseDataDesc": "Catat transaksi pengeluaran untuk melihat pembagian alokasi.",
   "noBudgets": "Belum ada anggaran yang dikonfigurasi",
   "noBudgetsDesc": "Tambahkan anggaran untuk melacak batas pengeluaran Anda",
   "onTrack": "Sesuai rencana",

--- a/lib/i18n/id/settings.i18n.json
+++ b/lib/i18n/id/settings.i18n.json
@@ -41,6 +41,8 @@
   "easterEggFound": "\ud83c\udf89 Anda menemukan easter egg!",
   "selectCurrency": "Pilih Mata Uang",
   "openSourceLicenses": "Lisensi Open Source",
+  "checkForUpdates": "Periksa Pembaruan",
+  "viewLatestReleasesOnGithub": "Lihat rilis terbaru di GitHub",
   "helpIssues": "Bantuan & Masalah",
   "reportBugsOrRequestFeatures": "Laporkan bug atau minta fitur",
   "legal": "Legal",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1273 (636 per locale)
+/// Strings: 1277 (638 per locale)
 ///
-/// Built on 2026-09-10 at 17:46 UTC
+/// Built on 2026-09-10 at 18:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1265 (632 per locale)
+/// Strings: 1273 (636 per locale)
 ///
-/// Built on 2026-09-10 at 17:34 UTC
+/// Built on 2026-09-10 at 17:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1249 (624 per locale)
+/// Strings: 1265 (632 per locale)
 ///
-/// Built on 2026-09-10 at 07:10 UTC
+/// Built on 2026-09-10 at 17:34 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 2
 /// Strings: 1277 (638 per locale)
 ///
-/// Built on 2026-09-10 at 18:46 UTC
+/// Built on 2026-09-10 at 20:09 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -164,6 +164,12 @@ class Translations$accounts$en {
 	/// en: 'No transactions yet'
 	String get noTransactionsYet => 'No transactions yet';
 
+	/// en: 'Transactions recorded in this account will appear here.'
+	String get accountTransactionsSubtitle => 'Transactions recorded in this account will appear here.';
+
+	/// en: 'Transactions recorded in this pocket will appear here.'
+	String get pocketTransactionsSubtitle => 'Transactions recorded in this pocket will appear here.';
+
 	/// en: 'Add Account'
 	String get addAccount => 'Add Account';
 
@@ -423,6 +429,9 @@ class Translations$budgets$en {
 
 	/// en: 'No transactions found for this budget period.'
 	String get noTransactionsFoundForThisBudgetPeriod => 'No transactions found for this budget period.';
+
+	/// en: 'Transactions matching this budget will appear here.'
+	String get budgetTransactionsSubtitle => 'Transactions matching this budget will appear here.';
 
 	/// en: 'Add Budget'
 	String get addBudget => 'Add Budget';
@@ -760,6 +769,9 @@ class Translations$dashboard$en {
 	/// en: 'No recent transactions'
 	String get noRecentTransactions => 'No recent transactions';
 
+	/// en: 'Transactions you recently record will appear here.'
+	String get recentTransactionsSubtitle => 'Transactions you recently record will appear here.';
+
 	/// en: 'See All'
 	String get seeAll => 'See All';
 
@@ -885,6 +897,9 @@ class Translations$debts$en {
 
 	/// en: 'No history found for this {{type}}'
 	String noHistoryFoundForThis({required Object type}) => 'No history found for this ${type}';
+
+	/// en: 'Payment or installment records for this {{type}} will appear here.'
+	String repaymentHistorySubtitle({required Object type}) => 'Payment or installment records for this ${type} will appear here.';
 
 	/// en: 'Failed to load debts: {{error}}'
 	String failedToLoadDebts({required Object error}) => 'Failed to load debts: ${error}';
@@ -1065,6 +1080,9 @@ class Translations$goals$en {
 
 	/// en: 'No transactions found for this goal.'
 	String get noTransactionsFoundForThisGoal => 'No transactions found for this goal.';
+
+	/// en: 'Transfers or savings recorded for this goal will appear here.'
+	String get goalTransactionsSubtitle => 'Transfers or savings recorded for this goal will appear here.';
 
 	/// en: 'Add Goal'
 	String get addGoal => 'Add Goal';
@@ -1273,6 +1291,9 @@ class Translations$recurring$en {
 	/// en: 'No history found for this schedule.'
 	String get noHistoryFoundForThisSchedule => 'No history found for this schedule.';
 
+	/// en: 'Transactions generated from this schedule will appear here.'
+	String get scheduleHistorySubtitle => 'Transactions generated from this schedule will appear here.';
+
 	/// en: 'Allocation'
 	String get allocation => 'Allocation';
 
@@ -1440,6 +1461,9 @@ class Translations$reports$en {
 
 	/// en: 'No data for this period'
 	String get noData => 'No data for this period';
+
+	/// en: 'Record expense transactions to see your spending allocation.'
+	String get noExpenseDataDesc => 'Record expense transactions to see your spending allocation.';
 
 	/// en: 'No budgets configured'
 	String get noBudgets => 'No budgets configured';
@@ -2144,6 +2168,8 @@ extension on Translations {
 			'accounts.permanentlyRemoveThisAccount' => 'Permanently remove this account',
 			'accounts.seeAll' => 'See All',
 			'accounts.noTransactionsYet' => 'No transactions yet',
+			'accounts.accountTransactionsSubtitle' => 'Transactions recorded in this account will appear here.',
+			'accounts.pocketTransactionsSubtitle' => 'Transactions recorded in this pocket will appear here.',
 			'accounts.addAccount' => 'Add Account',
 			'accounts.noAccountsFound' => 'No accounts found.',
 			'accounts.addPocket' => 'Add Pocket',
@@ -2225,6 +2251,7 @@ extension on Translations {
 			'budgets.totalLimit' => 'Total limit',
 			'budgets.selectEndDate' => 'Select end date',
 			'budgets.noTransactionsFoundForThisBudgetPeriod' => 'No transactions found for this budget period.',
+			'budgets.budgetTransactionsSubtitle' => 'Transactions matching this budget will appear here.',
 			'budgets.addBudget' => 'Add Budget',
 			'budgets.spent' => 'Spent ',
 			'budgets.noBudgetsYet' => 'No budgets yet',
@@ -2328,6 +2355,7 @@ extension on Translations {
 			'dashboard.recentTransactions' => 'Recent Transactions',
 			'dashboard.thisMonth' => 'This month',
 			'dashboard.noRecentTransactions' => 'No recent transactions',
+			'dashboard.recentTransactionsSubtitle' => 'Transactions you recently record will appear here.',
 			'dashboard.seeAll' => 'See All',
 			'dashboard.notSet' => 'Not set',
 			'dashboard.insight.noData' => 'No data this month to analyze.',
@@ -2379,6 +2407,7 @@ extension on Translations {
 			'debts.reminder' => ({required Object type, required Object name}) => 'Reminder ${type}: ${name}',
 			'debts.due' => ({required Object type, required Object name}) => '${type} Due: ${name}',
 			'debts.noHistoryFoundForThis' => ({required Object type}) => 'No history found for this ${type}',
+			'debts.repaymentHistorySubtitle' => ({required Object type}) => 'Payment or installment records for this ${type} will appear here.',
 			'debts.failedToLoadDebts' => ({required Object error}) => 'Failed to load debts: ${error}',
 			'debts.percentOf' => ({required Object percent}) => '${percent}% of ',
 			'debts.settled' => ({required Object count}) => '${count} settled',
@@ -2439,6 +2468,7 @@ extension on Translations {
 			'goals.totalTarget' => 'Total target',
 			'goals.selectTargetDate' => 'Select target date',
 			'goals.noTransactionsFoundForThisGoal' => 'No transactions found for this goal.',
+			'goals.goalTransactionsSubtitle' => 'Transfers or savings recorded for this goal will appear here.',
 			'goals.addGoal' => 'Add Goal',
 			'goals.aDedicatedPocketAccountWillBeCreatedAutomaticallyToTrackThisGoal' => 'A dedicated Pocket account will be created automatically to track this goal.',
 			'goals.saved' => 'saved',
@@ -2499,6 +2529,7 @@ extension on Translations {
 			'recurring.noRecurringTransactions' => 'No recurring transactions',
 			'recurring.automateBillsLikeSubscriptionsOrSalary' => 'Automate bills like subscriptions or salary. The app will record them on schedule.',
 			'recurring.noHistoryFoundForThisSchedule' => 'No history found for this schedule.',
+			'recurring.scheduleHistorySubtitle' => 'Transactions generated from this schedule will appear here.',
 			'recurring.allocation' => 'Allocation',
 			'recurring.active' => 'Active',
 			'recurring.eachTimeTheAppOpensOverdueRecurringTransactionsAre' => 'Each time the app opens, overdue recurring transactions are automatically recorded in your ledger.',
@@ -2552,6 +2583,7 @@ extension on Translations {
 			'reports.budgetUtilization' => 'Budget Utilization',
 			'reports.spendingAllocation' => 'Spending Allocation',
 			'reports.noData' => 'No data for this period',
+			'reports.noExpenseDataDesc' => 'Record expense transactions to see your spending allocation.',
 			'reports.noBudgets' => 'No budgets configured',
 			'reports.noBudgetsDesc' => 'Add budgets to track your spending limits',
 			'reports.onTrack' => 'On track',
@@ -2617,6 +2649,8 @@ extension on Translations {
 			'settings.resetDataDesc' => 'Erase all app data locally',
 			'settings.support' => 'Support',
 			'settings.faq' => 'FAQ',
+			_ => null,
+		} ?? switch (path) {
 			'settings.faqDesc' => 'Frequently Asked Questions',
 			'settings.about' => 'About Poka CE',
 			'settings.aboutDesc' => 'Version and legal information',
@@ -2625,8 +2659,6 @@ extension on Translations {
 			'settings.themeDark' => 'Dark',
 			'settings.selectLanguage' => 'Select Language',
 			'settings.oldTransactionsCleared' => 'Old transactions cleared successfully',
-			_ => null,
-		} ?? switch (path) {
 			'settings.appDataReset' => 'App data reset successfully',
 			'settings.failedToExportLogs' => 'Failed to export logs',
 			'settings.easterEggRemaining' => ({required Object remaining}) => '${remaining} taps away from a surprise...',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -20,21 +20,20 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	/// Constructing via the enum [AppLocale.build] is preferred.
 	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
 		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
-		  _meta = meta ?? TranslationMetadata(
+		  $meta = meta ?? TranslationMetadata(
 		    locale: AppLocale.en,
 		    overrides: overrides ?? {},
 		    cardinalResolver: cardinalResolver,
 		    ordinalResolver: ordinalResolver,
 		  ) {
-		_meta.setFlatMapFunction(_flatMapFunction);
+		$meta.setFlatMapFunction(_flatMapFunction);
 	}
 
 	/// Metadata for the translations of <en>.
-	final TranslationMetadata<AppLocale, Translations> _meta;
-	@override TranslationMetadata<AppLocale, Translations> get $meta => _meta;
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
 
 	/// Access flat map
-	dynamic operator[](String key) => _meta.getTranslation(key);
+	dynamic operator[](String key) => $meta.getTranslation(key);
 
 	late final Translations _root = this; // ignore: unused_field
 
@@ -1724,6 +1723,12 @@ class Translations$settings$en {
 	/// en: 'Open Source Licenses'
 	String get openSourceLicenses => 'Open Source Licenses';
 
+	/// en: 'Check for Updates'
+	String get checkForUpdates => 'Check for Updates';
+
+	/// en: 'View latest releases on GitHub'
+	String get viewLatestReleasesOnGithub => 'View latest releases on GitHub';
+
 	/// en: 'Help & Issues'
 	String get helpIssues => 'Help & Issues';
 
@@ -2682,6 +2687,8 @@ extension on Translations {
 			'settings.easterEggFound' => '🎉 You found the easter egg!',
 			'settings.selectCurrency' => 'Select Currency',
 			'settings.openSourceLicenses' => 'Open Source Licenses',
+			'settings.checkForUpdates' => 'Check for Updates',
+			'settings.viewLatestReleasesOnGithub' => 'View latest releases on GitHub',
 			'settings.helpIssues' => 'Help & Issues',
 			'settings.reportBugsOrRequestFeatures' => 'Report bugs or request features',
 			'settings.legal' => 'Legal',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -20,20 +20,21 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	/// Constructing via the enum [AppLocale.build] is preferred.
 	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
 		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
-		  $meta = meta ?? TranslationMetadata(
+		  _meta = meta ?? TranslationMetadata(
 		    locale: AppLocale.en,
 		    overrides: overrides ?? {},
 		    cardinalResolver: cardinalResolver,
 		    ordinalResolver: ordinalResolver,
 		  ) {
-		$meta.setFlatMapFunction(_flatMapFunction);
+		_meta.setFlatMapFunction(_flatMapFunction);
 	}
 
 	/// Metadata for the translations of <en>.
-	@override final TranslationMetadata<AppLocale, Translations> $meta;
+	final TranslationMetadata<AppLocale, Translations> _meta;
+	@override TranslationMetadata<AppLocale, Translations> get $meta => _meta;
 
 	/// Access flat map
-	dynamic operator[](String key) => $meta.getTranslation(key);
+	dynamic operator[](String key) => _meta.getTranslation(key);
 
 	late final Translations _root = this; // ignore: unused_field
 
@@ -1137,6 +1138,18 @@ class Translations$goals$en {
 
 	/// en: 'Target Date'
 	String get targetDateLabel => 'Target Date';
+
+	/// en: 'Active Goals'
+	String get activeGoals => 'Active Goals';
+
+	/// en: 'Completed Goals'
+	String get completedGoals => 'Completed Goals';
+
+	/// en: 'No active goals'
+	String get noActiveGoalsYet => 'No active goals';
+
+	/// en: 'Create a new goal to start saving for your next milestone.'
+	String get noActiveGoalsSubtitle => 'Create a new goal to start saving for your next milestone.';
 }
 
 // Path: lock
@@ -2487,6 +2500,10 @@ extension on Translations {
 			'goals.targetAmountGreaterThanZero' => 'Target amount must be greater than 0',
 			'goals.saveChanges' => 'Save Changes',
 			'goals.targetDateLabel' => 'Target Date',
+			'goals.activeGoals' => 'Active Goals',
+			'goals.completedGoals' => 'Completed Goals',
+			'goals.noActiveGoalsYet' => 'No active goals',
+			'goals.noActiveGoalsSubtitle' => 'Create a new goal to start saving for your next milestone.',
 			'lock.confirmPin' => 'Confirm PIN',
 			'lock.createPin' => 'Create PIN',
 			'lock.pinsDoNotMatch' => 'PINs do not match',
@@ -2645,12 +2662,12 @@ extension on Translations {
 			'settings.backupRestoreDesc' => 'Save or restore your data',
 			'settings.clearOld' => 'Clear Old Transactions',
 			'settings.clearOldDesc' => 'Remove transactions older than 1 year',
+			_ => null,
+		} ?? switch (path) {
 			'settings.resetData' => 'Reset Data',
 			'settings.resetDataDesc' => 'Erase all app data locally',
 			'settings.support' => 'Support',
 			'settings.faq' => 'FAQ',
-			_ => null,
-		} ?? switch (path) {
 			'settings.faqDesc' => 'Frequently Asked Questions',
 			'settings.about' => 'About Poka CE',
 			'settings.aboutDesc' => 'Version and legal information',

--- a/lib/i18n/strings_id.g.dart
+++ b/lib/i18n/strings_id.g.dart
@@ -16,22 +16,22 @@ class TranslationsId extends Translations with BaseTranslations<AppLocale, Trans
 	/// Constructing via the enum [AppLocale.build] is preferred.
 	TranslationsId({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
 		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
-		  _meta = meta ?? TranslationMetadata(
+		  $meta = meta ?? TranslationMetadata(
 		    locale: AppLocale.id,
 		    overrides: overrides ?? {},
 		    cardinalResolver: cardinalResolver,
 		    ordinalResolver: ordinalResolver,
 		  ),
 		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
-		_meta.setFlatMapFunction(_flatMapFunction);
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
 	}
 
 	/// Metadata for the translations of <id>.
-	final TranslationMetadata<AppLocale, Translations> _meta;
-	@override TranslationMetadata<AppLocale, Translations> get $meta => _meta;
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
 
 	/// Access flat map
-	@override dynamic operator[](String key) => _meta.getTranslation(key) ?? super[key];
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
 
 	late final TranslationsId _root = this; // ignore: unused_field
 
@@ -700,6 +700,8 @@ class _Translations$settings$id extends Translations$settings$en {
 	@override String get easterEggFound => '🎉 Anda menemukan easter egg!';
 	@override String get selectCurrency => 'Pilih Mata Uang';
 	@override String get openSourceLicenses => 'Lisensi Open Source';
+	@override String get checkForUpdates => 'Periksa Pembaruan';
+	@override String get viewLatestReleasesOnGithub => 'Lihat rilis terbaru di GitHub';
 	@override String get helpIssues => 'Bantuan & Masalah';
 	@override String get reportBugsOrRequestFeatures => 'Laporkan bug atau minta fitur';
 	@override String get legal => 'Legal';
@@ -1411,6 +1413,8 @@ extension on TranslationsId {
 			'settings.easterEggFound' => '🎉 Anda menemukan easter egg!',
 			'settings.selectCurrency' => 'Pilih Mata Uang',
 			'settings.openSourceLicenses' => 'Lisensi Open Source',
+			'settings.checkForUpdates' => 'Periksa Pembaruan',
+			'settings.viewLatestReleasesOnGithub' => 'Lihat rilis terbaru di GitHub',
 			'settings.helpIssues' => 'Bantuan & Masalah',
 			'settings.reportBugsOrRequestFeatures' => 'Laporkan bug atau minta fitur',
 			'settings.legal' => 'Legal',

--- a/lib/i18n/strings_id.g.dart
+++ b/lib/i18n/strings_id.g.dart
@@ -100,6 +100,8 @@ class _Translations$accounts$id extends Translations$accounts$en {
 	@override String get permanentlyRemoveThisAccount => 'Hapus permanen akun ini';
 	@override String get seeAll => 'Lihat Semua';
 	@override String get noTransactionsYet => 'Belum ada transaksi';
+	@override String get accountTransactionsSubtitle => 'Transaksi yang dicatat di akun ini akan muncul di sini.';
+	@override String get pocketTransactionsSubtitle => 'Transaksi yang dicatat di kantong ini akan muncul di sini.';
 	@override String get addAccount => 'Tambah Akun';
 	@override String get noAccountsFound => 'Akun tidak ditemukan.';
 	@override String get addPocket => 'Tambah Kantong';
@@ -206,6 +208,7 @@ class _Translations$budgets$id extends Translations$budgets$en {
 	@override String get totalLimit => 'Total batas';
 	@override String get selectEndDate => 'Pilih tanggal berakhir';
 	@override String get noTransactionsFoundForThisBudgetPeriod => 'Tidak ada transaksi yang ditemukan untuk periode anggaran ini.';
+	@override String get budgetTransactionsSubtitle => 'Transaksi yang terkait dengan anggaran ini akan muncul di sini.';
 	@override String get addBudget => 'Tambah Anggaran';
 	@override String get spent => 'Terpakai ';
 	@override String get noBudgetsYet => 'Belum ada anggaran';
@@ -336,6 +339,7 @@ class _Translations$dashboard$id extends Translations$dashboard$en {
 	@override String get recentTransactions => 'Transaksi Terakhir';
 	@override String get thisMonth => 'Bulan ini';
 	@override String get noRecentTransactions => 'Tidak ada transaksi baru';
+	@override String get recentTransactionsSubtitle => 'Transaksi yang baru saja Anda catat akan muncul di sini.';
 	@override String get seeAll => 'Lihat Semua';
 	@override String get notSet => 'Belum diatur';
 	@override late final _Translations$dashboard$insight$id insight = _Translations$dashboard$insight$id._(_root);
@@ -385,6 +389,7 @@ class _Translations$debts$id extends Translations$debts$en {
 	@override String reminder({required Object type, required Object name}) => 'Pengingat ${type}: ${name}';
 	@override String due({required Object type, required Object name}) => '${type} Jatuh Tempo: ${name}';
 	@override String noHistoryFoundForThis({required Object type}) => 'Tidak ada riwayat untuk ${type} ini';
+	@override String repaymentHistorySubtitle({required Object type}) => 'Catatan pembayaran atau cicilan untuk ${type} ini akan muncul di sini.';
 	@override String failedToLoadDebts({required Object error}) => 'Gagal memuat utang: ${error}';
 	@override String percentOf({required Object percent}) => '${percent}% dari ';
 	@override String settled({required Object count}) => '${count} diselesaikan';
@@ -451,6 +456,7 @@ class _Translations$goals$id extends Translations$goals$en {
 	@override String get totalTarget => 'Total target';
 	@override String get selectTargetDate => 'Pilih tanggal target';
 	@override String get noTransactionsFoundForThisGoal => 'Tidak ada transaksi yang ditemukan untuk target ini.';
+	@override String get goalTransactionsSubtitle => 'Transaksi atau simpanan untuk target ini akan muncul di sini.';
 	@override String get addGoal => 'Tambah Target';
 	@override String get aDedicatedPocketAccountWillBeCreatedAutomaticallyToTrackThisGoal => 'Akun Kantong khusus akan dibuat secara otomatis untuk melacak target ini.';
 	@override String get saved => 'terkumpul';
@@ -538,6 +544,7 @@ class _Translations$recurring$id extends Translations$recurring$en {
 	@override String get noRecurringTransactions => 'Tidak ada transaksi berulang';
 	@override String get automateBillsLikeSubscriptionsOrSalary => 'Otomatiskan tagihan seperti langganan atau gaji. Aplikasi akan mencatatnya sesuai jadwal.';
 	@override String get noHistoryFoundForThisSchedule => 'Tidak ada riwayat untuk jadwal ini.';
+	@override String get scheduleHistorySubtitle => 'Transaksi yang dibuat dari jadwal ini akan muncul di sini.';
 	@override String get allocation => 'Alokasi';
 	@override String get active => 'Aktif';
 	@override String get eachTimeTheAppOpensOverdueRecurringTransactionsAre => 'Setiap kali aplikasi dibuka, transaksi berulang yang telah lewat jatuh tempo akan otomatis dicatat dalam buku kas Anda.';
@@ -600,6 +607,7 @@ class _Translations$reports$id extends Translations$reports$en {
 	@override String get budgetUtilization => 'Pemanfaatan Anggaran';
 	@override String get spendingAllocation => 'Alokasi Pengeluaran';
 	@override String get noData => 'Tidak ada data untuk periode ini';
+	@override String get noExpenseDataDesc => 'Catat transaksi pengeluaran untuk melihat pembagian alokasi.';
 	@override String get noBudgets => 'Belum ada anggaran yang dikonfigurasi';
 	@override String get noBudgetsDesc => 'Tambahkan anggaran untuk melacak batas pengeluaran Anda';
 	@override String get onTrack => 'Sesuai rencana';
@@ -898,6 +906,8 @@ extension on TranslationsId {
 			'accounts.permanentlyRemoveThisAccount' => 'Hapus permanen akun ini',
 			'accounts.seeAll' => 'Lihat Semua',
 			'accounts.noTransactionsYet' => 'Belum ada transaksi',
+			'accounts.accountTransactionsSubtitle' => 'Transaksi yang dicatat di akun ini akan muncul di sini.',
+			'accounts.pocketTransactionsSubtitle' => 'Transaksi yang dicatat di kantong ini akan muncul di sini.',
 			'accounts.addAccount' => 'Tambah Akun',
 			'accounts.noAccountsFound' => 'Akun tidak ditemukan.',
 			'accounts.addPocket' => 'Tambah Kantong',
@@ -979,6 +989,7 @@ extension on TranslationsId {
 			'budgets.totalLimit' => 'Total batas',
 			'budgets.selectEndDate' => 'Pilih tanggal berakhir',
 			'budgets.noTransactionsFoundForThisBudgetPeriod' => 'Tidak ada transaksi yang ditemukan untuk periode anggaran ini.',
+			'budgets.budgetTransactionsSubtitle' => 'Transaksi yang terkait dengan anggaran ini akan muncul di sini.',
 			'budgets.addBudget' => 'Tambah Anggaran',
 			'budgets.spent' => 'Terpakai ',
 			'budgets.noBudgetsYet' => 'Belum ada anggaran',
@@ -1082,6 +1093,7 @@ extension on TranslationsId {
 			'dashboard.recentTransactions' => 'Transaksi Terakhir',
 			'dashboard.thisMonth' => 'Bulan ini',
 			'dashboard.noRecentTransactions' => 'Tidak ada transaksi baru',
+			'dashboard.recentTransactionsSubtitle' => 'Transaksi yang baru saja Anda catat akan muncul di sini.',
 			'dashboard.seeAll' => 'Lihat Semua',
 			'dashboard.notSet' => 'Belum diatur',
 			'dashboard.insight.noData' => 'Belum ada data bulan ini untuk dianalisa.',
@@ -1133,6 +1145,7 @@ extension on TranslationsId {
 			'debts.reminder' => ({required Object type, required Object name}) => 'Pengingat ${type}: ${name}',
 			'debts.due' => ({required Object type, required Object name}) => '${type} Jatuh Tempo: ${name}',
 			'debts.noHistoryFoundForThis' => ({required Object type}) => 'Tidak ada riwayat untuk ${type} ini',
+			'debts.repaymentHistorySubtitle' => ({required Object type}) => 'Catatan pembayaran atau cicilan untuk ${type} ini akan muncul di sini.',
 			'debts.failedToLoadDebts' => ({required Object error}) => 'Gagal memuat utang: ${error}',
 			'debts.percentOf' => ({required Object percent}) => '${percent}% dari ',
 			'debts.settled' => ({required Object count}) => '${count} diselesaikan',
@@ -1193,6 +1206,7 @@ extension on TranslationsId {
 			'goals.totalTarget' => 'Total target',
 			'goals.selectTargetDate' => 'Pilih tanggal target',
 			'goals.noTransactionsFoundForThisGoal' => 'Tidak ada transaksi yang ditemukan untuk target ini.',
+			'goals.goalTransactionsSubtitle' => 'Transaksi atau simpanan untuk target ini akan muncul di sini.',
 			'goals.addGoal' => 'Tambah Target',
 			'goals.aDedicatedPocketAccountWillBeCreatedAutomaticallyToTrackThisGoal' => 'Akun Kantong khusus akan dibuat secara otomatis untuk melacak target ini.',
 			'goals.saved' => 'terkumpul',
@@ -1253,6 +1267,7 @@ extension on TranslationsId {
 			'recurring.noRecurringTransactions' => 'Tidak ada transaksi berulang',
 			'recurring.automateBillsLikeSubscriptionsOrSalary' => 'Otomatiskan tagihan seperti langganan atau gaji. Aplikasi akan mencatatnya sesuai jadwal.',
 			'recurring.noHistoryFoundForThisSchedule' => 'Tidak ada riwayat untuk jadwal ini.',
+			'recurring.scheduleHistorySubtitle' => 'Transaksi yang dibuat dari jadwal ini akan muncul di sini.',
 			'recurring.allocation' => 'Alokasi',
 			'recurring.active' => 'Aktif',
 			'recurring.eachTimeTheAppOpensOverdueRecurringTransactionsAre' => 'Setiap kali aplikasi dibuka, transaksi berulang yang telah lewat jatuh tempo akan otomatis dicatat dalam buku kas Anda.',
@@ -1306,6 +1321,7 @@ extension on TranslationsId {
 			'reports.budgetUtilization' => 'Pemanfaatan Anggaran',
 			'reports.spendingAllocation' => 'Alokasi Pengeluaran',
 			'reports.noData' => 'Tidak ada data untuk periode ini',
+			'reports.noExpenseDataDesc' => 'Catat transaksi pengeluaran untuk melihat pembagian alokasi.',
 			'reports.noBudgets' => 'Belum ada anggaran yang dikonfigurasi',
 			'reports.noBudgetsDesc' => 'Tambahkan anggaran untuk melacak batas pengeluaran Anda',
 			'reports.onTrack' => 'Sesuai rencana',
@@ -1371,6 +1387,8 @@ extension on TranslationsId {
 			'settings.resetDataDesc' => 'Hapus semua data aplikasi lokal',
 			'settings.support' => 'Bantuan',
 			'settings.faq' => 'FAQ',
+			_ => null,
+		} ?? switch (path) {
 			'settings.faqDesc' => 'Pertanyaan yang Sering Diajukan',
 			'settings.about' => 'Tentang Poka CE',
 			'settings.aboutDesc' => 'Versi dan informasi legal',
@@ -1379,8 +1397,6 @@ extension on TranslationsId {
 			'settings.themeDark' => 'Gelap',
 			'settings.selectLanguage' => 'Pilih Bahasa',
 			'settings.oldTransactionsCleared' => 'Transaksi lama berhasil dibersihkan',
-			_ => null,
-		} ?? switch (path) {
 			'settings.appDataReset' => 'Data aplikasi berhasil direset',
 			'settings.failedToExportLogs' => 'Gagal mengekspor log',
 			'settings.easterEggRemaining' => ({required Object remaining}) => '${remaining} ketukan lagi dari sebuah kejutan...',

--- a/lib/i18n/strings_id.g.dart
+++ b/lib/i18n/strings_id.g.dart
@@ -16,22 +16,22 @@ class TranslationsId extends Translations with BaseTranslations<AppLocale, Trans
 	/// Constructing via the enum [AppLocale.build] is preferred.
 	TranslationsId({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
 		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
-		  $meta = meta ?? TranslationMetadata(
+		  _meta = meta ?? TranslationMetadata(
 		    locale: AppLocale.id,
 		    overrides: overrides ?? {},
 		    cardinalResolver: cardinalResolver,
 		    ordinalResolver: ordinalResolver,
 		  ),
 		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
-		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
-		$meta.setFlatMapFunction(_flatMapFunction);
+		_meta.setFlatMapFunction(_flatMapFunction);
 	}
 
 	/// Metadata for the translations of <id>.
-	@override final TranslationMetadata<AppLocale, Translations> $meta;
+	final TranslationMetadata<AppLocale, Translations> _meta;
+	@override TranslationMetadata<AppLocale, Translations> get $meta => _meta;
 
 	/// Access flat map
-	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+	@override dynamic operator[](String key) => _meta.getTranslation(key) ?? super[key];
 
 	late final TranslationsId _root = this; // ignore: unused_field
 
@@ -475,6 +475,10 @@ class _Translations$goals$id extends Translations$goals$en {
 	@override String get targetAmountGreaterThanZero => 'Jumlah target harus lebih besar dari 0';
 	@override String get saveChanges => 'Simpan Perubahan';
 	@override String get targetDateLabel => 'Tanggal Target';
+	@override String get activeGoals => 'Target Aktif';
+	@override String get completedGoals => 'Target Selesai';
+	@override String get noActiveGoalsYet => 'Belum ada target aktif';
+	@override String get noActiveGoalsSubtitle => 'Buat target baru untuk mulai menabung impian Anda berikutnya.';
 }
 
 // Path: lock
@@ -1225,6 +1229,10 @@ extension on TranslationsId {
 			'goals.targetAmountGreaterThanZero' => 'Jumlah target harus lebih besar dari 0',
 			'goals.saveChanges' => 'Simpan Perubahan',
 			'goals.targetDateLabel' => 'Tanggal Target',
+			'goals.activeGoals' => 'Target Aktif',
+			'goals.completedGoals' => 'Target Selesai',
+			'goals.noActiveGoalsYet' => 'Belum ada target aktif',
+			'goals.noActiveGoalsSubtitle' => 'Buat target baru untuk mulai menabung impian Anda berikutnya.',
 			'lock.confirmPin' => 'Konfirmasi PIN',
 			'lock.createPin' => 'Buat PIN',
 			'lock.pinsDoNotMatch' => 'PIN tidak cocok',
@@ -1383,12 +1391,12 @@ extension on TranslationsId {
 			'settings.backupRestoreDesc' => 'Simpan atau pulihkan data Anda',
 			'settings.clearOld' => 'Hapus Transaksi Lama',
 			'settings.clearOldDesc' => 'Hapus transaksi lebih dari 1 tahun',
+			_ => null,
+		} ?? switch (path) {
 			'settings.resetData' => 'Reset Data',
 			'settings.resetDataDesc' => 'Hapus semua data aplikasi lokal',
 			'settings.support' => 'Bantuan',
 			'settings.faq' => 'FAQ',
-			_ => null,
-		} ?? switch (path) {
 			'settings.faqDesc' => 'Pertanyaan yang Sering Diajukan',
 			'settings.about' => 'Tentang Poka CE',
 			'settings.aboutDesc' => 'Versi dan informasi legal',

--- a/lib/shared/widgets/poka_empty_view.dart
+++ b/lib/shared/widgets/poka_empty_view.dart
@@ -148,6 +148,7 @@ class PokaEmptyViewCentered extends StatefulWidget {
     this.actionLabel,
     this.onAction,
     this.actionKey,
+    this.hasBorder = false,
     super.key,
   }) : assert(
          (actionLabel == null) == (onAction == null),
@@ -160,6 +161,7 @@ class PokaEmptyViewCentered extends StatefulWidget {
   final String? actionLabel;
   final VoidCallback? onAction;
   final Key? actionKey;
+  final bool hasBorder;
 
   @override
   State<PokaEmptyViewCentered> createState() => _PokaEmptyViewCenteredState();
@@ -221,6 +223,7 @@ class _PokaEmptyViewCenteredState extends State<PokaEmptyViewCentered> {
       actionLabel: widget.actionLabel,
       onAction: widget.onAction,
       actionKey: widget.actionKey,
+      hasBorder: widget.hasBorder,
     );
 
     // Initial guess to prevent extreme layout shifts before the first frame is measured
@@ -230,13 +233,14 @@ class _PokaEmptyViewCenteredState extends State<PokaEmptyViewCentered> {
       // Calculate how far the top of this widget is from the exact center of the screen
       final distanceToCenter = (screenHeight / 2) - _yOffset!;
 
-      if (distanceToCenter > 50) {
+      // Enforce minimum height of 260px so content (icon, title, subtitle, action) is never clipped
+      if (distanceToCenter > 130) {
         // By making the container exactly twice the distance to the center,
         // the Center() widget will push the empty state exactly to screenHeight / 2.
         height = distanceToCenter * 2;
       } else {
-        // Fallback for detail pages where the empty state is placed very low (below a hero card).
-        height = 300;
+        // Fallback when the widget is placed near or below screen center (e.g. below a hero card).
+        height = 260;
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: poka_ce
 description: "Poka CE — Community Edition core package for the Poka financial app."
 publish_to: 'none'
 
-version: 1.0.0-rc.2+7
+version: 1.0.0+1
 
 environment:
   sdk: ^3.13.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,27 +32,49 @@ fi
 case "$TARGET" in
   ""|"fat"|"universal"|"default")
     ARCH_NAME="Universal (Fat)"
-    if [ -f "$APK_DIR/app-universal-release.apk" ]; then
+    if compgen -G "$APK_DIR/poka-*-universal.apk" >/dev/null; then
+      APK_PATH=$(ls -t "$APK_DIR"/poka-*-universal.apk | head -n 1)
+    elif [ -f "$APK_DIR/poka-universal.apk" ]; then
+      APK_PATH="$APK_DIR/poka-universal.apk"
+    elif [ -f "$APK_DIR/app-universal-release.apk" ]; then
       APK_PATH="$APK_DIR/app-universal-release.apk"
     elif [ -f "$APK_DIR/app-release.apk" ]; then
       APK_PATH="$APK_DIR/app-release.apk"
     elif [ -f "$APK_DIR/app-debug.apk" ]; then
       APK_PATH="$APK_DIR/app-debug.apk"
     else
-      APK_PATH="$APK_DIR/app-universal-release.apk"
+      APK_PATH="$APK_DIR/poka-universal.apk"
     fi
     ;;
   "arm64"|"arm64-v8a"|"aarch64"|"v8a")
     ARCH_NAME="arm64-v8a"
-    APK_PATH="$APK_DIR/app-arm64-v8a-release.apk"
+    if compgen -G "$APK_DIR/poka-*-arm64-v8a.apk" >/dev/null; then
+      APK_PATH=$(ls -t "$APK_DIR"/poka-*-arm64-v8a.apk | head -n 1)
+    elif [ -f "$APK_DIR/poka-arm64-v8a.apk" ]; then
+      APK_PATH="$APK_DIR/poka-arm64-v8a.apk"
+    else
+      APK_PATH="$APK_DIR/app-arm64-v8a-release.apk"
+    fi
     ;;
   "arm"|"armv7"|"armeabi"|"armeabi-v7a"|"v7a")
     ARCH_NAME="armeabi-v7a"
-    APK_PATH="$APK_DIR/app-armeabi-v7a-release.apk"
+    if compgen -G "$APK_DIR/poka-*-armeabi-v7a.apk" >/dev/null; then
+      APK_PATH=$(ls -t "$APK_DIR"/poka-*-armeabi-v7a.apk | head -n 1)
+    elif [ -f "$APK_DIR/poka-armeabi-v7a.apk" ]; then
+      APK_PATH="$APK_DIR/poka-armeabi-v7a.apk"
+    else
+      APK_PATH="$APK_DIR/app-armeabi-v7a-release.apk"
+    fi
     ;;
   "x86_64"|"x64"|"x86-64")
     ARCH_NAME="x86_64"
-    APK_PATH="$APK_DIR/app-x86_64-release.apk"
+    if compgen -G "$APK_DIR/poka-*-x86_64.apk" >/dev/null; then
+      APK_PATH=$(ls -t "$APK_DIR"/poka-*-x86_64.apk | head -n 1)
+    elif [ -f "$APK_DIR/poka-x86_64.apk" ]; then
+      APK_PATH="$APK_DIR/poka-x86_64.apk"
+    else
+      APK_PATH="$APK_DIR/app-x86_64-release.apk"
+    fi
     ;;
   *)
     ARCH_NAME="$TARGET"
@@ -84,9 +106,9 @@ if [ ! -f "$APK_PATH" ]; then
   fi
   echo ""
   if [ "$TARGET" = "fat" ] || [ "$TARGET" = "universal" ]; then
-    echo "💡 To build the universal APK, run: rune build"
+    echo "💡 To build the universal APK, run: rune build:apk"
   else
-    echo "💡 To build split-per-ABI APKs, run: rune build --split"
+    echo "💡 To build split-per-ABI APKs, run: rune build:apk --split"
   fi
   exit 1
 fi

--- a/test/e2e/features/debts/debts_e2e_test.dart
+++ b/test/e2e/features/debts/debts_e2e_test.dart
@@ -55,7 +55,7 @@ void main() {
     await tester.tap(catSelector);
     await settle();
 
-    final categoryItem = find.text('Food & Dining').first;
+    final categoryItem = find.text('Food & Drinks').first;
     await tester.ensureVisible(categoryItem);
     await tester.tap(categoryItem);
     await settle(); // Wait for sheet to close

--- a/test/e2e/features/recurring/recurring_e2e_test.dart
+++ b/test/e2e/features/recurring/recurring_e2e_test.dart
@@ -68,7 +68,7 @@ void main() {
     await tester.tap(catSelector);
     await settle();
 
-    final categoryItem = find.text('Food & Dining').first;
+    final categoryItem = find.text('Food & Drinks').first;
     await tester.ensureVisible(categoryItem);
     await tester.tap(categoryItem);
     await settle(); // Wait for sheet to close

--- a/test/feature/features/debts/presentation/widgets/debt_repayment_sheet_test.dart
+++ b/test/feature/features/debts/presentation/widgets/debt_repayment_sheet_test.dart
@@ -144,6 +144,7 @@ void main() {
       await tester.pumpWidget(buildWidget(sampleDebt()));
       await tester.pumpAndSettle();
 
+      expect(find.text('Add note...'), findsOneWidget);
       expect(find.text('Pay in Full'), findsOneWidget);
       expect(find.text('Wallet'), findsOneWidget);
       expect(find.text('Bank'), findsOneWidget);
@@ -151,7 +152,7 @@ void main() {
       expect(find.byKey(const Key('numpad-ok')), findsOneWidget);
     });
 
-    testWidgets('pay in full sets amount to remaining amount', (tester) async {
+    testWidgets('pay in full sets amount to remaining amount and toggles back to 0 on tap', (tester) async {
       await tester.pumpWidget(buildWidget(sampleDebt()));
       await tester.pumpAndSettle();
 
@@ -159,6 +160,28 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('1,000'), findsWidgets);
+
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('0'), findsWidgets);
+    });
+
+    testWidgets('tapping note in meta bar opens note editor and saves note', (tester) async {
+      await tester.pumpWidget(buildWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add note...'), findsOneWidget);
+      await tester.tap(find.text('Add note...'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add note'), findsOneWidget);
+      await tester.enterText(find.byType(EditableText).last, 'Partial payment via transfer');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Partial payment via transfer'), findsOneWidget);
     });
 
     testWidgets('numpad keys update the amount expression', (tester) async {
@@ -233,6 +256,41 @@ void main() {
       expect(captured[3], 'Repayment for Alice');
       // Sheet should be closed after successful save
       expect(find.text('Pay in Full'), findsNothing);
+    });
+
+    testWidgets('OK with custom note saves repayment with that note', (tester) async {
+      await tester.pumpWidget(buildShowWidget(sampleDebt()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('OpenRepayment'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Add note...'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(EditableText).last, 'Paid Alice back for lunch');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Pay in Full'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('numpad-ok')));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: any(named: 'amount'),
+          debtId: any(named: 'debtId'),
+          note: captureAny(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          categoryId: any(named: 'categoryId'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).captured;
+      expect(captured[0], 'Paid Alice back for lunch');
     });
 
     testWidgets('loan repayment saves as income', (tester) async {

--- a/test/feature/features/goals/presentation/screens/goal_list_page_test.dart
+++ b/test/feature/features/goals/presentation/screens/goal_list_page_test.dart
@@ -17,6 +17,7 @@ GoalModel _goal(
   int targetAmount, {
   String accountId = 'acc1',
   DateTime? targetDate,
+  GoalStatus status = GoalStatus.active,
 }) {
   return GoalModel(
     id: id,
@@ -24,6 +25,7 @@ GoalModel _goal(
     name: name,
     targetAmount: targetAmount,
     targetDate: targetDate,
+    status: status,
     createdAt: DateTime.utc(2024, 1, 1),
     updatedAt: DateTime.utc(2024, 1, 1),
   );
@@ -224,6 +226,43 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('0% of target'), findsOneWidget);
+    });
+
+    testWidgets('shows both active goals and completed goals in single stream', (tester) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+
+      final active = _goal('g1', 'Active Trip', 10000, accountId: 'a1');
+      final done = _goal('g2', 'Done Car', 50000, accountId: 'a2', status: GoalStatus.completed);
+      final dash = DashboardState(
+        isLoading: false,
+        accounts: [_acc('a1', 3000), _acc('a2', 50000)],
+      );
+
+      await tester.pumpWidget(wrapGoal([active, done], dashboardState: dash));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.goals.activeGoals.toUpperCase()), findsOneWidget);
+      expect(find.text('Active Trip'), findsOneWidget);
+      expect(find.text(t.goals.completedGoals.toUpperCase()), findsOneWidget);
+      expect(find.text('Done Car'), findsOneWidget);
+    });
+
+    testWidgets('shows empty active state when only completed goals exist', (tester) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+
+      final done = _goal('g1', 'Old Target', 20000, accountId: 'a1', status: GoalStatus.completed);
+      final dash = DashboardState(isLoading: false, accounts: [_acc('a1', 20000)]);
+
+      await tester.pumpWidget(wrapGoal([done], dashboardState: dash));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.goals.noActiveGoalsYet), findsOneWidget);
+      expect(find.text(t.goals.completedGoals.toUpperCase()), findsOneWidget);
+      expect(find.text('Old Target'), findsOneWidget);
     });
   });
 }

--- a/test/unit/database/seeder_test.dart
+++ b/test/unit/database/seeder_test.dart
@@ -11,7 +11,7 @@ void main() {
   tearDown(() async => db.close());
 
   group('DatabaseSeeder', () {
-    test('seed creates 6 accounts and 24 categories', () async {
+    test('seed creates 8 accounts and 62 categories', () async {
       await DatabaseSeeder.seed(db, overrideSeedDummyData: true);
       final accounts = await db.select(db.accounts).get();
       expect(accounts.length, 8);
@@ -33,24 +33,24 @@ void main() {
       expect(accounts.firstWhere((a) => a.name == 'Cash').balance, 750000); // Updated to match actual seeder data
 
       final categories = await db.select(db.categories).get();
-      expect(categories.length, 24);
-      expect(categories.where((c) => c.type == CategoryType.expense).length, 21);
-      expect(categories.where((c) => c.type == CategoryType.income).length, 3);
+      expect(categories.length, 62);
+      expect(categories.where((c) => c.type == CategoryType.expense).length, 42);
+      expect(categories.where((c) => c.type == CategoryType.income).length, 20);
     });
 
     test('seed categories have correct icons and colors for sub-categories', () async {
       await DatabaseSeeder.seed(db, overrideSeedDummyData: true);
       final categories = await db.select(db.categories).get();
-      final food = categories.firstWhere((c) => c.name == 'Food & Dining');
-      expect(food.icon, 'bowl-food');
+      final food = categories.firstWhere((c) => c.name == 'Food & Drinks');
+      expect(food.icon, 'fork-knife');
       expect(food.color, '#F97316');
-      final transport = categories.firstWhere((c) => c.name == 'Transport');
+      final transport = categories.firstWhere((c) => c.name == 'Transportation');
       expect(transport.icon, 'car');
       final salary = categories.firstWhere((c) => c.name == 'Salary');
       expect(salary.icon, 'bank');
-      final lunch = categories.firstWhere((c) => c.name == 'Groceries');
-      expect(lunch.icon, 'shopping-cart');
-      expect(lunch.parentId, isNotNull);
+      final groceries = categories.firstWhere((c) => c.name == 'Groceries');
+      expect(groceries.icon, 'shopping-cart');
+      expect(groceries.parentId, isNotNull);
     });
 
     test('seed wallet has expected icon and color', () async {

--- a/test/unit/features/accounts/presentation/controllers/account_list_notifier_test.dart
+++ b/test/unit/features/accounts/presentation/controllers/account_list_notifier_test.dart
@@ -300,6 +300,21 @@ void main() {
       expect(metrics.netWorth, 3800);
     });
 
+    test('accountMetrics excludes pockets and goal accounts from activeAccountCount', () async {
+      final parent = acc('p1', balance: 5000);
+      final pocket = acc('pk1', parentId: 'p1', balance: 2000);
+      final goal = acc('g1', type: AccountType.goal, balance: 1000);
+      when(() => mockRepo.watchAccounts()).thenAnswer((_) => resultStream(Success([parent, pocket, goal])));
+      final container = createContainer();
+      await wait();
+
+      final metrics = container.read(accountMetricsProvider);
+      expect(metrics.activeAccountCount, 1);
+      expect(metrics.totalAssets, 8000);
+      expect(metrics.totalLiabilities, 0);
+      expect(metrics.netWorth, 8000);
+    });
+
     test('accountAggregate returns aggregate for existing account', () async {
       final parent = acc('p0', name: 'Parent');
       final pocket = acc('pk1', parentId: 'p0');

--- a/test/unit/features/dashboard/domain/services/dashboard_analytics_service_test.dart
+++ b/test/unit/features/dashboard/domain/services/dashboard_analytics_service_test.dart
@@ -55,6 +55,57 @@ void main() {
         expect(metrics.totalLiabilities, 200.0);
         expect(metrics.netWorth, 300.0);
       });
+
+      test('excludes pockets and goal accounts from activeAccountCount but includes their balances', () {
+        final now = DateTime.now();
+        final accounts = [
+          AccountModel(
+            id: '1',
+            name: 'BCA',
+            icon: 'bank',
+            color: '#000000',
+            type: AccountType.assets,
+            balance: 1000,
+            initialBalance: 1000,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+          ),
+          AccountModel(
+            id: '2',
+            name: 'BCA Saving Pocket',
+            parentId: '1',
+            icon: 'savings',
+            color: '#000000',
+            type: AccountType.assets,
+            balance: 500,
+            initialBalance: 0,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+          ),
+          AccountModel(
+            id: '3',
+            name: 'Vacation Goal',
+            icon: 'flight',
+            color: '#000000',
+            type: AccountType.goal,
+            balance: 300,
+            initialBalance: 0,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ];
+
+        final metrics = DashboardAnalyticsService.calculateAccountMetrics(accounts);
+        // Only 1 primary account counted
+        expect(metrics.activeAccountCount, 1);
+        // Balances from parent, pocket, and goal are all included
+        expect(metrics.totalAssets, 1800.0);
+        expect(metrics.totalLiabilities, 0.0);
+        expect(metrics.netWorth, 1800.0);
+      });
     });
 
     group('calculateNetWorthTrend', () {

--- a/test/unit/features/recurring/presentation/controllers/recurring_list_notifier_test.dart
+++ b/test/unit/features/recurring/presentation/controllers/recurring_list_notifier_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -176,6 +178,22 @@ void main() {
       await container.read(recurringListProvider.notifier).toggleActive('unknown');
       await wait();
       verifyNever(() => mockRepo.updateRecurring(any()));
+    });
+
+    test('refresh safely handles unmounted ref after async gap', () async {
+      final completer = Completer<Result<List<RecurringTransactionModel>, Failure>>();
+      when(() => mockRepo.getRecurringTransactions()).thenAnswer((_) => completer.future);
+
+      final container = ProviderContainer(
+        overrides: [recurringRepositoryProvider.overrideWithValue(mockRepo)],
+      );
+      final future = container.read(recurringListProvider.notifier).refresh();
+
+      // Dispose container while async query is in flight
+      container.dispose();
+
+      completer.complete(const Success([]));
+      await expectLater(future, completes);
     });
   });
 }

--- a/test/unit/features/recurring/presentation/controllers/recurring_runner_notifier_test.dart
+++ b/test/unit/features/recurring/presentation/controllers/recurring_runner_notifier_test.dart
@@ -122,5 +122,38 @@ void main() {
       expect(list.refreshCount, 1);
       verify(() => transactionRepo.createTransaction(any())).called(1);
     });
+
+    test('processes due transactions using real recurringListProvider without disposal exception', () async {
+      when(() => recurringRepo.getDueRecurringTransactions(any())).thenAnswer(
+        (_) async => Success<List<RecurringTransactionModel>, Failure>([recurring()]),
+      );
+      when(() => recurringRepo.getRecurringTransactions()).thenAnswer(
+        (_) async => const Success<List<RecurringTransactionModel>, Failure>([]),
+      );
+      when(() => transactionRepo.createTransaction(any())).thenAnswer(
+        (_) async => const Success<void, Failure>(null),
+      );
+      when(() => recurringRepo.updateRecurring(any())).thenAnswer(
+        (_) async => const Success<void, Failure>(null),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          recurringRepositoryProvider.overrideWithValue(recurringRepo),
+          transactionRepositoryProvider.overrideWithValue(transactionRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Only listen to recurringRunnerProvider (simulating app startup when dashboard mounts)
+      container.listen(recurringRunnerProvider, (_, _) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final state = container.read(recurringRunnerProvider);
+      expect(state, isA<RecurringRunnerDone>());
+      expect((state as RecurringRunnerDone).processed, 1);
+      verify(() => transactionRepo.createTransaction(any())).called(1);
+      verify(() => recurringRepo.getRecurringTransactions()).called(2);
+    });
   });
 }


### PR DESCRIPTION
## Summary
This pull request prepares Poka CE for its `v1.0.0` release under feature freeze, consolidating core UI/UX refinements, bug fixes, catalog alignment, release metadata, and optimized release build packaging.

### Changes
- **Release & Branding (`9fa8e52`)**: Bump package version to `1.0.0+1`, standardize Android launcher label to TitleCase "Poka CE", enforce offline GoogleFonts runtime mode, and update `CHANGELOG.md`.
- **Build Hardening (`a9e712e`)**: Add `--extra-gen-snapshot-options=--strip` to Runefile (`build:apk`, `build:aab`) and GitHub Actions release workflow to strip unobfuscated DWARF debugging metadata from release binaries.
- **Accounts (`d81387f`)**: Exclude pocket accounts and goal accounts from the active accounts counter.
- **Categories (`cc24502`)**: Expand and align default expense and income category catalog with UUIDv7 IDs.
- **Packaging & Settings (`d5d29dd`)**: Optimize release packaging and enhance About settings with direct update link.
- **Debts UI (`96ce6fd`)**: Align repayment sheet layout and quick-fill action with transaction form.
- **Goals UI (`f1bfbb6`)**: Streamline goals overview into unified single-stream layout.
- **Empty Views UI (`ed579bd`)**: Add informative subtitles and standardize borders across empty views.
- **CLI Tooling (`d8f1c07`)**: Streamline Rune task runner commands, installer, and setup documentation.
- **Recurring (`27f71d2`)**: Resolve notifier lifecycle race condition during screen disposal.

### Feature Freeze Compliance
- No new features introduced (`feat:`). Strictly `fix:`, `refactor:`, `ui:`, and `chore:`.