### PR TITLE
refactor(theme): remove redundant font fallbacks and unused cupertino dependencies

### DIFF
--- a/lib/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart
+++ b/lib/shared/widgets/dialogs/poka_insufficient_balance_dialog.dart
@@ -85,6 +85,9 @@ Future<bool?> showPokaInsufficientBalanceDialog(
               const SizedBox(height: 24),
 
               // Actions
+              // Note: In forui 0.26, FButton places `child` directly inside an internal Row.
+              // Flexible is required so the Row constrains the child; without it, FittedBox
+              // receives unconstrained width (infinity) from the Row and overflows by 14px in tests.
               Row(
                 children: [
                   Expanded(

--- a/lib/theme/styles/card_style.dart
+++ b/lib/theme/styles/card_style.dart
@@ -1,4 +1,3 @@
-import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:forui/forui.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:poka_ce/theme/typography_roles.dart';

--- a/lib/theme/styles/scaffold_style.dart
+++ b/lib/theme/styles/scaffold_style.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:forui/forui.dart';

--- a/lib/theme/typography.dart
+++ b/lib/theme/typography.dart
@@ -7,18 +7,8 @@ FTypography _typography({required FColors colors, required bool touch}) {
   const headingFamily = 'PlusJakartaSans';
   const bodyFamily = 'Inter';
   return FTypography(
-    display: _display(
-      colors: colors,
-      touch: touch,
-      fontFamily: headingFamily,
-      fontFamilyFallback: const ['PlusJakartaSans_regular'],
-    ),
-    body: _body(
-      colors: colors,
-      touch: touch,
-      fontFamily: bodyFamily,
-      fontFamilyFallback: const ['Inter_regular'],
-    ),
+    display: _display(colors: colors, touch: touch, fontFamily: headingFamily),
+    body: _body(colors: colors, touch: touch, fontFamily: bodyFamily),
   );
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -250,7 +250,7 @@ packages:
     source: hosted
     version: "1.0.2"
   cupertino_ui:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: cupertino_ui
       sha256: "2137c0d41f3b62cc4d3d2495e6c354bd6b6133cd21c6bb155736cc31dbd49a11"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   flutter_slidable: ^4.0.3
   flutter_reorderable_grid_view: ^5.7.0
   material_ui: any
-  cupertino_ui: any
 
   # State Management
   riverpod: any
@@ -106,12 +105,6 @@ flutter:
     - family: Inter
       fonts:
         - asset: assets/fonts/Inter-Regular.ttf
-    - family: Inter_regular
-      fonts:
-        - asset: assets/fonts/Inter-Regular.ttf
     - family: PlusJakartaSans
-      fonts:
-        - asset: assets/fonts/PlusJakartaSans-Regular.ttf
-    - family: PlusJakartaSans_regular
       fonts:
         - asset: assets/fonts/PlusJakartaSans-Regular.ttf


### PR DESCRIPTION
## Summary
- **Redundant Font Fallbacks:** Drop `fontFamilyFallback` arguments in `_typography` and remove duplicate `Inter_regular` & `PlusJakartaSans_regular` families from `pubspec.yaml`. The single-weight Regular registration already provides the desired faux-bold rendering parity.
- **Cupertino Cleanup:** Remove unused `cupertino_ui` dependency from `pubspec.yaml` and clean up unused `cupertino_ui` / `flutter/cupertino.dart` imports.
- **Documentation:** Add inline commentary in `poka_insufficient_balance_dialog.dart` documenting why `Flexible` is required inside `FButton` (in ForUI 0.26, `child` is a direct child of an internal `Row`, without `Flexible`, `FittedBox` receives unconstrained width `infinity` from the `Row` and causes a 14px `RenderFlex` overflow).