### PR TITLE
feat: harden storage integrity, security posture, and query performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pubspec_overrides.yaml
 /android/build/
 .gradle/
 /android/.gradle/
+.kotlin/
 app.*.symbols
 app.*.map.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Disabled Android ADB backup (`android:allowBackup="false"`) in `AndroidManifest.xml` to prevent plaintext data extraction via USB debugging.
+- Strengthened backup encryption key derivation to 100,000 PBKDF2 iterations and enforced standard UTF-8 password encoding.
+- Hardened encrypted backup validation with a 50MB file size ceiling and verified SQLite 3 magic header before database restoration.
+- Sanitized Riverpod talker observer logging by masking provider state values and restricting verbose lifecycle logging to debug mode.
+- Implemented background app lifecycle auto-lock with a 1-minute grace period respecting active system sheets and photo pickers.
+
+### Performance
+
+- Added database indexes for `transaction_date`, `account_id`, `transaction_items.transaction_id`, `transaction_items.category_id`, and `accounts.parent_id`.
+- Configured SQLite runtime PRAGMAs (`synchronous = NORMAL`, `temp_store = MEMORY`, `cache_size = -64000`) for improved throughput and reduced flash storage wear.
+- Offloaded Excel file compression and encoding to a background Dart isolate (`Isolate.run`), eliminating UI thread hitches during transaction exports.
+- Executed atomic WAL checkpoint (`PRAGMA wal_checkpoint(TRUNCATE)`) prior to backup packaging to ensure complete transaction persistence.
+
+### Fixed
+
+- Fixed unreleased `TextEditingController` and `FocusNode` memory leaks across transaction, split item, and debt repayment note modal dialogs.
+- Ensured unresolved arithmetic keypad expressions evaluate automatically upon saving transactions.
+
 ## [v1.0.0] - 2026-09-11
 
 Initial General Availability release of Poka CE.

--- a/Runefile
+++ b/Runefile
@@ -76,6 +76,13 @@ fix:
     dart fix --apply
     dart format .
 
+#[Format blank lines after closing braces followed by code statements]
+# path: Specific file or directory to format (default: lib/ and test/)
+# dry_run: Pass --dry-run to preview changes without modifying
+format:lines path="" dry_run="":
+    dart run scripts/format_empty_lines.dart {{path}} {{dry_run}}
+    dart format .
+
 # ==========================================
 # Testing Suites
 # ==========================================

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application
         android:label="Poka CE"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -7,6 +7,7 @@ import 'package:poka_ce/app/router/router.dart';
 import 'package:poka_ce/core/services/quick_actions_service.dart';
 import 'package:poka_ce/features/backup/domain/backup_reminder_service.dart';
 import 'package:poka_ce/features/debts/domain/debt_alert_service_provider.dart';
+import 'package:poka_ce/features/settings/presentation/controllers/app_lock_controller.dart';
 import 'package:poka_ce/features/settings/presentation/controllers/settings_notifier.dart';
 import 'package:poka_ce/features/transactions/data/excel_export_service.dart';
 import 'package:poka_ce/i18n/strings.g.dart';
@@ -20,6 +21,26 @@ class PokaApp extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final settingsState = ref.watch(settingsProvider);
+
+    // ── App Lock Background Grace Period (1 minute) ──────────────────────────
+    final lifecycleState = useAppLifecycleState();
+    final lastBackgroundedAt = useRef<DateTime?>(null);
+
+    useEffect(() {
+      if (lifecycleState == AppLifecycleState.paused || lifecycleState == AppLifecycleState.hidden) {
+        lastBackgroundedAt.value = DateTime.now();
+      } else if (lifecycleState == AppLifecycleState.resumed) {
+        if (lastBackgroundedAt.value != null) {
+          final elapsed = DateTime.now().difference(lastBackgroundedAt.value!);
+          final isSuppressed = ref.read(appLockSuppressionProvider);
+          if (!isSuppressed && elapsed >= const Duration(minutes: 1)) {
+            ref.read(appLockControllerProvider.notifier).lock();
+          }
+          lastBackgroundedAt.value = null;
+        }
+      }
+      return null;
+    }, [lifecycleState]);
 
     var themeMode = ThemeMode.system;
     switch (settingsState.settings?.themeMode) {

--- a/lib/core/logger/talker_riverpod_observer.dart
+++ b/lib/core/logger/talker_riverpod_observer.dart
@@ -1,20 +1,27 @@
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:poka_ce/core/logger/poka_logger.dart';
 
 base class TalkerRiverpodObserver extends ProviderObserver {
   @override
   void didAddProvider(ProviderObserverContext context, Object? value) {
-    talker.info('Provider added: ${context.provider.name ?? context.provider.runtimeType} | Value: $value');
+    if (kDebugMode) {
+      talker.info('Provider added: ${context.provider.name ?? context.provider.runtimeType}');
+    }
   }
 
   @override
   void didUpdateProvider(ProviderObserverContext context, Object? previousValue, Object? newValue) {
-    talker.info('Provider updated: ${context.provider.name ?? context.provider.runtimeType}');
+    if (kDebugMode) {
+      talker.info('Provider updated: ${context.provider.name ?? context.provider.runtimeType}');
+    }
   }
 
   @override
   void didDisposeProvider(ProviderObserverContext context) {
-    talker.info('Provider disposed: ${context.provider.name ?? context.provider.runtimeType}');
+    if (kDebugMode) {
+      talker.info('Provider disposed: ${context.provider.name ?? context.provider.runtimeType}');
+    }
   }
 
   @override

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -82,8 +82,28 @@ class AppDatabase extends _$AppDatabase {
         await DatabaseSeeder.seed(this);
       },
       beforeOpen: (details) async {
-        // Enforce foreign key constraints in SQLite.
-        await customStatement('PRAGMA foreign_keys = ON');
+        // Enforce foreign key constraints and configure performance PRAGMAs.
+        await customStatement('PRAGMA foreign_keys = ON;');
+        await customStatement('PRAGMA synchronous = NORMAL;');
+        await customStatement('PRAGMA temp_store = MEMORY;');
+        await customStatement('PRAGMA cache_size = -64000;');
+
+        // Ensure key performance indexes exist for schema 1
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions (transaction_date);',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_transactions_account ON transactions (account_id);',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_tx_items_tx_id ON transaction_items (transaction_id);',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_tx_items_category_id ON transaction_items (category_id);',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_accounts_parent_id ON accounts (parent_id);',
+        );
       },
     );
   }

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6670,6 +6670,26 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     this,
   );
   late final $GoalsTable goals = $GoalsTable(this);
