### PR TITLE
feat(ci): migrate PR-Agent and Issue Triage to Cloudflare AI Gateway

### DIFF
--- a/.github/scripts/triage-issue.js
+++ b/.github/scripts/triage-issue.js
@@ -2,7 +2,7 @@
 
 /**
  * Poka CE Issue Triage & Bug Report Checker
- * Analyzes GitHub issues and comments with /triage or /check using DeepSeek API.
+ * Analyzes GitHub issues and comments with /triage or /check using Cloudflare AI Gateway.
  * Uses codebase grounding (real file index, database schema, snippet extraction) and comment upserting.
  */
 
@@ -177,10 +177,14 @@ async function main() {
     process.exit(1);
   }
 
-  // Strictly use DeepSeek API key (accommodate OPENAI_KEY if set on repo)
-  const apiKey = process.env.DEEPSEEK_API_KEY || process.env.OPENAI_KEY;
+  // API token for Cloudflare AI Gateway / OpenAI-compatible endpoint
+  const apiKey =
+    process.env.CLOUDFLARE_API_TOKEN ||
+    process.env.AI_GATEWAY_TOKEN ||
+    process.env.OPENAI_KEY ||
+    process.env.DEEPSEEK_API_KEY;
   if (!apiKey) {
-    console.error('Missing DEEPSEEK_API_KEY or OPENAI_KEY');
+    console.error('Missing API token (CLOUDFLARE_API_TOKEN, AI_GATEWAY_TOKEN, or OPENAI_KEY)');
     process.exit(1);
   }
 
@@ -236,14 +240,8 @@ async function main() {
     // Add eyes reaction to indicate processing
     await addReaction(owner, repo, comment.id, 'eyes', token);
   } else if (issue) {
-    // If triggered by issues: opened
-    const issueAuthorAssociation = issue.author_association;
-    if (!ALLOWED_ASSOCIATIONS.has(issueAuthorAssociation)) {
-      console.log(
-        `Issue opened by @${issue.user?.login} with author_association "${issueAuthorAssociation}". Only OWNER or MEMBER can trigger automated triage. Skipping.`
-      );
-      return;
-    }
+    // If triggered by issues: opened (Silent labeling mode for all authors)
+    console.log(`Issue #${issue.number} opened by @${issue.user?.login}. Running in silent labeling mode.`);
   } else {
     console.log('Not an issue or issue_comment event. Skipping.');
     return;
@@ -384,16 +382,26 @@ ${codeSnippetSection}
 ${dbSchemaSection}
 ${fileCatalogSample}`;
 
-  // Strictly use DeepSeek API & models
-  const baseUrl = 'https://api.deepseek.com';
-  const rawModel = (process.env.PR_AGENT_MODEL || 'deepseek-chat').trim();
-  let model = rawModel.replace(/^deepseek\//i, '').replace(/^openai\//i, '');
-  if (!['deepseek-chat', 'deepseek-reasoner'].includes(model)) {
-    model = 'deepseek-chat';
-  }
+  // Cloudflare AI Gateway & Model configuration
+  const rawBaseUrl = (
+    process.env.AI_GATEWAY_URL ||
+    process.env.OPENAI_BASE_URL ||
+    'https://aig.octopy.dev/compat'
+  ).trim().replace(/\/+$/, '');
 
-  console.log(`Calling DeepSeek API at ${baseUrl} using model ${model}...`);
-  const response = await fetch(`${baseUrl}/chat/completions`, {
+  const completionsUrl = rawBaseUrl.endsWith('/chat/completions')
+    ? rawBaseUrl
+    : `${rawBaseUrl}/chat/completions`;
+
+  const rawModel = (
+    process.env.AI_MODEL ||
+    process.env.PR_AGENT_MODEL ||
+    'dynamic/copilot'
+  ).trim();
+  const model = rawModel.replace(/^(?:openai|deepseek)\//i, '');
+
+  console.log(`Calling AI Gateway at ${completionsUrl} using model "${model}"...`);
+  const response = await fetch(completionsUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -411,7 +419,7 @@ ${fileCatalogSample}`;
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error(`DeepSeek API failed with status ${response.status}: ${errorText}`);
+    console.error(`AI Gateway API failed with status ${response.status}: ${errorText}`);
     process.exit(1);
   }
 
@@ -454,10 +462,16 @@ ${fileCatalogSample}`;
   }
 
   // Add signature footer
-  const commentText = `## 🤖 Poka Triage Report\n\n${cleanMarkdown}\n\n---\n*Automated triage powered by Poka Triage Assistant. Re-run anytime by commenting \`/triage\` or \`/check\`.*`;
+  const commentText = `## 🤖 Poka Triage Report\n\n${cleanMarkdown}\n\n---\n*Automated triage powered by Poka Triage Assistant (${model}). Re-run anytime by commenting \`/triage\` or \`/check\`.*`;
 