+  late final Index idxAccountsParentId = Index(
+    'idx_accounts_parent_id',
+    'CREATE INDEX idx_accounts_parent_id ON accounts (parent_id)',
+  );
+  late final Index idxTransactionsDate = Index(
+    'idx_transactions_date',
+    'CREATE INDEX idx_transactions_date ON transactions (transaction_date)',
+  );
+  late final Index idxTransactionsAccount = Index(
+    'idx_transactions_account',
+    'CREATE INDEX idx_transactions_account ON transactions (account_id)',
+  );
+  late final Index idxTxItemsTxId = Index(
+    'idx_tx_items_tx_id',
+    'CREATE INDEX idx_tx_items_tx_id ON transaction_items (transaction_id)',
+  );
+  late final Index idxTxItemsCategoryId = Index(
+    'idx_tx_items_category_id',
+    'CREATE INDEX idx_tx_items_category_id ON transaction_items (category_id)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables => allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
@@ -6686,6 +6706,11 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     transactions,
     transactionItems,
     goals,
+    idxAccountsParentId,
+    idxTransactionsDate,
+    idxTransactionsAccount,
+    idxTxItemsTxId,
+    idxTxItemsCategoryId,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/lib/database/tables/accounts_table.dart
+++ b/lib/database/tables/accounts_table.dart
@@ -5,6 +5,7 @@ import 'package:poka_ce/database/tables/categories_table.dart';
 import 'package:uuid/uuid.dart';
 
 /// Database table definition for user accounts (wallets, banks, and sub-pockets).
+@TableIndex(name: 'idx_accounts_parent_id', columns: {#parentId})
 class Accounts extends Table {
   TextColumn get id => text().clientDefault(() => const Uuid().v7())();
   TextColumn get name => text()();

--- a/lib/database/tables/transactions_table.dart
+++ b/lib/database/tables/transactions_table.dart
@@ -8,6 +8,8 @@ import 'package:poka_ce/database/tables/recurring_table.dart';
 import 'package:uuid/uuid.dart';
 
 /// Database table definition for physical transaction receipts (parent header).
+@TableIndex(name: 'idx_transactions_date', columns: {#transactionDate})
+@TableIndex(name: 'idx_transactions_account', columns: {#accountId})
 class Transactions extends Table {
   TextColumn get id => text().clientDefault(() => const Uuid().v7())();
   @ReferenceName('transactionSource')
@@ -30,6 +32,8 @@ class Transactions extends Table {
 }
 
 /// Database table definition for receipt detail line items (child items).
+@TableIndex(name: 'idx_tx_items_tx_id', columns: {#transactionId})
+@TableIndex(name: 'idx_tx_items_category_id', columns: {#categoryId})
 class TransactionItems extends Table {
   TextColumn get id => text().clientDefault(() => const Uuid().v7())();
   TextColumn get transactionId => text().references(Transactions, #id, onDelete: KeyAction.cascade)();

--- a/lib/features/backup/data/backup_service.dart
+++ b/lib/features/backup/data/backup_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -22,7 +23,7 @@ class BackupService {
   final _cipher = AesGcm.with256bits();
   final _kdf = Pbkdf2(
     macAlgorithm: Hmac.sha256(),
-    iterations: 10000,
+    iterations: 100000,
     bits: 256,
   );
 
@@ -35,7 +36,7 @@ class BackupService {
 
   /// Derives a SecretKey from the given password and salt
   Future<SecretKey> _deriveKey(String password, List<int> salt) async {
-    final secretKey = SecretKey(password.codeUnits);
+    final secretKey = SecretKey(utf8.encode(password));
     return _kdf.deriveKey(
       secretKey: secretKey,
       nonce: salt,
@@ -47,8 +48,12 @@ class BackupService {
   /// Uses PBKDF2 with HMAC-SHA256 for key derivation and AES-GCM 256-bit for authenticated encryption.
   /// The resulting file packages the salt (12 bytes), GCM nonce (12 bytes), authentication tag MAC (16 bytes),
   /// and ciphertext in order.
-  Future<Result<File>> createEncryptedBackup(String password) async {
+  Future<Result<File>> createEncryptedBackup(
+    String password, {
+    Future<void> Function()? onBeforeRead,
+  }) async {
     try {
+      await onBeforeRead?.call();
       final docsFolder = await getApplicationDocumentsDirectory();
       final supportFolder = await getApplicationSupportDirectory();
 
@@ -120,6 +125,12 @@ class BackupService {
         return Failure(Exception('Backup file not found'));
       }
 
+      // Enforce backup file size limit (< 50MB) to prevent OOM
+      final fileLength = await backupFile.length();
+      if (fileLength > 50 * 1024 * 1024) {
+        return Failure(Exception('Backup file exceeds maximum allowed size (50MB)'));
+      }
+
       final fileBytes = await backupFile.readAsBytes();
 
       // Expected minimum length: 12 (salt) + 12 (nonce) + 16 (mac) = 40 bytes
@@ -148,6 +159,34 @@ class BackupService {
         secretBox,
         secretKey: key,
       );
+
+      // Verify SQLite 3 magic header: "SQLite format 3\000"
+      const sqliteMagic = [
+        0x53,
+        0x51,
+        0x4C,
+        0x69,
+        0x74,
+        0x65,
+        0x20,
+        0x66,
+        0x6F,
+        0x72,
+        0x6D,
+        0x61,
+        0x74,
+        0x20,
+        0x33,
+        0x00,
+      ];
+      if (clearText.length < 16) {
+        return Failure(Exception('Corrupted backup: invalid database size'));
+      }
+      for (var i = 0; i < 16; i++) {
+        if (clearText[i] != sqliteMagic[i]) {
+          return Failure(Exception('Invalid backup file: not a valid SQLite database'));
+        }
+      }
 
       // Cleanly teardown any active database handles before modifying files on disk
       await onBeforeWrite?.call();

--- a/lib/features/backup/presentation/controllers/backup_controller.dart
+++ b/lib/features/backup/presentation/controllers/backup_controller.dart
@@ -23,7 +23,14 @@ class BackupController extends _$BackupController {
     state = const AsyncLoading();
     try {
       final service = ref.read(backupServiceProvider);
-      final result = await service.createEncryptedBackup(password);
+      final result = await service.createEncryptedBackup(
+        password,
+        onBeforeRead: () async {
+          try {
+            await ref.read(databaseProvider).customStatement('PRAGMA wal_checkpoint(TRUNCATE);');
+          } on Exception catch (_) {}
+        },
+      );
       if (result.isSuccess()) {
         final backupFile = result.getOrThrow();
         // We use Share.shareXFiles for stability but package structure causes this lint

--- a/lib/features/backup/presentation/controllers/backup_controller.dart
+++ b/lib/features/backup/presentation/controllers/backup_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:poka_ce/app/providers/repository_providers.dart';
+import 'package:poka_ce/core/logger/poka_logger.dart';
 import 'package:poka_ce/features/backup/data/backup_service.dart';
 import 'package:poka_ce/features/backup/domain/backup_reminder_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -27,8 +28,22 @@ class BackupController extends _$BackupController {
         password,
         onBeforeRead: () async {
           try {
-            await ref.read(databaseProvider).customStatement('PRAGMA wal_checkpoint(TRUNCATE);');
-          } on Exception catch (_) {}
+            final rows = await ref.read(databaseProvider).customSelect('PRAGMA wal_checkpoint(TRUNCATE);').get();
+            if (rows.isNotEmpty) {
+              final row = rows.first.data;
+              final busy = (row['busy'] as num?)?.toInt() ?? 0;
+              final log = (row['log'] as num?)?.toInt() ?? 0;
+              final checkpointed = (row['checkpointed'] as num?)?.toInt() ?? 0;
+              if (busy != 0) {
+                talker.warning(
+                  'WAL checkpoint busy ($busy, log: $log, checkpointed: $checkpointed). '
+                  'Uncheckpointed WAL pages may be omitted from backup.',
+                );
+              }
+            }
+          } on Object catch (e, st) {
+            talker.error('Failed to run WAL checkpoint before backup', e, st);
+          }
         },
       );
       if (result.isSuccess()) {

--- a/lib/features/backup/presentation/controllers/backup_controller.g.dart
+++ b/lib/features/backup/presentation/controllers/backup_controller.g.dart
@@ -38,7 +38,7 @@ final class BackupControllerProvider extends $AsyncNotifierProvider<BackupContro
   BackupController create() => BackupController();
 }
 
-String _$backupControllerHash() => r'c33ac93a240f945063edff8f10898d1dd7eb6cb8';
+String _$backupControllerHash() => r'23e59d6b46913d2de7252152dd99b71753ea532e';
 
 /// Controller managing the execution of encrypted backup and restore operations,
 /// updating its async state and invoking system share sheets.

--- a/lib/features/debts/presentation/widgets/debt_repayment_sheet.dart
+++ b/lib/features/debts/presentation/widgets/debt_repayment_sheet.dart
@@ -103,56 +103,62 @@ class DebtRepaymentSheet extends HookConsumerWidget {
 
     Future<void> showNoteEditor() async {
       final controller = TextEditingController(text: state.note);
-      await showFDialog<void>(
-        context: context,
-        builder: (ctx, style, animation) => FDialog(
-          animation: animation,
-          builder: (dialogCtx, dialogStyle) {
-            final dialogTheme = ctx.theme;
-            return Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    t.debts.addNote,
-                    style: dialogTheme.typography.display.sm.copyWith(fontWeight: FontWeight.w700),
-                  ),
-                  const SizedBox(height: 14),
-                  FTextField(
-                    focusNode: FocusNode()..requestFocus(),
-                    control: FTextFieldControl.managed(controller: controller),
-                    maxLines: 3,
-                  ),
-                  const SizedBox(height: 24),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: FButton(
-                          onPress: () => Navigator.of(ctx).pop(),
-                          variant: FButtonVariant.outline,
-                          child: Text(t.debts.cancel),
+      final focusNode = FocusNode()..requestFocus();
+      try {
+        await showFDialog<void>(
+          context: context,
+          builder: (ctx, style, animation) => FDialog(
+            animation: animation,
+            builder: (dialogCtx, dialogStyle) {
+              final dialogTheme = ctx.theme;
+              return Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      t.debts.addNote,
+                      style: dialogTheme.typography.display.sm.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    const SizedBox(height: 14),
+                    FTextField(
+                      focusNode: focusNode,
+                      control: FTextFieldControl.managed(controller: controller),
+                      maxLines: 3,
+                    ),
+                    const SizedBox(height: 24),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: FButton(
+                            onPress: () => Navigator.of(ctx).pop(),
+                            variant: FButtonVariant.outline,
+                            child: Text(t.debts.cancel),
+                          ),
                         ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: FButton(
-                          onPress: () {
-                            notifier.setNote(controller.text.trim());
-                            Navigator.of(ctx).pop();
-                          },
-                          child: Text(t.debts.save),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: FButton(
+                            onPress: () {
+                              notifier.setNote(controller.text.trim());
+                              Navigator.of(ctx).pop();
+                            },
+                            child: Text(t.debts.save),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            );
-          },
-        ),
-      );
+                      ],
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      } finally {
+        controller.dispose();
+        focusNode.dispose();
+      }
     }
 
     return Column(

--- a/lib/features/transactions/data/excel_export_service.dart
+++ b/lib/features/transactions/data/excel_export_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:ui';
 
 import 'package:excel/excel.dart';
@@ -176,7 +177,7 @@ class ExcelExportService {
       }
       excel.setDefaultSheet('Transactions');
 
-      final bytes = excel.encode();
+      final bytes = await Isolate.run(excel.encode);
       if (bytes == null) {
         return const ErrorResult<File, Failure>(UnexpectedFailure('Failed to encode Excel file'));
       }

--- a/lib/features/transactions/presentation/controllers/transaction_form_notifier.dart
+++ b/lib/features/transactions/presentation/controllers/transaction_form_notifier.dart
@@ -272,7 +272,11 @@ class TransactionFormNotifier extends _$TransactionFormNotifier {
   }
 
   Future<void> _handleSimpleSave() async {
-    final amount = int.tryParse(state.amountExpression) ?? 0;
+    var rawExpr = state.amountExpression;
+    if (MathEvaluator.hasUnresolvedOperator(rawExpr)) {
+      rawExpr = MathEvaluator.evaluate(rawExpr) ?? rawExpr;
+    }
+    final amount = int.tryParse(rawExpr) ?? 0;
     if (amount <= 0) return;
     final catId = state.type == TransactionType.transfer ? state.destinationAccountId : state.categoryId;
     if (state.type == TransactionType.transfer && catId == null) return;

--- a/lib/features/transactions/presentation/controllers/transaction_form_notifier.g.dart
+++ b/lib/features/transactions/presentation/controllers/transaction_form_notifier.g.dart
@@ -63,7 +63,7 @@ final class TransactionFormNotifierProvider extends $NotifierProvider<Transactio
   }
 }
 
-String _$transactionFormNotifierHash() => r'b23c76ff47eaae665bf1827f070bc66f0406e9a6';
+String _$transactionFormNotifierHash() => r'691d2c5ffdae883c7ac16f1a2009f394d2b5c013';
 
 /// Controller managing form input, split items, in-place math evaluation, and submission
 /// for creating and updating transactions.

--- a/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/forms/transaction_form_sheet.dart
@@ -162,56 +162,62 @@ class TransactionFormSheet extends HookConsumerWidget {
 
     Future<void> showNoteEditor() async {
       final controller = TextEditingController(text: state.note);
-      await showFDialog<void>(
-        context: context,
-        builder: (ctx, style, animation) => FDialog(
-          animation: animation,
-          builder: (dialogCtx, dialogStyle) {
-            final dialogTheme = ctx.theme;
-            return Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    t.transactions.addNote,
-                    style: dialogTheme.typography.display.sm.copyWith(fontWeight: FontWeight.w700),
-                  ),
-                  const SizedBox(height: 14),
-                  FTextField(
-                    focusNode: FocusNode()..requestFocus(),
-                    control: FTextFieldControl.managed(controller: controller),
-                    maxLines: 3,
-                  ),
-                  const SizedBox(height: 24),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: FButton(
-                          onPress: () => Navigator.of(ctx).pop(),
-                          variant: FButtonVariant.outline,
-                          child: Text(t.transactions.cancel),
+      final focusNode = FocusNode()..requestFocus();
+      try {
+        await showFDialog<void>(
+          context: context,
+          builder: (ctx, style, animation) => FDialog(
+            animation: animation,
+            builder: (dialogCtx, dialogStyle) {
+              final dialogTheme = ctx.theme;
+              return Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      t.transactions.addNote,
+                      style: dialogTheme.typography.display.sm.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    const SizedBox(height: 14),
+                    FTextField(
+                      focusNode: focusNode,
+                      control: FTextFieldControl.managed(controller: controller),
+                      maxLines: 3,
+                    ),
+                    const SizedBox(height: 24),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: FButton(
+                            onPress: () => Navigator.of(ctx).pop(),
+                            variant: FButtonVariant.outline,
+                            child: Text(t.transactions.cancel),
+                          ),
                         ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: FButton(
-                          onPress: () {
-                            notifier.setNote(controller.text.trim());
-                            Navigator.of(ctx).pop();
-                          },
-                          child: Text(t.transactions.save),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: FButton(
+                            onPress: () {
+                              notifier.setNote(controller.text.trim());
+                              Navigator.of(ctx).pop();
+                            },
+                            child: Text(t.transactions.save),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            );
-          },
-        ),
-      );
+                      ],
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      } finally {
+        controller.dispose();
+        focusNode.dispose();
+      }
     }
 
     final selectedAccount = accounts.where((a) => a.id == state.accountId).firstOrNull;

--- a/lib/features/transactions/presentation/widgets/split/transaction_split_item_form_sheet.dart
+++ b/lib/features/transactions/presentation/widgets/split/transaction_split_item_form_sheet.dart
@@ -139,56 +139,62 @@ class _TransactionSplitItemFormSheetState extends ConsumerState<TransactionSplit
 
   Future<void> _showNoteEditor() async {
     final controller = TextEditingController(text: _note);
-    await showFDialog<void>(
-      context: context,
-      builder: (ctx, style, animation) => FDialog(
-        animation: animation,
-        builder: (dialogCtx, dialogStyle) {
-          final dialogTheme = ctx.theme;
-          return Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Text(
-                  t.transactions.addNote,
-                  style: dialogTheme.typography.display.sm.copyWith(fontWeight: FontWeight.w700),
-                ),
-                const SizedBox(height: 14),
-                FTextField(
-                  focusNode: FocusNode()..requestFocus(),
-                  control: FTextFieldControl.managed(controller: controller),
-                  maxLines: 3,
-                ),
-                const SizedBox(height: 24),
-                Row(
-                  children: [
-                    Expanded(
-                      child: FButton(
-                        onPress: () => Navigator.of(ctx).pop(),
-                        variant: FButtonVariant.outline,
-                        child: Text(t.transactions.cancel),
+    final focusNode = FocusNode()..requestFocus();
+    try {
+      await showFDialog<void>(
+        context: context,
+        builder: (ctx, style, animation) => FDialog(
+          animation: animation,
+          builder: (dialogCtx, dialogStyle) {
+            final dialogTheme = ctx.theme;
+            return Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    t.transactions.addNote,
+                    style: dialogTheme.typography.display.sm.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 14),
+                  FTextField(
+                    focusNode: focusNode,
+                    control: FTextFieldControl.managed(controller: controller),
+                    maxLines: 3,
+                  ),
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: FButton(
+                          onPress: () => Navigator.of(ctx).pop(),
+                          variant: FButtonVariant.outline,
+                          child: Text(t.transactions.cancel),
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: FButton(
-                        onPress: () {
-                          setState(() => _note = controller.text.trim());
-                          Navigator.of(ctx).pop();
-                        },
-                        child: Text(t.transactions.save),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: FButton(
+                          onPress: () {
+                            setState(() => _note = controller.text.trim());
+                            Navigator.of(ctx).pop();
+                          },
+                          child: Text(t.transactions.save),
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          );
-        },
-      ),
-    );
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      );
+    } finally {
+      controller.dispose();
+      focusNode.dispose();
+    }
   }
 
   @override

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 2
 /// Strings: 1277 (638 per locale)
 ///
-/// Built on 2026-09-10 at 20:09 UTC
+/// Built on 2026-09-11 at 22:28 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/scripts/format_empty_lines.dart
+++ b/scripts/format_empty_lines.dart
@@ -1,0 +1,192 @@
+import 'dart:io';
+
+/// CLI tool to format Dart source files by inserting a single blank line
+/// after a closing brace `}` when followed by subsequent code/statements.
+///
+/// Usage:
+///   dart run scripts/format_empty_lines.dart [path] [--dry-run]
+///
+/// If no path is provided, it processes files in `lib/` and `test/`.
+void main(List<String> args) {
+  final isDryRun = args.contains('--dry-run');
+  final paths = args.where((arg) => !arg.startsWith('--')).toList();
+
+  final targets = paths.isEmpty ? ['lib', 'test'] : paths;
+  var modifiedCount = 0;
+  var scannedCount = 0;
+
+  for (final target in targets) {
+    final entity = FileSystemEntity.typeSync(target);
+    if (entity == FileSystemEntityType.file) {
+      if (_shouldProcess(target)) {
+        scannedCount++;
+        if (_processFile(File(target), isDryRun: isDryRun)) {
+          modifiedCount++;
+        }
+      }
+    } else if (entity == FileSystemEntityType.directory) {
+      final dir = Directory(target);
+      final files = dir.listSync(recursive: true).whereType<File>();
+      for (final file in files) {
+        if (_shouldProcess(file.path)) {
+          scannedCount++;
+          if (_processFile(file, isDryRun: isDryRun)) {
+            modifiedCount++;
+          }
+        }
+      }
+    } else {
+      stderr.writeln('Warning: Target "$target" does not exist.');
+    }
+  }
+
+  stdout.writeln(
+    '\nScan complete. Scanned $scannedCount Dart file(s). '
+    '${isDryRun ? 'Would modify' : 'Modified'} $modifiedCount file(s).',
+  );
+
+  if (!isDryRun && modifiedCount > 0) {
+    stdout.writeln('Run "dart format ." to normalize and align the updated files.');
+  }
+}
+
+/// Determines whether the file at [filePath] should be processed.
+/// Excludes generated code files and non-Dart files.
+bool _shouldProcess(String filePath) {
+  if (!filePath.endsWith('.dart')) return false;
+  if (filePath.endsWith('.g.dart')) return false;
+  if (filePath.endsWith('.freezed.dart')) return false;
+  return true;
+}
+
+/// Processes a single [file], inserting empty lines where appropriate.
+/// Returns `true` if the file content changed.
+bool _processFile(File file, {required bool isDryRun}) {
+  final content = file.readAsStringSync();
+  final updated = formatBlankLinesAfterBraces(content);
+
+  if (content != updated) {
+    if (isDryRun) {
+      stdout.writeln('[DRY-RUN] Would update: ${file.path}');
+    } else {
+      file.writeAsStringSync(updated);
+      stdout.writeln('[UPDATED] ${file.path}');
+    }
+    return true;
+  }
+  return false;
+}
+
+/// Formats Dart code string by inserting a blank line after standalone closing
+/// braces `}` that are followed by executable statements.
+String formatBlankLinesAfterBraces(String content) {
+  final lines = content.split('\n');
+  final result = <String>[];
+  var inMultilineString = false;
+  var multilineDelimiter = '';
+  var inMultilineComment = false;
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    final trimmed = line.trim();
+
+    result.add(line);
+
+    // Track multiline block comments (/* ... */)
+    if (!inMultilineString) {
+      if (inMultilineComment) {
+        if (trimmed.contains('*/')) {
+          inMultilineComment = false;
+        }
+        continue;
+      } else if (trimmed.startsWith('/*') && !trimmed.contains('*/')) {
+        inMultilineComment = true;
+        continue;
+      }
+    }
+
+    // Track multiline raw/interpolated strings (''' or """)
+    if (!inMultilineComment) {
+      if (inMultilineString) {
+        if (trimmed.contains(multilineDelimiter)) {
+          inMultilineString = false;
+          multilineDelimiter = '';
+        }
+        continue;
+      } else {
+        if (trimmed.contains("'''") && (trimmed.indexOf("'''") == trimmed.lastIndexOf("'''"))) {
+          inMultilineString = true;
+          multilineDelimiter = "'''";
+          continue;
+        } else if (trimmed.contains('"""') && (trimmed.indexOf('"""') == trimmed.lastIndexOf('"""'))) {
+          inMultilineString = true;
+          multilineDelimiter = '"""';
+          continue;
+        }
+      }
+    }
+
+    // Only inspect lines that end with a standalone closing brace `}`
+    // Strip inline comments at the end of line, e.g. `} // comment`
+    final cleanLine = _stripTrailingComment(trimmed);
+    if (!cleanLine.endsWith('}')) {
+      continue;
+    }
+
+    // Do not process single-line constructs, e.g. `{ return 0; }`
+    if (cleanLine.contains('{')) {
+      continue;
+    }
+
+    // Must have a following line to inspect
+    if (i + 1 >= lines.length) {
+      continue;
+    }
+
+    final nextLine = lines[i + 1];
+    final nextTrimmed = nextLine.trim();
+
+    // Skip if there is already a blank line
+    if (nextTrimmed.isEmpty) {
+      continue;
+    }
+
+    // Skip if the next line continues the existing construct or closes another block:
+    // - Closing delimiters: `}`, `)`, `]`, `,`, `;`
+    // - Method/cascade chaining: `.`, `..`
+    // - Control flow continuations: `else`, `catch`, `on `, `finally`, `while`
+    if (nextTrimmed.startsWith('}') ||
+        nextTrimmed.startsWith(')') ||
+        nextTrimmed.startsWith(']') ||
+        nextTrimmed.startsWith(',') ||
+        nextTrimmed.startsWith(';') ||
+        nextTrimmed.startsWith('.') ||
+        nextTrimmed.startsWith('..') ||
+        nextTrimmed.startsWith('else') ||
+        nextTrimmed.startsWith('catch') ||
+        nextTrimmed.startsWith('on ') ||
+        nextTrimmed.startsWith('finally') ||
+        nextTrimmed.startsWith('while')) {
+      continue;
+    }
+
+    // Skip if next line begins with closing punctuation wrapped with whitespace
+    if (RegExp(r'^[}\]\),;]').hasMatch(nextTrimmed)) {
+      continue;
+    }
+
+    // Valid standalone `}` followed by new code: insert 1 empty line
+    result.add('');
+  }
+
+  return result.join('\n');
+}
+
+/// Strips trailing single-line comments from a code line.
+String _stripTrailingComment(String line) {
+  final idx = line.indexOf('//');
+  if (idx != -1) {
+    return line.substring(0, idx).trim();
+  }
+  return line;
+}

--- a/test/unit/features/backup/data/backup_service_test.dart
+++ b/test/unit/features/backup/data/backup_service_test.dart
@@ -59,9 +59,12 @@ void main() {
       }
     });
 
+    const validSqliteHeader = 'SQLite format 3\x00';
+
     Future<File> createFakeDb({String content = 'hello poka db content'}) async {
       final dbFile = File(p.join(appDocsDir.path, service.dbName));
-      await dbFile.writeAsString(content);
+      final fullContent = content.startsWith(validSqliteHeader) ? content : '$validSqliteHeader$content';
+      await dbFile.writeAsString(fullContent);
       return dbFile;
     }
 
@@ -121,7 +124,7 @@ void main() {
     });
 
     test('round-trip: encrypt -> decrypt -> original bytes match', () async {
-      const original = 'round-trip-content-💰-with-unicode-12345';
+      const original = '${validSqliteHeader}round-trip-content-💰-with-unicode-12345';
       final dbFile = await createFakeDb(content: original);
       final originalBytes = await dbFile.readAsBytes();
 
@@ -237,6 +240,34 @@ void main() {
       expect(beforeWriteCalled, isTrue);
       expect(walFile.existsSync(), isFalse);
       expect(shmFile.existsSync(), isFalse);
+    });
+
+    test('createEncryptedBackup — triggers onBeforeRead callback before reading', () async {
+      await createFakeDb();
+      var beforeReadInvoked = false;
+
+      final result = await service.createEncryptedBackup(
+        'testPass',
+        onBeforeRead: () async {
+          beforeReadInvoked = true;
+        },
+      );
+
+      expect(result.isSuccess(), isTrue);
+      expect(beforeReadInvoked, isTrue);
+    });
+
+    test('restoreEncryptedBackup — fails when decrypted cleartext lacks SQLite magic header', () async {
+      // Create a db file with non-sqlite content
+      final dbFile = File(p.join(appDocsDir.path, service.dbName));
+      await dbFile.writeAsString('plain-non-sqlite-content-that-lacks-magic-header');
+
+      final enc = await service.createEncryptedBackup('validPass');
+      final backupFile = enc.getOrThrow();
+
+      final res = await service.restoreEncryptedBackup(backupFile.path, 'validPass');
+      expect(res.isSuccess(), isFalse);
+      expect(res.exceptionOrNull().toString(), contains('not a valid SQLite database'));
     });
   });
 }

--- a/test/unit/features/backup/presentation/controllers/backup_controller_test.dart
+++ b/test/unit/features/backup/presentation/controllers/backup_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:poka_ce/app/providers/repository_providers.dart';
 import 'package:poka_ce/database/database.dart';
 import 'package:poka_ce/features/backup/data/backup_service.dart';
 import 'package:poka_ce/features/backup/domain/backup_reminder_service.dart';
+import 'package:drift/drift.dart';
 import 'package:poka_ce/features/backup/presentation/controllers/backup_controller.dart';
 import 'package:result_dart/result_dart.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
@@ -17,6 +18,10 @@ class MockBackupService extends Mock implements BackupService {}
 class MockBackupReminderService extends Mock implements BackupReminderService {}
 
 class MockAppDatabase extends Mock implements AppDatabase {}
+
+class MockSelectable extends Mock implements Selectable<QueryRow> {}
+
+class MockQueryRow extends Mock implements QueryRow {}
 
 class FakeSharePlatform extends SharePlatform with MockPlatformInterfaceMixin {
   @override
@@ -31,14 +36,18 @@ void main() {
   late MockBackupService mockService;
   late MockBackupReminderService mockReminderService;
   late MockAppDatabase mockDb;
+  late MockSelectable mockSelectable;
   late SharePlatform originalSharePlatform;
 
   setUp(() {
     mockService = MockBackupService();
     mockReminderService = MockBackupReminderService();
     mockDb = MockAppDatabase();
+    mockSelectable = MockSelectable();
     when(() => mockDb.close()).thenAnswer((_) async {});
     when(() => mockDb.customStatement(any())).thenAnswer((_) async {});
+    when(() => mockDb.customSelect(any())).thenReturn(mockSelectable);
+    when(() => mockSelectable.get()).thenAnswer((_) async => <QueryRow>[]);
     when(() => mockReminderService.recordBackupCompleted(any())).thenAnswer((_) async {});
     when(() => mockReminderService.recordBackupCompleted()).thenAnswer((_) async {});
     originalSharePlatform = SharePlatform.instance;
@@ -104,7 +113,64 @@ void main() {
       verify(
         () => mockService.createEncryptedBackup('password123', onBeforeRead: any(named: 'onBeforeRead')),
       ).called(1);
+      verify(() => mockDb.customSelect('PRAGMA wal_checkpoint(TRUNCATE);')).called(1);
       verify(() => mockReminderService.recordBackupCompleted()).called(1);
+    });
+
+    test('backup() — executes PRAGMA wal_checkpoint(TRUNCATE) and handles busy status gracefully', () async {
+      final tempFile = File(
+        '${Directory.systemTemp.path}/backup_busy_${DateTime.now().microsecondsSinceEpoch}.enc.db',
+      );
+      await tempFile.writeAsString('fake');
+      addTearDown(() async {
+        if (await tempFile.exists()) await tempFile.delete();
+      });
+
+      final mockRow = MockQueryRow();
+      when(() => mockRow.data).thenReturn(<String, Object?>{'busy': 1, 'log': 10, 'checkpointed': 5});
+      when(() => mockSelectable.get()).thenAnswer((_) async => <QueryRow>[mockRow]);
+
+      when(
+        () => mockService.createEncryptedBackup(any(), onBeforeRead: any(named: 'onBeforeRead')),
+      ).thenAnswer((invocation) async {
+        final onBefore = invocation.namedArguments[#onBeforeRead] as Future<void> Function()?;
+        await onBefore?.call();
+        return Success(tempFile);
+      });
+
+      final container = createContainer();
+      final notifier = container.read(backupControllerProvider.notifier);
+
+      final result = await notifier.backup('password123');
+      expect(result, isTrue);
+      verify(() => mockDb.customSelect('PRAGMA wal_checkpoint(TRUNCATE);')).called(1);
+    });
+
+    test('backup() — handles WAL checkpoint error gracefully without failing the entire backup', () async {
+      final tempFile = File(
+        '${Directory.systemTemp.path}/backup_err_${DateTime.now().microsecondsSinceEpoch}.enc.db',
+      );
+      await tempFile.writeAsString('fake');
+      addTearDown(() async {
+        if (await tempFile.exists()) await tempFile.delete();
+      });
+
+      when(() => mockSelectable.get()).thenThrow(Exception('database locked'));
+
+      when(
+        () => mockService.createEncryptedBackup(any(), onBeforeRead: any(named: 'onBeforeRead')),
+      ).thenAnswer((invocation) async {
+        final onBefore = invocation.namedArguments[#onBeforeRead] as Future<void> Function()?;
+        await onBefore?.call();
+        return Success(tempFile);
+      });
+
+      final container = createContainer();
+      final notifier = container.read(backupControllerProvider.notifier);
+
+      final result = await notifier.backup('password123');
+      expect(result, isTrue);
+      verify(() => mockDb.customSelect('PRAGMA wal_checkpoint(TRUNCATE);')).called(1);
     });
 
     test('backup() — on BackupService failure: state transitions loading -> error, returns false', () async {

--- a/test/unit/features/backup/presentation/controllers/backup_controller_test.dart
+++ b/test/unit/features/backup/presentation/controllers/backup_controller_test.dart
@@ -38,6 +38,7 @@ void main() {
     mockReminderService = MockBackupReminderService();
     mockDb = MockAppDatabase();
     when(() => mockDb.close()).thenAnswer((_) async {});
+    when(() => mockDb.customStatement(any())).thenAnswer((_) async {});
     when(() => mockReminderService.recordBackupCompleted(any())).thenAnswer((_) async {});
     when(() => mockReminderService.recordBackupCompleted()).thenAnswer((_) async {});
     originalSharePlatform = SharePlatform.instance;
@@ -80,7 +81,13 @@ void main() {
         if (await tempFile.exists()) await tempFile.delete();
       });
 
-      when(() => mockService.createEncryptedBackup(any())).thenAnswer((_) async => Success(tempFile));
+      when(
+        () => mockService.createEncryptedBackup(any(), onBeforeRead: any(named: 'onBeforeRead')),
+      ).thenAnswer((invocation) async {
+        final onBefore = invocation.namedArguments[#onBeforeRead] as Future<void> Function()?;
+        await onBefore?.call();
+        return Success(tempFile);
+      });
 
       final container = createContainer();
       final notifier = container.read(backupControllerProvider.notifier);
@@ -94,12 +101,16 @@ void main() {
       expect(container.read(backupControllerProvider).hasValue, isTrue);
       expect(container.read(backupControllerProvider).isLoading, isFalse);
       expect(container.read(backupControllerProvider).hasError, isFalse);
-      verify(() => mockService.createEncryptedBackup('password123')).called(1);
+      verify(
+        () => mockService.createEncryptedBackup('password123', onBeforeRead: any(named: 'onBeforeRead')),
+      ).called(1);
       verify(() => mockReminderService.recordBackupCompleted()).called(1);
     });
 
     test('backup() — on BackupService failure: state transitions loading -> error, returns false', () async {
-      when(() => mockService.createEncryptedBackup(any())).thenAnswer((_) async => Failure(Exception('disk full')));
+      when(
+        () => mockService.createEncryptedBackup(any(), onBeforeRead: any(named: 'onBeforeRead')),
+      ).thenAnswer((_) async => Failure(Exception('disk full')));
 
       final container = createContainer();
       final notifier = container.read(backupControllerProvider.notifier);
@@ -116,7 +127,9 @@ void main() {
     });
 
     test('backup() — on Exception thrown: state = error, returns false', () async {
-      when(() => mockService.createEncryptedBackup(any())).thenThrow(Exception('unexpected throw'));
+      when(
+        () => mockService.createEncryptedBackup(any(), onBeforeRead: any(named: 'onBeforeRead')),
+      ).thenThrow(Exception('unexpected throw'));
 
       final container = createContainer();
       final notifier = container.read(backupControllerProvider.notifier);

--- a/test/unit/features/transactions/presentation/controllers/transaction_form_notifier_test.dart
+++ b/test/unit/features/transactions/presentation/controllers/transaction_form_notifier_test.dart
@@ -140,6 +140,37 @@ void main() {
       expect(container.read(transactionFormProvider(args)).isLoading, false);
     });
 
+    test('save evaluates uncalculated arithmetic expression on save', () async {
+      stubCreateSuccess();
+      final container = createContainer();
+      final n = container.read(transactionFormProvider(args).notifier);
+      n.setType(TransactionType.expense);
+      n.setAccount('a1');
+      n.onKeyPressed('5');
+      n.onKeyPressed('0');
+      n.onKeyPressed('0');
+      n.onKeyPressed('+');
+      n.onKeyPressed('2');
+      n.onKeyPressed('0');
+      n.onKeyPressed('0');
+      n.setCategory('c1');
+      await n.save();
+
+      verify(
+        () => mockCreate.execute(
+          type: any(named: 'type'),
+          accountId: any(named: 'accountId'),
+          amount: 700,
+          categoryId: any(named: 'categoryId'),
+          note: any(named: 'note'),
+          transactionDate: any(named: 'transactionDate'),
+          allocation: any(named: 'allocation'),
+          splitItems: any(named: 'splitItems'),
+        ),
+      ).called(1);
+      expect(container.read(transactionFormProvider(args)).isSuccess, true);
+    });
+
     test('save expense failure', () async {
       when(
         () => mockCreate.execute(


### PR DESCRIPTION
## Summary
Post-v1 hardening addressing storage integrity, query performance, and user privacy:

1. **Security & Privacy**:
   - Disable Android ADB backup extraction via USB debugging (`android:allowBackup="false"`).
   - Upgrade backup PBKDF2 key derivation to 100,000 iterations with explicit UTF-8 encoding.
   - Add encrypted backup validation with 50MB ceiling and SQLite magic header checks.
   - Mask sensitive state model values in `TalkerRiverpodObserver` logging to prevent leakage.
   - Add app lifecycle auto-lock with 1-minute grace period and suppression support.

2. **Storage Integrity & Query Performance**:
   - Add Drift table indexes on `Transactions` (`transactionDate`, `accountId`), `TransactionItems` (`transactionId`, `categoryId`), and `Accounts` (`parentId`).
   - Configure SQLite runtime PRAGMAs (`synchronous = NORMAL`, `temp_store = MEMORY`, `cache_size = -64000`).
   - Offload Excel export encoding and compression to background worker isolate.
   - Prevent resource leaks by properly disposing focus nodes and text editing controllers in note dialogs.
   - Auto-evaluate uncalculated arithmetic expressions when saving transactions.

Closes #66