-  // Upsert triage report comment (update existing comment or create a new one)
-  await upsertComment(owner, repo, issueNumber, commentText, token);
+  // Only post detailed report comment if explicitly requested via /triage or /check comment
+  if (isCommentTrigger) {
+    console.log(`Posting/updating detailed triage comment for #${issueNumber}...`);
+    await upsertComment(owner, repo, issueNumber, commentText, token);
+    await addReaction(owner, repo, comment.id, 'rocket', token);
+  } else {
+    console.log('Silent mode: skipping comment posting on newly opened issue.');
+  }
 
   // Apply suggested labels (only whitelisted and not already present)
   if (suggestedLabels.length > 0) {
@@ -465,11 +479,6 @@ ${fileCatalogSample}`;
     await applyLabels(owner, repo, issueNumber, suggestedLabels, token);
   } else {
     console.log('No new labels to apply.');
-  }
-
-  // If comment triggered, add rocket reaction to the trigger comment
-  if (isCommentTrigger) {
-    await addReaction(owner, repo, comment.id, 'rocket', token);
   }
 
   console.log('Triage finished successfully!');

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,10 +15,7 @@ jobs:
     if: |
       github.event.sender.type != 'Bot' &&
       (
-        (
-          github.event_name == 'issues' &&
-          (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER')
-        ) ||
+        github.event_name == 'issues' ||
         (
           github.event_name == 'issue_comment' &&
           !github.event.issue.pull_request &&
@@ -50,8 +47,9 @@ jobs:
       - name: Run Triage & Check Bug
         env:
           GITHUB_TOKEN: ${{ steps.octopy.outputs.token || secrets.GITHUB_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          AI_GATEWAY_TOKEN: ${{ secrets.AI_GATEWAY_TOKEN }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.OPENAI_KEY }}
-          PR_AGENT_MODEL: ${{ vars.PR_AGENT_MODEL || 'deepseek-chat' }}
-          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL || 'https://api.deepseek.com' }}
+          AI_GATEWAY_URL: ${{ secrets.AI_GATEWAY_URL || vars.AI_GATEWAY_URL || 'https://aig.octopy.dev/compat' }}
+          AI_MODEL: ${{ secrets.AI_MODEL || vars.AI_MODEL || 'dynamic/copilot' }}
         run: node .github/scripts/triage-issue.js

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -2,9 +2,9 @@ name: PR-Agent
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, ready_for_review]
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 permissions:
   issues: write
@@ -16,8 +16,15 @@ jobs:
     if: |
       github.event.sender.type != 'Bot' &&
       (
-        github.event_name == 'pull_request' ||
-        github.event.issue.pull_request
+        (
+          github.event_name == 'pull_request' &&
+          !github.event.pull_request.draft
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          contains(github.event.comment.body, '/review')
+        )
       )
     runs-on: ubuntu-latest
     steps:
@@ -33,10 +40,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.octopy.outputs.token }}
 
-          # DeepSeek API key — stored under OPENAI_KEY secret in this repo
-          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.OPENAI_KEY }}
+          # Cloudflare AI Gateway & LiteLLM Configuration
+          OPENAI_KEY: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.AI_GATEWAY_TOKEN || secrets.OPENAI_KEY }}
+          OPENAI.KEY: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.AI_GATEWAY_TOKEN || secrets.OPENAI_KEY }}
+          OPENAI.API_BASE: ${{ secrets.AI_GATEWAY_URL || vars.AI_GATEWAY_URL || 'https://aig.octopy.dev/compat' }}
+          OPENAI_API_BASE: ${{ secrets.AI_GATEWAY_URL || vars.AI_GATEWAY_URL || 'https://aig.octopy.dev/compat' }}
+          OPENAI_BASE_URL: ${{ secrets.AI_GATEWAY_URL || vars.AI_GATEWAY_URL || 'https://aig.octopy.dev/compat' }}
 
-          # Model Configuration (managed via Repository Variables)
-          CONFIG.MODEL: ${{ vars.PR_AGENT_MODEL }}
-          CONFIG.FALLBACK_MODELS: ${{ vars.PR_AGENT_FALLBACK_MODELS }}
+          # Model Configuration (managed via Secrets or Repository Variables)
+          CONFIG.MODEL: ${{ secrets.AI_MODEL && (startsWith(secrets.AI_MODEL, 'openai/') && secrets.AI_MODEL || format('openai/{0}', secrets.AI_MODEL)) || 'openai/dynamic/copilot' }}
+          CONFIG.FALLBACK_MODELS: ${{ vars.PR_AGENT_FALLBACK_MODELS || '["openai/dynamic/copilot"]' }}


### PR DESCRIPTION
## Summary
- Migrate **PR-Agent** and **Issue Triage** to use Cloudflare AI Gateway endpoint (`https://aig.octopy.dev/compat/chat/completions`).
- Configure model to default to `dynamic/copilot` with support for GitHub Secrets/Variables (`AI_MODEL`, `CLOUDFLARE_API_TOKEN`, `AI_GATEWAY_URL`).
- Restrict PR-Agent execution to non-draft `opened` and `ready_for_review` events (as well as manual `/review` comments), removing the noisy `synchronize` commit push trigger.
- Implement **Pattern B (Silent Labeling)** for Issue Triage: newly opened issues from any author are labeled automatically in the background without posting noisy comments, while detailed in-depth code triage reports remain accessible on-demand via maintainer comments (`/triage` or `/check`).